### PR TITLE
Update old images

### DIFF
--- a/DB/AB_W31.json
+++ b/DB/AB_W31.json
@@ -23,7 +23,7 @@
         "set": "AB",
         "release": "11",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W11_E107.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/WS_AB_W11_E107.jpg"
     },
     {
         "name": "Kanade Sending Everyone Off",
@@ -50,7 +50,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E001.png"
     },
     {
         "name": "\"Messenger of God\" Angel",
@@ -76,7 +76,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E002.png"
     },
     {
         "name": "Battle Meeting, Kanade",
@@ -102,7 +102,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E003.png"
     },
     {
         "name": "Yui's Sex Appeal?",
@@ -128,7 +128,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E004.png"
     },
     {
         "name": "Angel Wings, Kanade",
@@ -155,7 +155,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E005.png"
     },
     {
         "name": "End of the Confrontation, Kanade",
@@ -182,7 +182,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E006.png"
     },
     {
         "name": "A Good Understanding, Iwasawa & Hisako",
@@ -208,7 +208,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E007.png"
     },
     {
         "name": "Worrying Kanade",
@@ -237,7 +237,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E008.png"
     },
     {
         "name": "Cool Beauty, Iwasawa",
@@ -265,7 +265,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E009.png"
     },
     {
         "name": "Kanade Standing Still",
@@ -293,7 +293,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E010.png"
     },
     {
         "name": "Realizing a Dream, Yui",
@@ -323,7 +323,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E011.png"
     },
     {
         "name": "Yuzuru's Heart, Kanade",
@@ -352,7 +352,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E012.png"
     },
     {
         "name": "Parting Words, Kanade",
@@ -381,7 +381,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E013.png"
     },
     {
         "name": "Passionate Girl, Yui",
@@ -411,7 +411,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E014.png"
     },
     {
         "name": "Gldemo's Assistant, Yui",
@@ -438,7 +438,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E015.png"
     },
     {
         "name": "Student Council President, Kanade",
@@ -464,7 +464,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E016.png"
     },
     {
         "name": "Yui & Hinata",
@@ -491,7 +491,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E017.png"
     },
     {
         "name": "Lonely Angel",
@@ -517,7 +517,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E018.png"
     },
     {
         "name": "Kanade's Innocent Eyes",
@@ -543,7 +543,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E019.png"
     },
     {
         "name": "Hypnotist, Naoi",
@@ -569,7 +569,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E020.png"
     },
     {
         "name": "Kanade's Reason for Battle",
@@ -595,7 +595,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E021.png"
     },
     {
         "name": "Always Energetic, Yui",
@@ -621,7 +621,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E022.png"
     },
     {
         "name": "Mount Position, Yui",
@@ -647,7 +647,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E023.png"
     },
     {
         "name": "Couple Who Are Alike, Yui & Hinata",
@@ -673,7 +673,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E024.png"
     },
     {
         "name": "Straw Hat Kanade",
@@ -702,7 +702,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E025U.png"
     },
     {
         "name": "Casual Gesture, Kanade",
@@ -728,7 +728,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E026.png"
     },
     {
         "name": "Normal Girl, Kanade",
@@ -756,7 +756,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E027.png"
     },
     {
         "name": "Lots of Things to Do, Yui",
@@ -785,7 +785,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E028.png"
     },
     {
         "name": "Kanade Under the Blue Skies",
@@ -815,7 +815,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E029.png"
     },
     {
         "name": "Otonashi Understanding Kanade",
@@ -841,7 +841,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E030.png"
     },
     {
         "name": "Memories of the Beat, Otonashi",
@@ -867,7 +867,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E031.png"
     },
     {
         "name": "Always Together, Sekine & Irie",
@@ -893,7 +893,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E032.png"
     },
     {
         "name": "Swimsuit Kanade",
@@ -919,7 +919,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E033.png"
     },
     {
         "name": "Hardworking Fangirl, Yui",
@@ -945,7 +945,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E034.png"
     },
     {
         "name": "Self-proclaimed God, Naoi",
@@ -971,7 +971,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E035.png"
     },
     {
         "name": "Kanade's Quiet Appearance",
@@ -997,7 +997,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E036.png"
     },
     {
         "name": "Guitar Performer, Iwasawa",
@@ -1023,7 +1023,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E037.png"
     },
     {
         "name": "Kanade & Otonashi",
@@ -1049,7 +1049,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E038.png"
     },
     {
         "name": "Iwasawa's Successor, Yui",
@@ -1075,7 +1075,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E039.png"
     },
     {
         "name": "Battlefront's Enemy, Angel",
@@ -1103,7 +1103,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E040.png"
     },
     {
         "name": "Baseball Girl, Yui",
@@ -1132,7 +1132,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E041.png"
     },
     {
         "name": "Irie & Hisako",
@@ -1158,7 +1158,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E042.png"
     },
     {
         "name": "Pink Cape, Kanade",
@@ -1186,7 +1186,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E043.png"
     },
     {
         "name": "Strong Minded Guitarist, Hisako",
@@ -1214,7 +1214,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E044.png"
     },
     {
         "name": "Awkward Confrontation, Kanade",
@@ -1242,7 +1242,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E045.png"
     },
     {
         "name": "Otonashi Without Past Memories",
@@ -1270,7 +1270,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E046.png"
     },
     {
         "name": "Two Faces, Naoi",
@@ -1298,7 +1298,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E047.png"
     },
     {
         "name": "Song I Wanted to Sing",
@@ -1324,7 +1324,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E048.png"
     },
     {
         "name": "Hypnotism",
@@ -1350,7 +1350,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E049.png"
     },
     {
         "name": "Memories of Gldemo",
@@ -1379,7 +1379,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E050.png"
     },
     {
         "name": "Time to Part Ways",
@@ -1409,7 +1409,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E051.png"
     },
     {
         "name": "Somewhere, Someday",
@@ -1439,7 +1439,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E052.png"
     },
     {
         "name": "Power to Protect",
@@ -1468,7 +1468,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E053.png"
     },
     {
         "name": "A Girl's Ultimate Happiness",
@@ -1498,7 +1498,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E054.png"
     },
     {
         "name": "Descending Angel",
@@ -1528,7 +1528,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E055.png"
     },
     {
         "name": "Strategic Provocation, Yuri",
@@ -1555,7 +1555,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E056.png"
     },
     {
         "name": "Resolved Conflict, Yuri",
@@ -1582,7 +1582,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E057.png"
     },
     {
         "name": "Yuri's Independent Actions",
@@ -1611,7 +1611,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E058.png"
     },
     {
         "name": "Winter Yuri",
@@ -1638,7 +1638,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E059.png"
     },
     {
         "name": "Yuri's Invitation to the Battlefront",
@@ -1664,7 +1664,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E060.png"
     },
     {
         "name": "Role of a Big Sister, Yuri",
@@ -1691,7 +1691,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E061.png"
     },
     {
         "name": "Yuri's Fearless Gaze",
@@ -1717,7 +1717,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E062.png"
     },
     {
         "name": "United Battlefront, Kanade & Yuri",
@@ -1743,7 +1743,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E063.png"
     },
     {
         "name": "Skilled Martial Artist, Shiina",
@@ -1769,7 +1769,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E064.png"
     },
     {
         "name": "Messenger, Yusa",
@@ -1798,7 +1798,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E065.png"
     },
     {
         "name": "Highly Skilled Shiina",
@@ -1827,7 +1827,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E066.png"
     },
     {
         "name": "Irregular in the World, Otonashi",
@@ -1855,7 +1855,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E067.png"
     },
     {
         "name": "\"Godfather\" Yuri",
@@ -1883,7 +1883,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E068.png"
     },
     {
         "name": "Yuri Defying an Unreasonable Fate",
@@ -1912,7 +1912,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E069.png"
     },
     {
         "name": "Conflicted Otonashi",
@@ -1938,7 +1938,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E070.png"
     },
     {
         "name": "Excellent Communicator, Yusa",
@@ -1964,7 +1964,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E071.png"
     },
     {
         "name": "Like a Villian, Yuri",
@@ -1991,7 +1991,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E072.png"
     },
     {
         "name": "Operator, Yusa",
@@ -2017,7 +2017,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E073.png"
     },
     {
         "name": "Swimsuit Yuri",
@@ -2043,7 +2043,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E074.png"
     },
     {
         "name": "Yuri's Time for Departure",
@@ -2070,7 +2070,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E075.png"
     },
     {
         "name": "Unreasonable Request, Yuri",
@@ -2096,7 +2096,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E076.png"
     },
     {
         "name": "Commander, Yuri",
@@ -2125,7 +2125,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E077.png"
     },
     {
         "name": "Graduation from This World, Yuri",
@@ -2153,7 +2153,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E078.png"
     },
     {
         "name": "Separate Ways, Yuri",
@@ -2181,7 +2181,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E079.png"
     },
     {
         "name": "\"SSS(Underworld Battlefront)\" Yuri",
@@ -2210,7 +2210,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E080.png"
     },
     {
         "name": "Otonashi Searching for His Past",
@@ -2239,7 +2239,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E081.png"
     },
     {
         "name": "Operation Start, Yuri",
@@ -2265,7 +2265,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E082.png"
     },
     {
         "name": "Stinks at English, TK",
@@ -2291,7 +2291,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E083.png"
     },
     {
         "name": "Noda & Ooyama",
@@ -2317,7 +2317,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E084.png"
     },
     {
         "name": "Everyone's Pillar, Yuri",
@@ -2343,7 +2343,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E085.png"
     },
     {
         "name": "Genius Hacker, Takeyama",
@@ -2369,7 +2369,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E086.png"
     },
     {
         "name": "Hinata Looking Out for Allies",
@@ -2395,7 +2395,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E087.png"
     },
     {
         "name": "Moodmaker, Hinata",
@@ -2421,7 +2421,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E088.png"
     },
     {
         "name": "Rivalry, Noda",
@@ -2447,7 +2447,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E089.png"
     },
     {
         "name": "Codename Takeyama",
@@ -2473,7 +2473,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E090.png"
     },
     {
         "name": "Kanade's Friend, Yuri",
@@ -2499,7 +2499,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E091.png"
     },
     {
         "name": "Hinata's Response to Her Feelings",
@@ -2525,7 +2525,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E092.png"
     },
     {
         "name": "Proud Kunoichi, Shiina",
@@ -2551,7 +2551,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E093.png"
     },
     {
         "name": "Takamatsu Not Taking Off Enough",
@@ -2577,7 +2577,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E094.png"
     },
     {
         "name": "Unknown Identity, TK",
@@ -2603,7 +2603,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E095.png"
     },
     {
         "name": "Famous Battlefront Combination, Hinata & Otonashi",
@@ -2631,7 +2631,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E096.png"
     },
     {
         "name": "Matsushita\nthe Fifth",
@@ -2659,7 +2659,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E097.png"
     },
     {
         "name": "Operation Tornado",
@@ -2685,7 +2685,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E098.png"
     },
     {
         "name": "Jet Engine",
@@ -2711,7 +2711,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E099.png"
     },
     {
         "name": "Please call me Christ",
@@ -2738,7 +2738,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E100.png"
     },
     {
         "name": "After the Battle",
@@ -2767,7 +2767,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E101.png"
     },
     {
         "name": "Memories of a Past Life",
@@ -2796,7 +2796,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E102.png"
     },
     {
         "name": "Underworld Battlefront",
@@ -2825,7 +2825,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E103.png"
     },
     {
         "name": "Fulfilled Feelings",
@@ -2854,7 +2854,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E104.png"
     },
     {
         "name": "\"Little Braver\" Yui",
@@ -2884,7 +2884,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E105.png"
     },
     {
         "name": "Kanade Tachibana",
@@ -2913,7 +2913,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E106.png"
     },
     {
         "name": "Sekine Loves Pranks",
@@ -2939,7 +2939,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E107.png"
     },
     {
         "name": "Powerful Performance, Irie",
@@ -2965,7 +2965,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E108.png"
     },
     {
         "name": "Sub-leader, Hisako",
@@ -2994,7 +2994,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E109.png"
     },
     {
         "name": "\"Crow Song\" Iwasawa",
@@ -3023,7 +3023,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E110.png"
     },
     {
         "name": "Kanade Waking Up",
@@ -3051,7 +3051,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E111.png"
     },
     {
         "name": "Somewhere, Someday",
@@ -3080,7 +3080,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E112.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E112.png"
     },
     {
         "name": "Yuri Nakamura",
@@ -3109,7 +3109,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E113.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E113.png"
     },
     {
         "name": "MAX Tension, Shiina",
@@ -3135,7 +3135,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E114.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E114.png"
     },
     {
         "name": "Student Council President, Otonashi",
@@ -3161,7 +3161,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E115.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E115.png"
     },
     {
         "name": "Demonic Commander, Yuri",
@@ -3190,7 +3190,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E116.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E116.png"
     },
     {
         "name": "Heart of the World",
@@ -3219,7 +3219,7 @@
         "set": "AB",
         "release": "31",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_E117.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_E117.png"
     },
     {
         "name": "\"Graduation Ceremony\" Kanade & Yuri",
@@ -3405,7 +3405,7 @@
         "set": "AB",
         "release": "31",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_PE01.png"
     },
     {
         "name": "Friendly Combination, Sekine & Irie",
@@ -3432,7 +3432,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE01.png"
     },
     {
         "name": "Big Fan of Gldemo, Yui",
@@ -3458,7 +3458,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE02.png"
     },
     {
         "name": "Charisma Vocalist, Iwasawa",
@@ -3484,7 +3484,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE03.png"
     },
     {
         "name": "Past Formidable Enemy, Kanade",
@@ -3510,7 +3510,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE04.png"
     },
     {
         "name": "Like an Elder Sister, Hisako",
@@ -3536,7 +3536,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE05.png"
     },
     {
         "name": "Girl Known as \"Angel\", Kanade",
@@ -3562,7 +3562,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE06.png"
     },
     {
         "name": "2nd Generation Vocalist, Yui",
@@ -3588,7 +3588,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE07.png"
     },
     {
         "name": "Girl Standing Up Against Fate",
@@ -3614,7 +3614,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE08.png"
     },
     {
         "name": "Leader of Gldemo, Iwasawa",
@@ -3643,7 +3643,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE09.png"
     },
     {
         "name": "\"Maradona\" Yui",
@@ -3671,7 +3671,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE10.png"
     },
     {
         "name": "Tenshi's Mabo Tofu",
@@ -3697,7 +3697,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE11.png"
     },
     {
         "name": "Operation Tornado feat. Yui",
@@ -3726,7 +3726,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE12.png"
     },
     {
         "name": "Fujimaki & Ooyama",
@@ -3752,7 +3752,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE13.png"
     },
     {
         "name": "Thinner in Clothes, Takamatsu",
@@ -3778,7 +3778,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE14.png"
     },
     {
         "name": "Baseball Boy, Hinata",
@@ -3804,7 +3804,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE15.png"
     },
     {
         "name": "Gone Unnoticed, Fujimaki",
@@ -3830,7 +3830,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE16.png"
     },
     {
         "name": "Releasing Oneself, Takamatsu",
@@ -3858,7 +3858,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE17.png"
     },
     {
         "name": "Yuri Defying God",
@@ -3886,7 +3886,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE18.png"
     },
     {
         "name": "Cheerful Dancer, TK",
@@ -3914,7 +3914,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE19.png"
     },
     {
         "name": "Just Like Sisters, Kanade & Yuri",
@@ -3942,7 +3942,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE20.png"
     },
     {
         "name": "Battle with Shadows",
@@ -3971,7 +3971,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE21.png"
     },
     {
         "name": "Model Student, Kanade",
@@ -3997,7 +3997,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE22.png"
     },
     {
         "name": "Yuri's Powerful Draw?",
@@ -4026,7 +4026,7 @@
         "set": "AB",
         "release": "31",
         "sid": "TE23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE23.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE23.png"
     },
     {
         "name": "Otonashi & Kanade in Winter",
@@ -4055,6 +4055,6 @@
         "set": "AB",
         "release": "31",
         "sid": "TE24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_AB_W31_TE24.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/ab_w31/AB_W31_TE24.png"
     }
 ]

--- a/DB/AOT2_S50.json
+++ b/DB/AOT2_S50.json
@@ -24,7 +24,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E001.png"
     },
     {
         "name": "\"My Fate to Bear\" Eren",
@@ -51,7 +51,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E002.png"
     },
     {
         "name": "\"Crimson Fighting Spirit\" Eren",
@@ -81,7 +81,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E003.png"
     },
     {
         "name": "\"Single Ray of Light\" Armin",
@@ -107,7 +107,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E004.png"
     },
     {
         "name": "\"Keen Mind\" Armin",
@@ -136,7 +136,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E005.png"
     },
     {
         "name": "\"To Seize Freedom\" Eren",
@@ -165,7 +165,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E006.png"
     },
     {
         "name": "\"Until the Dying Breath\" Armin",
@@ -195,7 +195,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E007.png"
     },
     {
         "name": "\"Single Ray of Light\" Eren Titan",
@@ -225,7 +225,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E008.png"
     },
     {
         "name": "\"Relief\" Eren",
@@ -252,7 +252,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E009.png"
     },
     {
         "name": "\"Cleanup\" Eren",
@@ -278,7 +278,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E010.png"
     },
     {
         "name": "\"Born in Ragako\" Conny",
@@ -304,7 +304,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E011.png"
     },
     {
         "name": "\"Steady Advance\" Eren Titan",
@@ -333,7 +333,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E012.png"
     },
     {
         "name": "\"Memory of that Day\" Annie",
@@ -362,7 +362,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E013a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E013a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E013a.png"
     },
     {
         "name": "\"Memory of that Day\" Annie",
@@ -391,7 +391,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E013b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E013b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E013b.png"
     },
     {
         "name": "\"Whimsical Days\" Eren",
@@ -418,7 +418,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E014.png"
     },
     {
         "name": "\"Recovering Eren\" Armin",
@@ -445,7 +445,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E015.png"
     },
     {
         "name": "\"Until the Dying Breath\" Conny",
@@ -471,7 +471,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E016.png"
     },
     {
         "name": "\"Revenge\" Hannes",
@@ -497,7 +497,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E017a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E017a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E017a.png"
     },
     {
         "name": "\"Revenge\" Hannes",
@@ -523,7 +523,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E017b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E017b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E017b.png"
     },
     {
         "name": "\"Captured\" Eren",
@@ -549,7 +549,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E018.png"
     },
     {
         "name": "\"Sunset on Your Back\" Eren Titan",
@@ -576,7 +576,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E019.png"
     },
     {
         "name": "Anti-Titan Device \"Omni-Directional Mobility Gear\"",
@@ -602,7 +602,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E020.png"
     },
     {
         "name": "Coordinate",
@@ -629,7 +629,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E021.png"
     },
     {
         "name": "Outcry",
@@ -659,7 +659,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E022.png"
     },
     {
         "name": "Yell of Rage",
@@ -689,7 +689,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E023a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E023a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E023a.png"
     },
     {
         "name": "Yell of Rage",
@@ -719,7 +719,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E023b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E023b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E023b.png"
     },
     {
         "name": "Close Combat",
@@ -748,7 +748,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E024.png"
     },
     {
         "name": "\"Silent Fury\" Levi",
@@ -778,7 +778,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E025.png"
     },
     {
         "name": "\"To Seize Freedom\" Hange",
@@ -808,7 +808,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E026.png"
     },
     {
         "name": "\"Until the Dying Breath\" Hange",
@@ -836,7 +836,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E027.png"
     },
     {
         "name": "\"Until the Dying Breath\" Erwin",
@@ -863,7 +863,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E028.png"
     },
     {
         "name": "\"Single Ray of Light\" Levi",
@@ -889,7 +889,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E029.png"
     },
     {
         "name": "\"Until the Dying Breath\" Levi",
@@ -916,7 +916,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E030.png"
     },
     {
         "name": "\"To Seize Freedom\" Levi",
@@ -943,7 +943,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E031.png"
     },
     {
         "name": "Pastor Nick",
@@ -969,7 +969,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E032.png"
     },
     {
         "name": "“Confirming the Unknown” Hange",
@@ -998,7 +998,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E033.png"
     },
     {
         "name": "\"To Seize Freedom\" Erwin",
@@ -1025,7 +1025,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E034.png"
     },
     {
         "name": "\"Cleanup\" Levi",
@@ -1054,7 +1054,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E035.png"
     },
     {
         "name": "\"Sunset on Your Back\" Levi",
@@ -1083,7 +1083,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E036.png"
     },
     {
         "name": "\"Communication\" Hange",
@@ -1112,7 +1112,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E037.png"
     },
     {
         "name": "\"The Fate of Mankind's Survival\" Erwin",
@@ -1139,7 +1139,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E038.png"
     },
     {
         "name": "\"Veteran Scout\" Nanaba",
@@ -1166,7 +1166,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E039a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E039a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E039a.png"
     },
     {
         "name": "\"Veteran Scout\" Nanaba",
@@ -1193,7 +1193,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E039b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E039b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E039b.png"
     },
     {
         "name": "\"Veteran Scout\" Gelgar",
@@ -1219,7 +1219,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E040a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E040a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E040a.png"
     },
     {
         "name": "\"Veteran Scout\" Gelgar",
@@ -1245,7 +1245,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E040b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E040b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E040b.png"
     },
     {
         "name": "Moblit",
@@ -1272,7 +1272,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E041.png"
     },
     {
         "name": "\"What Happens Henceforth\" Hange",
@@ -1298,7 +1298,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E042.png"
     },
     {
         "name": "\"A Definite Step\" Hange",
@@ -1324,7 +1324,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E043.png"
     },
     {
         "name": "\"What Happens Henceforth\" Levi",
@@ -1350,7 +1350,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E044.png"
     },
     {
         "name": "\"Until the Dying Breath\" Miche",
@@ -1377,7 +1377,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E045a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E045a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E045a.png"
     },
     {
         "name": "\"Until the Dying Breath\" Miche",
@@ -1404,7 +1404,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E045b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E045b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E045b.png"
     },
     {
         "name": "A Request or… an Order…?",
@@ -1431,7 +1431,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E046.png"
     },
     {
         "name": "Repose",
@@ -1457,7 +1457,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E047.png"
     },
     {
         "name": "Blade that Rends Despair",
@@ -1486,7 +1486,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E048.png"
     },
     {
         "name": "Revolutionists",
@@ -1515,7 +1515,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E049a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E049a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E049a.png"
     },
     {
         "name": "Revolutionists",
@@ -1544,7 +1544,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E049b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E049b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E049b.png"
     },
     {
         "name": "Standby for Full Scale Assault!",
@@ -1573,7 +1573,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E050a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E050a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E050a.png"
     },
     {
         "name": "Standby for Full Scale Assault!",
@@ -1602,7 +1602,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E050b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E050b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E050b.png"
     },
     {
         "name": "\"Goddess' Smile\" Christa",
@@ -1629,7 +1629,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E051.png"
     },
     {
         "name": "\"Embraced Memories\" Mikasa",
@@ -1659,7 +1659,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E052.png"
     },
     {
         "name": "\"To Seize Freedom\" Sasha",
@@ -1689,7 +1689,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E053.png"
     },
     {
         "name": "\"Single Ray of Light\" Mikasa",
@@ -1716,7 +1716,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E054.png"
     },
     {
         "name": "\"Insatiable Hunger\" Sasha",
@@ -1743,7 +1743,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E055.png"
     },
     {
         "name": "\"Brief Respite\" Christa",
@@ -1770,7 +1770,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E056.png"
     },
     {
         "name": "\"Sunset on Your Back\" Mikasa",
@@ -1797,7 +1797,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E057.png"
     },
     {
         "name": "\"Until the Dying Breath\" Sasha",
@@ -1824,7 +1824,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E058.png"
     },
     {
         "name": "\"To Seize Freedom\" Mikasa",
@@ -1854,7 +1854,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E059.png"
     },
     {
         "name": "\"Until the Dying Breath\" Christa",
@@ -1883,7 +1883,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E060.png"
     },
     {
         "name": "\"Recovering Eren\" Mikasa",
@@ -1910,7 +1910,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E061.png"
     },
     {
         "name": "\"Piercing Terror\" Sasha",
@@ -1937,7 +1937,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E062.png"
     },
     {
         "name": "\"Fine as Is\" Christa",
@@ -1964,7 +1964,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E063.png"
     },
     {
         "name": "“Hidden Truth” Ymir",
@@ -1991,7 +1991,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E064a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E064a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E064a.png"
     },
     {
         "name": "\"Hidden Truth\" Ymir",
@@ -2018,7 +2018,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E064b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E064b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E064b.png"
     },
     {
         "name": "\"Until the Dying Breath\" Bertholdt",
@@ -2044,7 +2044,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E065.png"
     },
     {
         "name": "\"Hidden Truth\" Bertholdt",
@@ -2073,7 +2073,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E066.png"
     },
     {
         "name": "\"Born in Dauper\" Sasha",
@@ -2102,7 +2102,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E067.png"
     },
     {
         "name": "“Hidden Truth” Reiner",
@@ -2130,7 +2130,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E068.png"
     },
     {
         "name": "\"The Smile I Want to Protect\" Christa",
@@ -2157,7 +2157,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E069.png"
     },
     {
         "name": "\"Until the Dying Breath\" Jean",
@@ -2184,7 +2184,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E070.png"
     },
     {
         "name": "\"Soldier and Warrior\" Reiner",
@@ -2211,7 +2211,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E071.png"
     },
     {
         "name": "\"Dispossession\" Bertholdt",
@@ -2237,7 +2237,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E072.png"
     },
     {
         "name": "\"Until the Dying Breath\" Ymir",
@@ -2263,7 +2263,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E073.png"
     },
     {
         "name": "“Until the Dying Breath” Reiner",
@@ -2290,7 +2290,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E074.png"
     },
     {
         "name": "\"Until the Dying Breath\" Mikasa",
@@ -2316,7 +2316,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E075.png"
     },
     {
         "name": "\"Safekeeping\" Sasha",
@@ -2343,7 +2343,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E076.png"
     },
     {
         "name": "\"To Seize Freedom\" Jean",
@@ -2372,7 +2372,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E077.png"
     },
     {
         "name": "\"Relief\" Mikasa",
@@ -2401,7 +2401,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E078.png"
     },
     {
         "name": "\"Noble Bloodline\" Christa",
@@ -2430,7 +2430,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E079.png"
     },
     {
         "name": "The Goddess",
@@ -2456,7 +2456,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E080.png"
     },
     {
         "name": "Murderous Glare",
@@ -2482,7 +2482,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E081.png"
     },
     {
         "name": "My Real Name…",
@@ -2511,7 +2511,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E082.png"
     },
     {
         "name": "Thank You…",
@@ -2540,7 +2540,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E083.png"
     },
     {
         "name": "Run!!",
@@ -2569,7 +2569,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E084a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E084a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E084a.png"
     },
     {
         "name": "Run!!",
@@ -2598,7 +2598,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E084b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E084b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E084b.png"
     },
     {
         "name": "\"Strength Assessment\" Beast Titan",
@@ -2625,7 +2625,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E085.png"
     },
     {
         "name": "Beast Titan",
@@ -2654,7 +2654,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E086.png"
     },
     {
         "name": "\"Resurgence\" Armored Titan",
@@ -2684,7 +2684,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E087.png"
     },
     {
         "name": "\"Pursuit\" Titan",
@@ -2711,7 +2711,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E088a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E088a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E088a.png"
     },
     {
         "name": "\"Pursuit\" Titan",
@@ -2738,7 +2738,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E088b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E088b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E088b.png"
     },
     {
         "name": "\"Pursuit\" Titan",
@@ -2765,7 +2765,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E088c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E088c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E088c.png"
     },
     {
         "name": "\"Pursuit\" Titan",
@@ -2792,7 +2792,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E088d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E088d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E088d.png"
     },
     {
         "name": "\"Multiple Decisive Battles\" Colossal Titan",
@@ -2821,7 +2821,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E089.png"
     },
     {
         "name": "Ymir Titan",
@@ -2850,7 +2850,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E090a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E090a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E090a.png"
     },
     {
         "name": "Ymir Titan",
@@ -2879,7 +2879,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E090b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E090b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E090b.png"
     },
     {
         "name": "\"Enemy of Humanity\" Colossal Titan",
@@ -2908,7 +2908,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E091.png"
     },
     {
         "name": "\"Nemesis\" Titan",
@@ -2934,7 +2934,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E092.png"
     },
     {
         "name": "\"Incomprehensible\" Titan",
@@ -2961,7 +2961,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E093.png"
     },
     {
         "name": "\"Until the Goal is Accomplished\" Armored Titan",
@@ -2988,7 +2988,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E094.png"
     },
     {
         "name": "\"Predation\" Titan",
@@ -3015,7 +3015,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E095a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E095a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E095a.png"
     },
     {
         "name": "\"Predation\" Titan",
@@ -3042,7 +3042,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E095b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E095b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E095b.png"
     },
     {
         "name": "\"Predation\" Titan",
@@ -3069,7 +3069,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E095c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E095c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E095c.png"
     },
     {
         "name": "\"Predation\" Titan",
@@ -3096,7 +3096,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E095d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E095d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E095d.png"
     },
     {
         "name": "\"All-surpassing Existence\" Colossal Titan",
@@ -3122,7 +3122,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E096.png"
     },
     {
         "name": "\"Confrontation\" Armored Titan",
@@ -3151,7 +3151,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E097.png"
     },
     {
         "name": "In the Wall",
@@ -3177,7 +3177,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E098.png"
     },
     {
         "name": "Sentience",
@@ -3206,7 +3206,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E099a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E099a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E099a.png"
     },
     {
         "name": "Sentience",
@@ -3235,7 +3235,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E099b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E099b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E099b.png"
     },
     {
         "name": "Duel",
@@ -3265,7 +3265,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E100a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E100a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E100a.png"
     },
     {
         "name": "Duel",
@@ -3295,7 +3295,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E100b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E100b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E100b.png"
     },
     {
         "name": "\"Mischievous Battle\" Chimi Armin",
@@ -3324,7 +3324,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E101.png"
     },
     {
         "name": "\"Mischievous Battle\" Chimi Eren",
@@ -3350,7 +3350,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E102.png"
     },
     {
         "name": "\"Mischievous Battle\" Chimi Mikasa",
@@ -3379,7 +3379,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E103.png"
     },
     {
         "name": "\"Mischievous Battle\" Chimi Colossal Titan",
@@ -3405,7 +3405,7 @@
         "set": "AOT",
         "release": "50",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_E104.png"
     },
     {
         "name": "\"Indomitable Will\" Eren",
@@ -3434,6 +3434,6 @@
         "set": "AOT",
         "release": "50",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AOT_S50_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aot_s50/AOT_S50_PE01.png"
     }
 ]

--- a/DB/APO_S53.json
+++ b/DB/APO_S53.json
@@ -24,7 +24,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E001.png"
     },
     {
         "name": "\"Luminosité Eternelle\" Ruler",
@@ -54,7 +54,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E002.png"
     },
     {
         "name": "\"Inherited Prayer\" Sieg",
@@ -83,7 +83,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E003.png"
     },
     {
         "name": "\"Faraway Promise\" Ruler",
@@ -109,7 +109,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E004.png"
     },
     {
         "name": "\"Master's Qualifications\" Sieg",
@@ -136,7 +136,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E005.png"
     },
     {
         "name": "\"Adjudicator\" Ruler",
@@ -162,7 +162,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E006.png"
     },
     {
         "name": "\"La Pucelle\" Ruler",
@@ -191,7 +191,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E007.png"
     },
     {
         "name": "\"Depraved Dragon\" Fafnir",
@@ -220,7 +220,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E008.png"
     },
     {
         "name": "\"Return to the Greater Grail\" Ruler",
@@ -247,7 +247,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E009.png"
     },
     {
         "name": "\"Great Holy Grail War\" Sieg",
@@ -274,7 +274,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E010.png"
     },
     {
         "name": "\"With My Command Spell\" Ruler",
@@ -301,7 +301,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E011.png"
     },
     {
         "name": "\"Hero Possession\" Sieg",
@@ -330,7 +330,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E012.png"
     },
     {
         "name": "Lord El-Melloi II",
@@ -358,7 +358,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E013.png"
     },
     {
         "name": "\"Legend of Dracula\" Dracula",
@@ -386,7 +386,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E014.png"
     },
     {
         "name": "Gilles de Rais",
@@ -413,7 +413,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E015.png"
     },
     {
         "name": "\"King of Knights\" Altria",
@@ -439,7 +439,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E016.png"
     },
     {
         "name": "\"To the Hanging Gardens\" Ruler",
@@ -465,7 +465,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E017.png"
     },
     {
         "name": "Laetitia",
@@ -492,7 +492,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E018.png"
     },
     {
         "name": "\"Apocrypha\" Sieg",
@@ -518,7 +518,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E019.png"
     },
     {
         "name": "\"Dead Count Shapeshifter\" Sieg",
@@ -545,7 +545,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E020.png"
     },
     {
         "name": "\"The Me in the Mirror\" Ruler",
@@ -574,7 +574,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E021.png"
     },
     {
         "name": "The Greater Grail",
@@ -600,7 +600,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E022.png"
     },
     {
         "name": "Luminosité Eternelle",
@@ -630,7 +630,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E023.png"
     },
     {
         "name": "Speaking To My Reflection",
@@ -659,7 +659,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E024.png"
     },
     {
         "name": "Blasted Tree",
@@ -688,7 +688,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E025.png"
     },
     {
         "name": "\"Great Holy Grail War\" Shirou",
@@ -715,7 +715,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E026RR.png"
     },
     {
         "name": "\"Brimming with Confidence\" Saber of Red",
@@ -742,7 +742,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E027.png"
     },
     {
         "name": "\"Final Flash\" Saber of Red",
@@ -771,7 +771,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E028.png"
     },
     {
         "name": "\"Secret of Pedigree\" Saber of Red",
@@ -799,7 +799,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E029.png"
     },
     {
         "name": "\"Humanity's Salvation\" Shirou Kotomine",
@@ -826,7 +826,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E030.png"
     },
     {
         "name": "\"Promised Rematch\" Lancer of Red",
@@ -852,7 +852,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E031.png"
     },
     {
         "name": "\"Blessing of Immortality\" Rider of Red",
@@ -879,7 +879,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E032.png"
     },
     {
         "name": "\"Duel\" Rider of Red",
@@ -906,7 +906,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E033.png"
     },
     {
         "name": "\"Before the Throne\" Assassin of Red",
@@ -933,7 +933,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E034.png"
     },
     {
         "name": "\"Knight of the Round Table\" Saber of Red",
@@ -959,7 +959,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E035R.png"
     },
     {
         "name": "\"Apocrypha\" Shirou",
@@ -989,7 +989,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E036.png"
     },
     {
         "name": "\"Demonic Beast Strength\" Archer of Red",
@@ -1018,7 +1018,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E037.png"
     },
     {
         "name": "\"Overflowing Interest\" Caster of Red",
@@ -1045,7 +1045,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E038.png"
     },
     {
         "name": "\"Bewitching Smile\" Assassin of Red",
@@ -1071,7 +1071,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E039.png"
     },
     {
         "name": "\"Quick Judgment\" Saber of Red",
@@ -1098,7 +1098,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E040.png"
     },
     {
         "name": "Kairi Shishigou",
@@ -1125,7 +1125,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E041.png"
     },
     {
         "name": "\"Command Spell\" Saber of Red",
@@ -1152,7 +1152,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E042.png"
     },
     {
         "name": "\"Gold Armor\" Lancer of Red",
@@ -1179,7 +1179,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E043.png"
     },
     {
         "name": "\"Transformation\" Archer of Red",
@@ -1208,7 +1208,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E044.png"
     },
     {
         "name": "\"Empress\" Assassin of Red",
@@ -1237,7 +1237,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E045.png"
     },
     {
         "name": "\"Tauropolos\" Archer of Red",
@@ -1264,7 +1264,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E046.png"
     },
     {
         "name": "\"With My Command Spell\" Kairi Shishigou",
@@ -1291,7 +1291,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E047.png"
     },
     {
         "name": "\"Crying Warmonger\" Berserker of Red",
@@ -1319,7 +1319,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E048.png"
     },
     {
         "name": "\"In the Gardens\" Assassin of Red",
@@ -1345,7 +1345,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E049.png"
     },
     {
         "name": "\"Realization of the Goal\" Shirou",
@@ -1372,7 +1372,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E050.png"
     },
     {
         "name": "\"Huntress\" Archer of Red",
@@ -1399,7 +1399,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E051.png"
     },
     {
         "name": "\"Playwright\" Caster of Red",
@@ -1428,7 +1428,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E052.png"
     },
     {
         "name": "\"Defense\" Lancer of Red",
@@ -1457,7 +1457,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E053.png"
     },
     {
         "name": "\"In the Gardens\" Shirou",
@@ -1486,7 +1486,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E054.png"
     },
     {
         "name": "\"Rebel\" Berserker of Red",
@@ -1515,7 +1515,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E055.png"
     },
     {
         "name": "\"Promised Feast\" Saber of Red",
@@ -1544,7 +1544,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E056.png"
     },
     {
         "name": "Two Cigarettes",
@@ -1571,7 +1571,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E057a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E057a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E057a.png"
     },
     {
         "name": "Two Cigarettes",
@@ -1598,7 +1598,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E057b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E057b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E057b.png"
     },
     {
         "name": "Miike Tenta",
@@ -1624,7 +1624,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E058.png"
     },
     {
         "name": "Clarent",
@@ -1653,7 +1653,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E059.png"
     },
     {
         "name": "Hanging Gardens of Babylon",
@@ -1683,7 +1683,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E060.png"
     },
     {
         "name": "Vermillion Peal",
@@ -1712,7 +1712,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E061.png"
     },
     {
         "name": "Conflict of Desires",
@@ -1741,7 +1741,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E062.png"
     },
     {
         "name": "\"Like Scattered Petals\" Berserker of Black",
@@ -1767,7 +1767,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E063.png"
     },
     {
         "name": "\"Outstretched Hand\" Rider of Black",
@@ -1793,7 +1793,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E064.png"
     },
     {
         "name": "\"Unleashing the True Name\" Rider of Black",
@@ -1822,7 +1822,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E065.png"
     },
     {
         "name": "\"Massacre\" Assassin of Black",
@@ -1852,7 +1852,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E066.png"
     },
     {
         "name": "\"Battle Ready\" Berserker of Black",
@@ -1879,7 +1879,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E067.png"
     },
     {
         "name": "\"Savagery\" Assassin of Black",
@@ -1906,7 +1906,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E068.png"
     },
     {
         "name": "Fiore Forvedge Yggdmillennia",
@@ -1933,7 +1933,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E069.png"
     },
     {
         "name": "\"Growl\" Berserker of Black",
@@ -1960,7 +1960,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E070.png"
     },
     {
         "name": "\"Duel\" Archer of Black",
@@ -1986,7 +1986,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E071.png"
     },
     {
         "name": "\"King of Capital Punishment\" Lancer of Black",
@@ -2015,7 +2015,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E072.png"
     },
     {
         "name": "\"Before the Duel\" Rider of Black",
@@ -2044,7 +2044,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E073.png"
     },
     {
         "name": "\"Divine Blade\" Saber of Black",
@@ -2073,7 +2073,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E074.png"
     },
     {
         "name": "Reika Rikudou",
@@ -2100,7 +2100,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E075.png"
     },
     {
         "name": "\"Heroic Spirit\" Saber of Black",
@@ -2126,7 +2126,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E076.png"
     },
     {
         "name": "\"Poison Mist\" Assassin of Black",
@@ -2153,7 +2153,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E077.png"
     },
     {
         "name": "\"The Twelve Paladins\" Rider of Black",
@@ -2180,7 +2180,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E078.png"
     },
     {
         "name": "Gordes Musik Yggdmillennia",
@@ -2210,7 +2210,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E079.png"
     },
     {
         "name": "\"Deep Satisfaction\" Berserker of Black",
@@ -2239,7 +2239,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E080.png"
     },
     {
         "name": "Golem Keter Malkuth",
@@ -2269,7 +2269,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E081.png"
     },
     {
         "name": "Caules Forvedge Yggdmillennia",
@@ -2296,7 +2296,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E082.png"
     },
     {
         "name": "\"Twice Ovelapping\" Assassin of Black",
@@ -2325,7 +2325,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E083.png"
     },
     {
         "name": "\"Mage\" Caster of Black",
@@ -2352,7 +2352,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E084.png"
     },
     {
         "name": "\"Relieved Expression\" Rider of Black",
@@ -2379,7 +2379,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E085.png"
     },
     {
         "name": "\"Bowman\" Archer of Black",
@@ -2406,7 +2406,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E086.png"
     },
     {
         "name": "\"Transfiguration\" Lancer of Black",
@@ -2432,7 +2432,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E087.png"
     },
     {
         "name": "\"On the Phone\" Assassin of Black",
@@ -2458,7 +2458,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E088.png"
     },
     {
         "name": "Roche Frain Yggdmillennia",
@@ -2484,7 +2484,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E089.png"
     },
     {
         "name": "Homunculus",
@@ -2511,7 +2511,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E090.png"
     },
     {
         "name": "\"Bridal Chest\" Berserker of Black",
@@ -2537,7 +2537,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E091.png"
     },
     {
         "name": "\"Inherited Heart\" Saber of Black",
@@ -2563,7 +2563,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E092.png"
     },
     {
         "name": "Darnic Prestone Yggdmillennia",
@@ -2589,7 +2589,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E093.png"
     },
     {
         "name": "Celenike Icecolle Yggdmillennia",
@@ -2618,7 +2618,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E094.png"
     },
     {
         "name": "La Black Luna",
@@ -2645,7 +2645,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E095.png"
     },
     {
         "name": "Entrusted Shield",
@@ -2672,7 +2672,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E096.png"
     },
     {
         "name": "Master's Command",
@@ -2701,7 +2701,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E097.png"
     },
     {
         "name": "Blasted Tree",
@@ -2731,7 +2731,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E098.png"
     },
     {
         "name": "Balmung",
@@ -2760,7 +2760,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E099.png"
     },
     {
         "name": "Maria the Ripper",
@@ -2789,7 +2789,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E100.png"
     },
     {
         "name": "Petit Ruler",
@@ -2818,7 +2818,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E101PR.png"
     },
     {
         "name": "Petit Saber of Red",
@@ -2846,7 +2846,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E102PR.png"
     },
     {
         "name": "Petit Rider of Black",
@@ -2872,7 +2872,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E103PR.png"
     },
     {
         "name": "Petit Assassin of Black",
@@ -2899,7 +2899,7 @@
         "set": "APO",
         "release": "53",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_E104PR.png"
     },
     {
         "name": "\"Greatest Heroic Spirit\" Saber of Red",
@@ -2925,7 +2925,7 @@
         "set": "APO",
         "release": "53",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_PE01PR.png"
     },
     {
         "name": "\"Great Holy Grail War\" Ruler",
@@ -2951,7 +2951,7 @@
         "set": "APO",
         "release": "53",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_PE02PR.png"
     },
     {
         "name": "\"Summoning\" Kairi Shishigou",
@@ -2978,7 +2978,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE01.png"
     },
     {
         "name": "\"Shadow Maneuvers\" Shirou Kotomine & Assassin of Red",
@@ -3004,7 +3004,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE02.png"
     },
     {
         "name": "\"Declaration of War\" Lancer of Red",
@@ -3031,7 +3031,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE03.png"
     },
     {
         "name": "\"Summoning\" Saber of Red",
@@ -3057,7 +3057,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE04.png"
     },
     {
         "name": "\"Advance\" Berserker of Red",
@@ -3083,7 +3083,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE05.png"
     },
     {
         "name": "\"Guardian\" Archer of Red",
@@ -3111,7 +3111,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE06.png"
     },
     {
         "name": "\"Taunt\" Rider of Red",
@@ -3140,7 +3140,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE07.png"
     },
     {
         "name": "\"Great Holy Grail War\" Saber of Red",
@@ -3169,7 +3169,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE08.png"
     },
     {
         "name": "Summoning Rite",
@@ -3195,7 +3195,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE09.png"
     },
     {
         "name": "Clash of Spear and Sword",
@@ -3224,7 +3224,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE10.png"
     },
     {
         "name": "\"Lord of the Land\" Lancer of Black",
@@ -3251,7 +3251,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE11.png"
     },
     {
         "name": "\"Genesis\" Caster of Black",
@@ -3278,7 +3278,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE12.png"
     },
     {
         "name": "\"True Name\" Rider of Black",
@@ -3304,7 +3304,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE13.png"
     },
     {
         "name": "\"The First Steps of Fate\" Ruler",
@@ -3330,7 +3330,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE14.png"
     },
     {
         "name": "\"The First Steps of Fate\" Sieg",
@@ -3356,7 +3356,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE15.png"
     },
     {
         "name": "\"Berserk\" Berserker of Black",
@@ -3382,7 +3382,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE16.png"
     },
     {
         "name": "\"Interception\" Archer of Black",
@@ -3411,7 +3411,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE17.png"
     },
     {
         "name": "\"Volition\" Saber of Black",
@@ -3440,7 +3440,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE18.png"
     },
     {
         "name": "Holy Smile",
@@ -3470,7 +3470,7 @@
         "set": "APO",
         "release": "53",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE19.png"
     },
     {
         "name": "Stra?e/Gehen",
@@ -3499,6 +3499,6 @@
         "set": "APO",
         "release": "53",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_APO_S53_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/apo_s53/APO_S53_TE20.png"
     }
 ]

--- a/DB/AT_WX02.json
+++ b/DB/AT_WX02.json
@@ -27,7 +27,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_001.png"
     },
     {
         "name": "Finn the Human",
@@ -56,7 +56,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_002.png"
     },
     {
         "name": "Finn: Heroic Pose",
@@ -83,7 +83,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_003.png"
     },
     {
         "name": "Jake the Dog",
@@ -113,7 +113,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_004.png"
     },
     {
         "name": "Jake: Mocking Imitation",
@@ -140,7 +140,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_005.png"
     },
     {
         "name": "Finn: Trusty Weapon",
@@ -166,7 +166,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_006.png"
     },
     {
         "name": "Finn: What Was Missing",
@@ -194,7 +194,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_007.png"
     },
     {
         "name": "Finn: Demonic Disguise",
@@ -221,7 +221,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_008.png"
     },
     {
         "name": "Jake: Demonic Disguise",
@@ -249,7 +249,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_009.png"
     },
     {
         "name": "Jake: Infected",
@@ -276,7 +276,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_010.png"
     },
     {
         "name": "Cake the Cat",
@@ -305,7 +305,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_011.png"
     },
     {
         "name": "Flame Princess",
@@ -332,7 +332,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_012.png"
     },
     {
         "name": "Finn & Jake: Working as a Team",
@@ -359,7 +359,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_013.png"
     },
     {
         "name": "Finn: Prince Hotbod",
@@ -386,7 +386,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_014.png"
     },
     {
         "name": "Jake: Finding His Buddy a New Love Interest",
@@ -413,7 +413,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_015.png"
     },
     {
         "name": "Jake: What Was Missing",
@@ -439,7 +439,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_016.png"
     },
     {
         "name": "BMO: Buttons Pushed",
@@ -465,7 +465,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_017.png"
     },
     {
         "name": "BMO: Professor Pants",
@@ -492,7 +492,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_018.png"
     },
     {
         "name": "Billy the Hero",
@@ -518,7 +518,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_019.png"
     },
     {
         "name": "Fionna the Human",
@@ -547,7 +547,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_020.png"
     },
     {
         "name": "Joshua & Margaret",
@@ -574,7 +574,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_021.png"
     },
     {
         "name": "Finn: Protected from the Cold",
@@ -601,7 +601,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_022.png"
     },
     {
         "name": "Finn: Fireproof Suit",
@@ -630,7 +630,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_023.png"
     },
     {
         "name": "Finn: Filled with Chaotic Evil",
@@ -660,7 +660,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_024.png"
     },
     {
         "name": "Jake: Gold-Crazed",
@@ -687,7 +687,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_025.png"
     },
     {
         "name": "Jake: Fireproof Suit",
@@ -717,7 +717,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_026.png"
     },
     {
         "name": "Jake: Randy Butternubs",
@@ -746,7 +746,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_027.png"
     },
     {
         "name": "BMO: Noire",
@@ -776,7 +776,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_028.png"
     },
     {
         "name": "BMO: Beating Himself at His Own Game",
@@ -803,7 +803,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_029.png"
     },
     {
         "name": "N.E.P.T.R.",
@@ -832,7 +832,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_030.png"
     },
     {
         "name": "Super Freak",
@@ -858,7 +858,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_031.png"
     },
     {
         "name": "Demon Blood Sword",
@@ -884,7 +884,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_032.png"
     },
     {
         "name": "Scarlet, the Golden Sword of Battle",
@@ -912,7 +912,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_033.png"
     },
     {
         "name": "Card Wars!",
@@ -943,7 +943,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_034.png"
     },
     {
         "name": "The Call of Adventure",
@@ -972,7 +972,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_035.png"
     },
     {
         "name": "His Hero",
@@ -1002,7 +1002,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_036.png"
     },
     {
         "name": "A Tough Case to Crack",
@@ -1032,7 +1032,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_037.png"
     },
     {
         "name": "The Creeps!",
@@ -1061,7 +1061,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_038.png"
     },
     {
         "name": "Escape from Ice Kingdom",
@@ -1090,7 +1090,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_039.png"
     },
     {
         "name": "Princess Bubblegum",
@@ -1117,7 +1117,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_040.png"
     },
     {
         "name": "Princess Bubblegum: Sending Off on a Quest",
@@ -1146,7 +1146,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_041.png"
     },
     {
         "name": "Marceline the Vampire Queen",
@@ -1176,7 +1176,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_042.png"
     },
     {
         "name": "Marceline: I Remember You",
@@ -1203,7 +1203,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_043.png"
     },
     {
         "name": "Princess Bubblegum: Possessed",
@@ -1230,7 +1230,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_044.png"
     },
     {
         "name": "Princess Bubblegum: Beauty and Brains",
@@ -1259,7 +1259,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_045.png"
     },
     {
         "name": "Princess Bubblegum: Lady Quietbottom",
@@ -1286,7 +1286,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_046.png"
     },
     {
         "name": "Marceline: Monstrous",
@@ -1316,7 +1316,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_047.png"
     },
     {
         "name": "Marceline: What Was Missing",
@@ -1345,7 +1345,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_048.png"
     },
     {
         "name": "Wildberry Princess",
@@ -1372,7 +1372,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_049.png"
     },
     {
         "name": "Lady Rainicorn",
@@ -1401,7 +1401,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_050.png"
     },
     {
         "name": "Princess Bubblegum: What Was Missing",
@@ -1427,7 +1427,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_051.png"
     },
     {
         "name": "Marceline: With Hambo",
@@ -1454,7 +1454,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_052.png"
     },
     {
         "name": "Marceline: Filled with Chaotic Evil",
@@ -1483,7 +1483,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_053.png"
     },
     {
         "name": "Teenaged Marceline",
@@ -1509,7 +1509,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_054.png"
     },
     {
         "name": "Slime Princess",
@@ -1536,7 +1536,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_055.png"
     },
     {
         "name": "Lady Rainicorn: Afraid for Her Love",
@@ -1564,7 +1564,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_056.png"
     },
     {
         "name": "Lord Monochromicorn",
@@ -1591,7 +1591,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_057.png"
     },
     {
         "name": "Marshall Lee",
@@ -1618,7 +1618,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_058.png"
     },
     {
         "name": "Prince Gumball",
@@ -1644,7 +1644,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_059.png"
     },
     {
         "name": "Princess Bubblegum: Reconstituted",
@@ -1671,7 +1671,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_060.png"
     },
     {
         "name": "Princess Bubblegum: Infected",
@@ -1698,7 +1698,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_061.png"
     },
     {
         "name": "Marceline: Sanguine Form",
@@ -1725,7 +1725,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_062.png"
     },
     {
         "name": "Hot Dog Princess",
@@ -1754,7 +1754,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_063.png"
     },
     {
         "name": "Lumpy Space Princess",
@@ -1781,7 +1781,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_064.png"
     },
     {
         "name": "Muscle Princess",
@@ -1807,7 +1807,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_065.png"
     },
     {
         "name": "Skeleton Princess",
@@ -1834,7 +1834,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_066.png"
     },
     {
         "name": "Turtle Princess",
@@ -1861,7 +1861,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_067.png"
     },
     {
         "name": "Bob & Ethel Rainicorn",
@@ -1888,7 +1888,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_068.png"
     },
     {
         "name": "Remember You",
@@ -1915,7 +1915,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_069.png"
     },
     {
         "name": "The Nightosphere Amulet",
@@ -1943,7 +1943,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_070.png"
     },
     {
         "name": "My Best Friends In The World",
@@ -1973,7 +1973,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_071.png"
     },
     {
         "name": "Science!",
@@ -2003,7 +2003,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_072.png"
     },
     {
         "name": "Fry Song",
@@ -2032,7 +2032,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_073.png"
     },
     {
         "name": "Captured!",
@@ -2061,7 +2061,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_074.png"
     },
     {
         "name": "Ice King: The King of Ice",
@@ -2090,7 +2090,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_075.png"
     },
     {
         "name": "Ice King",
@@ -2120,7 +2120,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_076.png"
     },
     {
         "name": "Ice King: I Remember You",
@@ -2150,7 +2150,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_077.png"
     },
     {
         "name": "The Lich",
@@ -2179,7 +2179,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_078.png"
     },
     {
         "name": "Hunson Abadeer",
@@ -2208,7 +2208,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_079.png"
     },
     {
         "name": "Hunson Abadeer: Chaotic Evil",
@@ -2238,7 +2238,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_080.png"
     },
     {
         "name": "Kitten",
@@ -2264,7 +2264,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_081.png"
     },
     {
         "name": "Ice King: Nice King?",
@@ -2291,7 +2291,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_082.png"
     },
     {
         "name": "Ice King: Past Self",
@@ -2318,7 +2318,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_083.png"
     },
     {
         "name": "Gunter",
@@ -2345,7 +2345,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_084.png"
     },
     {
         "name": "The Lich: Possessing Billy",
@@ -2374,7 +2374,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_085.png"
     },
     {
         "name": "Earl of Lemongrab",
@@ -2402,7 +2402,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_086.png"
     },
     {
         "name": "Ice Queen",
@@ -2429,7 +2429,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_087.png"
     },
     {
         "name": "Magic Man",
@@ -2456,7 +2456,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_088.png"
     },
     {
         "name": "Ricardio the Heart Guy",
@@ -2483,7 +2483,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_089.png"
     },
     {
         "name": "Gunter: Demonic Wishing Eye",
@@ -2510,7 +2510,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_090.png"
     },
     {
         "name": "Gunter: Giant Penguin Monster",
@@ -2539,7 +2539,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_091.png"
     },
     {
         "name": "The Lich: Possessing Snail",
@@ -2566,7 +2566,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_092.png"
     },
     {
         "name": "Princess Monster Wife",
@@ -2596,7 +2596,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_093.png"
     },
     {
         "name": "King of Mars",
@@ -2623,7 +2623,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_094.png"
     },
     {
         "name": "Demonic Wishing Eye",
@@ -2649,7 +2649,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_095.png"
     },
     {
         "name": "The Ice King's Schemes",
@@ -2676,7 +2676,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_096.png"
     },
     {
         "name": "Unlocking the Enchiridion",
@@ -2702,7 +2702,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_097.png"
     },
     {
         "name": "Prisoners of Love",
@@ -2732,7 +2732,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_098.png"
     },
     {
         "name": "Ruler of the Nightosphere",
@@ -2761,7 +2761,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_099.png"
     },
     {
         "name": "Ultimate Evil",
@@ -2790,7 +2790,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_100.png"
     },
     {
         "name": "Finn: Let's Play!",
@@ -2816,7 +2816,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_101.png"
     },
     {
         "name": "Jake: Let's Play!",
@@ -2845,7 +2845,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_102.png"
     },
     {
         "name": "Princess Bubblegum: Let's Play!",
@@ -2871,7 +2871,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_103.png"
     },
     {
         "name": "Marceline: Let's Play!",
@@ -2898,7 +2898,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_104.png"
     },
     {
         "name": "Finn: Everything In!",
@@ -3277,7 +3277,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "P01A",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_P01A.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_P01A.png"
     },
     {
         "name": "Princess Bubblegum: Gauntleted Fists",
@@ -3306,7 +3306,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "P02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_P02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_P02.png"
     },
     {
         "name": "Finn: Home Remedy",
@@ -3332,7 +3332,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T01.png"
     },
     {
         "name": "Finn: Pledge of Ultimate Responsibility",
@@ -3358,7 +3358,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T02.png"
     },
     {
         "name": "Jake: Don't Roast Them!",
@@ -3385,7 +3385,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T03.png"
     },
     {
         "name": "BMO: Movie Filming Time",
@@ -3412,7 +3412,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T04.png"
     },
     {
         "name": "Finn & Jake: Gauntlet Dock Cleared!",
@@ -3439,7 +3439,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T05.png"
     },
     {
         "name": "Jake: No Longer Pure",
@@ -3465,7 +3465,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T06.png"
     },
     {
         "name": "Finn: Daily Diligence",
@@ -3494,7 +3494,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T07.png"
     },
     {
         "name": "BMO: Doing Strange Things When Nobody's Around",
@@ -3522,7 +3522,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T08.png"
     },
     {
         "name": "Finn & Jake: Heroes of Ooo",
@@ -3552,7 +3552,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T09.png"
     },
     {
         "name": "Vampire Kick",
@@ -3582,7 +3582,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T10.png"
     },
     {
         "name": "Imagination Hyperdrive",
@@ -3611,7 +3611,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T11.png"
     },
     {
         "name": "Princess Bubblegum: Casual",
@@ -3638,7 +3638,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T12.png"
     },
     {
         "name": "Princess Bubblegum: Stately Gown",
@@ -3664,7 +3664,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T13.png"
     },
     {
         "name": "Emerald Princess",
@@ -3690,7 +3690,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T14.png"
     },
     {
         "name": "Marceline: Vampiric Tendencies",
@@ -3717,7 +3717,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T15.png"
     },
     {
         "name": "Engagement Ring Princess",
@@ -3746,7 +3746,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T16.png"
     },
     {
         "name": "Lady Rainicorn: Universally Understood",
@@ -3775,7 +3775,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T17.png"
     },
     {
         "name": "Marceline: Fond of Pranks",
@@ -3804,7 +3804,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T18.png"
     },
     {
         "name": "Don't Eat Those",
@@ -3830,7 +3830,7 @@
         "set": "AT",
         "release": "X02",
         "sid": "T19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T19.png"
     },
     {
         "name": "Whistling Choir Deathmatch Championship Practice",
@@ -3859,6 +3859,6 @@
         "set": "AT",
         "release": "X02",
         "sid": "T20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AT_WX02_T20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/at_wx02/AT_WX02_T20.png"
     }
 ]

--- a/DB/AW2_S43.json
+++ b/DB/AW2_S43.json
@@ -24,7 +24,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E001.png"
     },
     {
         "name": "Bond of the 《Accelerated World》, Kuroyukihime",
@@ -53,7 +53,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E002.png"
     },
     {
         "name": "Vacillating Memories, Kuroyukihime",
@@ -80,7 +80,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E003.png"
     },
     {
         "name": "Summer Festival, Kuroyukihime",
@@ -106,7 +106,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E004.png"
     },
     {
         "name": "《Silver Crow》",
@@ -132,7 +132,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E005.png"
     },
     {
         "name": "Dress Fluttering in the Wind, Kuroyukihime",
@@ -159,7 +159,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E006.png"
     },
     {
         "name": "Rousing Battlecry, Kuroyukihime",
@@ -185,7 +185,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E007.png"
     },
     {
         "name": "《Lotus of Black Death》 Black Lotus",
@@ -215,7 +215,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E008.png"
     },
     {
         "name": "Looking Flushed After a Bath, Kuroyukihime",
@@ -241,7 +241,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E009.png"
     },
     {
         "name": "Beacon of Counterattack, Black Lotus",
@@ -268,7 +268,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E010.png"
     },
     {
         "name": "Unforeseen Circumstances, Kuroyukihime",
@@ -294,7 +294,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E011.png"
     },
     {
         "name": "Uneasy Feeling, Kuroyukihime",
@@ -321,7 +321,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E012.png"
     },
     {
         "name": "Bad at Cooking, Kuroyukihime",
@@ -350,7 +350,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E013.png"
     },
     {
         "name": "A Scene in the Summer, Kuroyukihime",
@@ -379,7 +379,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E014.png"
     },
     {
         "name": "Will of Opposition, Haruyuki",
@@ -408,7 +408,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E015.png"
     },
     {
         "name": "Silver Crow Embracing the Monarch",
@@ -438,7 +438,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E016.png"
     },
     {
         "name": "Acrimonious Advice, Metatron",
@@ -465,7 +465,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E017.png"
     },
     {
         "name": "Waking from Siesta, Kuroyukihime",
@@ -492,7 +492,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E018.png"
     },
     {
         "name": "Yellow Radio",
@@ -518,7 +518,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E019.png"
     },
     {
         "name": "Promised Reward, Kuroyukihime",
@@ -544,7 +544,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E020.png"
     },
     {
         "name": "Armed to the Teeth, Haruyuki",
@@ -570,7 +570,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E021.png"
     },
     {
         "name": "Reasonable 《Acceleration》, Haruyuki",
@@ -596,7 +596,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E022.png"
     },
     {
         "name": "Acting on Volition, Black Lotus",
@@ -625,7 +625,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E023.png"
     },
     {
         "name": "Nurturing Counsel, Kuroyukihime",
@@ -654,7 +654,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E024.png"
     },
     {
         "name": "3D Icon",
@@ -680,7 +680,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E025.png"
     },
     {
         "name": "Incident at the Summer Festival",
@@ -706,7 +706,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E026.png"
     },
     {
         "name": "Nega Nebulas",
@@ -736,7 +736,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E027.png"
     },
     {
         "name": "Dual Flight",
@@ -765,7 +765,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E028.png"
     },
     {
         "name": "Vorpal Strike",
@@ -795,7 +795,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E029.png"
     },
     {
         "name": "Seaside Vacation, Chiyuri",
@@ -825,7 +825,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E030.png"
     },
     {
         "name": "Full of Vigor, Chiyuri",
@@ -851,7 +851,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E031.png"
     },
     {
         "name": "Quiet Love, Rin",
@@ -877,7 +877,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E032.png"
     },
     {
         "name": "《Watch Witch》 Lime Bell",
@@ -904,7 +904,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E033.png"
     },
     {
         "name": "Green Grande",
@@ -931,7 +931,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E034.png"
     },
     {
         "name": "One Who Never Looks Back, Ash Roller",
@@ -960,7 +960,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E035.png"
     },
     {
         "name": "Humming, Lime Bell",
@@ -987,7 +987,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E036.png"
     },
     {
         "name": "Cat-like Behavior, Chiyuri",
@@ -1014,7 +1014,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E037.png"
     },
     {
         "name": "Traversing Through the Black Cloud, Lime Bell",
@@ -1044,7 +1044,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E038.png"
     },
     {
         "name": "Nyx & Risa",
@@ -1073,7 +1073,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E039.png"
     },
     {
         "name": "Goddess of Night, Nyx",
@@ -1102,7 +1102,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E040.png"
     },
     {
         "name": "Hometown Is Shibuya, Ash Roller",
@@ -1129,7 +1129,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E041.png"
     },
     {
         "name": "Disc-shaped Enemy",
@@ -1156,7 +1156,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E042.png"
     },
     {
         "name": "White Duel Avatar",
@@ -1182,7 +1182,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E043.png"
     },
     {
         "name": "Nox Core",
@@ -1210,7 +1210,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E044.png"
     },
     {
         "name": "Summer Festival, Rin",
@@ -1236,7 +1236,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E045.png"
     },
     {
         "name": "Summer Festival, Chiyuri",
@@ -1262,7 +1262,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E046.png"
     },
     {
         "name": "Nemesis & Thanatos",
@@ -1291,7 +1291,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E047.png"
     },
     {
         "name": "Strategy Meeting, Chiyuri",
@@ -1319,7 +1319,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E048.png"
     },
     {
         "name": "Famous 《Healer》 Skill",
@@ -1345,7 +1345,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E049.png"
     },
     {
         "name": "Return to Reality",
@@ -1372,7 +1372,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E050.png"
     },
     {
         "name": "Special Exception for a Childhood Friend",
@@ -1401,7 +1401,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E051.png"
     },
     {
         "name": "Citron Call",
@@ -1430,7 +1430,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E052.png"
     },
     {
         "name": "Older Brother's Punishment",
@@ -1459,7 +1459,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E053.png"
     },
     {
         "name": "A Scene in the Summer, Niko",
@@ -1489,7 +1489,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E054.png"
     },
     {
         "name": "Ardor Maiden",
@@ -1519,7 +1519,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E055.png"
     },
     {
         "name": "Driving, Scarlet Rain",
@@ -1546,7 +1546,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E056.png"
     },
     {
         "name": "Summer Festival, Utai",
@@ -1573,7 +1573,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E057.png"
     },
     {
         "name": "Calming Sight, Niko & Pado",
@@ -1600,7 +1600,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E058.png"
     },
     {
         "name": "Winter's Day Niko",
@@ -1628,7 +1628,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E059.png"
     },
     {
         "name": "A Scene in the Summer, Pado",
@@ -1657,7 +1657,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E060.png"
     },
     {
         "name": "Competitive, Scarlet Rain",
@@ -1686,7 +1686,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E061.png"
     },
     {
         "name": "Battle at the Jingu, Ardor Maiden",
@@ -1713,7 +1713,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E062.png"
     },
     {
         "name": "Executing the Plan, Blood Leopard",
@@ -1739,7 +1739,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E063.png"
     },
     {
         "name": "《Bloody Kitty》 Blood Leopard",
@@ -1765,7 +1765,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E064.png"
     },
     {
         "name": "Matsunoki Elementary School, Utai",
@@ -1791,7 +1791,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E065.png"
     },
     {
         "name": "Cool Vibe, Pado",
@@ -1818,7 +1818,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E066.png"
     },
     {
         "name": "Armor Up Command, Scarlet Rain",
@@ -1847,7 +1847,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E067.png"
     },
     {
         "name": "Enforced Logout, Niko",
@@ -1873,7 +1873,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E068.png"
     },
     {
         "name": "Chatterbox, Niko",
@@ -1900,7 +1900,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E069.png"
     },
     {
         "name": "Cooking with a Smile, Niko",
@@ -1926,7 +1926,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E070.png"
     },
     {
         "name": "Stable Person, Utai",
@@ -1955,7 +1955,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E071.png"
     },
     {
         "name": "In the Heat of Battle, Utai",
@@ -1984,7 +1984,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E072.png"
     },
     {
         "name": "《Foothold》",
@@ -2010,7 +2010,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E073.png"
     },
     {
         "name": "Dangerous Driving",
@@ -2037,7 +2037,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E074.png"
     },
     {
         "name": "Having Fun in the Summer",
@@ -2066,7 +2066,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E075.png"
     },
     {
         "name": "Heat Blast Saturation",
@@ -2095,7 +2095,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E076.png"
     },
     {
         "name": "Flame Torrents",
@@ -2124,7 +2124,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E077.png"
     },
     {
         "name": "《Strato Shooter》 Sky Raker",
@@ -2153,7 +2153,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E078.png"
     },
     {
         "name": "Intent-filled Eyes, Fuko",
@@ -2180,7 +2180,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E079.png"
     },
     {
         "name": "Girl Who Aimed for the Skies, Fuko",
@@ -2206,7 +2206,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E080.png"
     },
     {
         "name": "Akira Himi",
@@ -2232,7 +2232,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E081.png"
     },
     {
         "name": "Summer Festival, Fuko",
@@ -2259,7 +2259,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E082.png"
     },
     {
         "name": "Traversing Through the Black Cloud, Sky Raker",
@@ -2286,7 +2286,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E083.png"
     },
     {
         "name": "Blue Knight",
@@ -2314,7 +2314,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E084.png"
     },
     {
         "name": "《Aquamatic》 Aqua Current",
@@ -2341,7 +2341,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E085.png"
     },
     {
         "name": "Changing Clothes, Fuko",
@@ -2367,7 +2367,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E086.png"
     },
     {
         "name": "《Nega Nebulas》 Submaster, Fuko",
@@ -2396,7 +2396,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E087.png"
     },
     {
         "name": "Melee Combat Form, Aqua Current",
@@ -2425,7 +2425,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E088.png"
     },
     {
         "name": "Summer Festival, Akira",
@@ -2452,7 +2452,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E089.png"
     },
     {
         "name": "Purple Thorn",
@@ -2479,7 +2479,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E090.png"
     },
     {
         "name": "Strategist Position, Takumu",
@@ -2505,7 +2505,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E091.png"
     },
     {
         "name": "Cyan Pile Becoming a Shield",
@@ -2531,7 +2531,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E092.png"
     },
     {
         "name": "Birds of a Feather, Takumu & Haruyuki",
@@ -2557,7 +2557,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E093.png"
     },
     {
         "name": "Battle at the Jingu, Sky Raker",
@@ -2585,7 +2585,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E094.png"
     },
     {
         "name": "《Perforation》 Ability, Cyan Pile",
@@ -2614,7 +2614,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E095.png"
     },
     {
         "name": "Marker of Mortification",
@@ -2640,7 +2640,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E096.png"
     },
     {
         "name": "Gale Thruster",
@@ -2666,7 +2666,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E097.png"
     },
     {
         "name": "Summer Night's Slumber",
@@ -2696,7 +2696,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E098.png"
     },
     {
         "name": "Combination?",
@@ -2725,7 +2725,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E099.png"
     },
     {
         "name": "Lightning Cyan Spike",
@@ -2754,7 +2754,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E100.png"
     },
     {
         "name": "Mini Kuroyukihime",
@@ -2781,7 +2781,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E101.png"
     },
     {
         "name": "Mini Chiyuri",
@@ -2807,7 +2807,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E102.png"
     },
     {
         "name": "Mini Niko",
@@ -2833,7 +2833,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E103.png"
     },
     {
         "name": "Mini Fuko",
@@ -2859,7 +2859,7 @@
         "set": "AW",
         "release": "43",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_E104.png"
     },
     {
         "name": "Santa Kuroyukihime",
@@ -2886,6 +2886,6 @@
         "set": "AW",
         "release": "43",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S43_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s43/AW_S43_PE01.png"
     }
 ]

--- a/DB/AW_S18.json
+++ b/DB/AW_S18.json
@@ -24,7 +24,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E001.png"
     },
     {
         "name": "Kuroyukihime",
@@ -53,7 +53,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E002.png"
     },
     {
         "name": "\"Churakagi\" Kuroyukihime",
@@ -80,7 +80,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E003.png"
     },
     {
         "name": "Intimate Relationship, Kuroyukihime",
@@ -107,7 +107,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E004.png"
     },
     {
         "name": "In Pursuit of the End, Kuroyukihime",
@@ -134,7 +134,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E005.png"
     },
     {
         "name": "Maiden in Love, Kuroyukihime",
@@ -163,7 +163,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E006.png"
     },
     {
         "name": "Challenging a Formidable Foe, Silver Crow",
@@ -191,7 +191,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E007.png"
     },
     {
         "name": "Pure Desire to Monopolize, Kuroyukihime",
@@ -220,7 +220,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E008.png"
     },
     {
         "name": "Black Lotus",
@@ -249,7 +249,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E009.png"
     },
     {
         "name": "Black Lotus Facing a Crossroad Duel",
@@ -275,7 +275,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E010.png"
     },
     {
         "name": "Amateur Burst Linker, Silver Crow",
@@ -301,7 +301,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E011.png"
     },
     {
         "name": "《Black King》Black Lotus",
@@ -327,7 +327,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E012.png"
     },
     {
         "name": "Twilight Promise, Kuroyukihime",
@@ -354,7 +354,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E013.png"
     },
     {
         "name": "Real Strength, Kuroyukihime",
@@ -383,7 +383,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E014.png"
     },
     {
         "name": "To the Unexplored Heights of Mankind, Haruyuki",
@@ -411,7 +411,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E015.png"
     },
     {
         "name": "The Boy Who Wanted Wings, Haruyuki",
@@ -438,7 +438,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E016.png"
     },
     {
         "name": "Pink Pig, Haruyuki",
@@ -464,7 +464,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E017.png"
     },
     {
         "name": "King's Return, Black Lotus",
@@ -490,7 +490,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E018.png"
     },
     {
         "name": "School Madonna, Kuroyukihime",
@@ -516,7 +516,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E019.png"
     },
     {
         "name": "Bullied Kid, Haruyuki",
@@ -542,7 +542,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E020.png"
     },
     {
         "name": "Enormous Klutz, Haruyuki",
@@ -570,7 +570,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E021.png"
     },
     {
         "name": "Silver Wings, Silver Crow",
@@ -596,7 +596,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E022.png"
     },
     {
         "name": "Pony Tail Kuroyukihime",
@@ -624,7 +624,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E023.png"
     },
     {
         "name": "Impeding Wall, Haruyuki",
@@ -652,7 +652,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E024.png"
     },
     {
         "name": "Betrayal",
@@ -679,7 +679,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E025.png"
     },
     {
         "name": "Gale Thruster",
@@ -705,7 +705,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E026.png"
     },
     {
         "name": "The Heart That Yearns for the Sky",
@@ -734,7 +734,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E027.png"
     },
     {
         "name": "A Feeling Never Felt Before",
@@ -763,7 +763,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E028.png"
     },
     {
         "name": "Death By Piercing",
@@ -793,7 +793,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E029.png"
     },
     {
         "name": "Knight of the《Black King》",
@@ -823,7 +823,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E030.png"
     },
     {
         "name": "Sea of Cushions, Chiyuri",
@@ -850,7 +850,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E031.png"
     },
     {
         "name": "《Healer》Lime Bell",
@@ -877,7 +877,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E032.png"
     },
     {
         "name": "Nonchalant Talk, Chiyuri",
@@ -904,7 +904,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E033.png"
     },
     {
         "name": "Apology Ice Cream, Chiyuri",
@@ -930,7 +930,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E034.png"
     },
     {
         "name": "Optimistic Lime Bell",
@@ -957,7 +957,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E035.png"
     },
     {
         "name": "Taking Care of Friends, Chiyuri",
@@ -986,7 +986,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E036.png"
     },
     {
         "name": "Chiyuri Kurashima",
@@ -1015,7 +1015,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E037.png"
     },
     {
         "name": "Lime Bell",
@@ -1041,7 +1041,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E038.png"
     },
     {
         "name": "Seiji Nomi",
@@ -1067,7 +1067,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E039.png"
     },
     {
         "name": "Ash Roller",
@@ -1093,7 +1093,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E040.png"
     },
     {
         "name": "Dusk Taker",
@@ -1119,7 +1119,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E041.png"
     },
     {
         "name": "Betrayer, Lime Bell",
@@ -1147,7 +1147,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E042.png"
     },
     {
         "name": "Younger Days, Chiyuri",
@@ -1173,7 +1173,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E043.png"
     },
     {
         "name": "Suspicious Gaze, Chiyuri",
@@ -1199,7 +1199,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E044.png"
     },
     {
         "name": "Silver Cat, Chiyuri",
@@ -1225,7 +1225,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E045.png"
     },
     {
         "name": "Bright and Cheerful, Chiyuri",
@@ -1251,7 +1251,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E046.png"
     },
     {
         "name": "Manly Skull Mask, Ash Roller",
@@ -1277,7 +1277,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E047.png"
     },
     {
         "name": "Sunny Smile, Chiyuri",
@@ -1303,7 +1303,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E048.png"
     },
     {
         "name": "Lovable Charm, Chiyuri",
@@ -1331,7 +1331,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E049.png"
     },
     {
         "name": "Good Rival, Ash Roller",
@@ -1359,7 +1359,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E050.png"
     },
     {
         "name": "Pyro Dealer",
@@ -1385,7 +1385,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E051.png"
     },
     {
         "name": "Choir Chime",
@@ -1411,7 +1411,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E052.png"
     },
     {
         "name": "Chiyuri's Tears",
@@ -1440,7 +1440,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E053.png"
     },
     {
         "name": "Citron Call",
@@ -1469,7 +1469,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E054.png"
     },
     {
         "name": "Demonic Commandeer",
@@ -1498,7 +1498,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E055.png"
     },
     {
         "name": "Good at Cooking, Niko",
@@ -1527,7 +1527,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E056.png"
     },
     {
         "name": "Yuniko Kozuki",
@@ -1556,7 +1556,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E057.png"
     },
     {
         "name": "Emotional Scarlet Rain",
@@ -1583,7 +1583,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E058.png"
     },
     {
         "name": "Cute Cousin!? Niko",
@@ -1610,7 +1610,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E059.png"
     },
     {
         "name": "Rain & Leopard",
@@ -1636,7 +1636,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E060.png"
     },
     {
         "name": "《Immobile Fortress》Scarlet Rain",
@@ -1665,7 +1665,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E061.png"
     },
     {
         "name": "《Red King》Scarlet Rain",
@@ -1694,7 +1694,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E062.png"
     },
     {
         "name": "Niko Staying Over",
@@ -1721,7 +1721,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E063.png"
     },
     {
         "name": "Heart Race in the Bath, Niko",
@@ -1747,7 +1747,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E064.png"
     },
     {
         "name": "Angel Mode, Niko",
@@ -1774,7 +1774,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E065.png"
     },
     {
         "name": "Darkness of the Heart, Silver Crow",
@@ -1800,7 +1800,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E066.png"
     },
     {
         "name": "Strongest Name, C.K",
@@ -1828,7 +1828,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E067.png"
     },
     {
         "name": "Crimson Kingbolt",
@@ -1854,7 +1854,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E068.png"
     },
     {
         "name": "Maid of Nerima, Pard",
@@ -1880,7 +1880,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E069.png"
     },
     {
         "name": "Megumi Wakamiya",
@@ -1906,7 +1906,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E070.png"
     },
     {
         "name": "《Bloody Storm》 Scarlet Rain",
@@ -1932,7 +1932,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E071.png"
     },
     {
         "name": "Close Friend Going Out-of-control, Scarlet Rain",
@@ -1958,7 +1958,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E072.png"
     },
     {
         "name": "5th Generation Chrome Disaster",
@@ -1984,7 +1984,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E073.png"
     },
     {
         "name": "《Prominence》's Top, Niko & Pard",
@@ -2012,7 +2012,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E074.png"
     },
     {
         "name": "Peak of Impudence, Niko",
@@ -2041,7 +2041,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E075.png"
     },
     {
         "name": "Invincible",
@@ -2067,7 +2067,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E076.png"
     },
     {
         "name": "Armor of Calamity",
@@ -2094,7 +2094,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E077.png"
     },
     {
         "name": "Hailstorm Domination",
@@ -2123,7 +2123,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E078.png"
     },
     {
         "name": "Black Repercussions",
@@ -2152,7 +2152,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E079.png"
     },
     {
         "name": "Judgment Blow",
@@ -2181,7 +2181,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E080.png"
     },
     {
         "name": "Hermit, Sky Raker",
@@ -2208,7 +2208,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E081.png"
     },
     {
         "name": "Kendo Club, Takumu",
@@ -2234,7 +2234,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E082.png"
     },
     {
         "name": "Calm Smile, Fuko",
@@ -2260,7 +2260,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E083.png"
     },
     {
         "name": "Cyan Pile",
@@ -2286,7 +2286,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E084.png"
     },
     {
         "name": "Fuko Kurasaki",
@@ -2315,7 +2315,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E085.png"
     },
     {
         "name": "Former Ally, Sky Raker",
@@ -2342,7 +2342,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E086.png"
     },
     {
         "name": "Reliable Partner, Cyan Pile",
@@ -2368,7 +2368,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E087.png"
     },
     {
         "name": "Intelligent and Cute, Fuko",
@@ -2394,7 +2394,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E088.png"
     },
     {
         "name": "Ash's Teacher, Sky Raker",
@@ -2422,7 +2422,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E089.png"
     },
     {
         "name": "Mana Itosu",
@@ -2448,7 +2448,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E090.png"
     },
     {
         "name": "New Ally, Takumu",
@@ -2474,7 +2474,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E091.png"
     },
     {
         "name": "《Bouncer》 Aqua Current",
@@ -2500,7 +2500,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E092.png"
     },
     {
         "name": "Ruka Asato",
@@ -2526,7 +2526,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E093.png"
     },
     {
         "name": "Glasses Character, Takumu",
@@ -2554,7 +2554,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E094.png"
     },
     {
         "name": "Unlimited Field, Cyan Pile",
@@ -2582,7 +2582,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E095.png"
     },
     {
         "name": "Silent Beauty, Aqua Current",
@@ -2610,7 +2610,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E096.png"
     },
     {
         "name": "Pile Driver",
@@ -2636,7 +2636,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E097.png"
     },
     {
         "name": "Forced Transition",
@@ -2663,7 +2663,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E098.png"
     },
     {
         "name": "Incarnation",
@@ -2692,7 +2692,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E099.png"
     },
     {
         "name": "Lightning Cyan Spike",
@@ -2721,7 +2721,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E100.png"
     },
     {
         "name": "Meddlesome Childhood Friend, Chiyuri",
@@ -2747,7 +2747,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E101.png"
     },
     {
         "name": "Miraculous Survival, Kuroyukihime",
@@ -2776,7 +2776,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E102.png"
     },
     {
         "name": "Jet Black Swallowtail Butterfly, Kuroyukihime",
@@ -2802,7 +2802,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E103.png"
     },
     {
         "name": "Silver Crow",
@@ -2832,7 +2832,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E104.png"
     },
     {
         "name": "Pajama Look, Kuroyukihime",
@@ -2860,7 +2860,7 @@
         "set": "AW",
         "release": "18",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_E105.png"
     },
     {
         "name": "Conditions of Reward, Kuroyukihime",
@@ -3016,7 +3016,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE01.png"
     },
     {
         "name": "Novice Burst Linker, Silver Crow",
@@ -3042,7 +3042,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE02.png"
     },
     {
         "name": "The King's Return, Black Lotus",
@@ -3068,7 +3068,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE03.png"
     },
     {
         "name": "School Madonna, Kuroyukihime",
@@ -3094,7 +3094,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE04.png"
     },
     {
         "name": "Bullied Kid, Haruyuki",
@@ -3120,7 +3120,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE05.png"
     },
     {
         "name": "Twilight Promise, Kuroyukihime",
@@ -3147,7 +3147,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE06.png"
     },
     {
         "name": "Silver Wings, Silver Crow",
@@ -3173,7 +3173,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE07.png"
     },
     {
         "name": "Impeding Wall, Haruyuki",
@@ -3201,7 +3201,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE08.png"
     },
     {
         "name": "A Feeling Never Felt Before",
@@ -3230,7 +3230,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE09.png"
     },
     {
         "name": "Knight of the《Black King》",
@@ -3260,7 +3260,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE10.png"
     },
     {
         "name": "Silver Cat, Chiyuri",
@@ -3286,7 +3286,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE11.png"
     },
     {
         "name": "Bright and Cheerful, Chiyuri",
@@ -3312,7 +3312,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE12.png"
     },
     {
         "name": "Adorable Charm, Chiyuri",
@@ -3340,7 +3340,7 @@
         "set": "AW",
         "release": "18",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE13.png"
     },
     {
         "name": "Citron Call",
@@ -3369,6 +3369,6 @@
         "set": "AW",
         "release": "18",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/AW_S18_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/a/aw_s18/AW_S18_TE14.png"
     }
 ]

--- a/DB/BD2_W73.json
+++ b/DB/BD2_W73.json
@@ -24,7 +24,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E001.png"
     },
     {
         "name": "\"Music of Smiles\" Kokoro Tsurumaki",
@@ -53,7 +53,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E002.png"
     },
     {
         "name": "For the Sake of Smiles, Kokoro Tsurumaki",
@@ -80,7 +80,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E003 copy.png"
     },
     {
         "name": "\"Music of Smiles\" Misaki Okusawa",
@@ -109,7 +109,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E004.png"
     },
     {
         "name": "\"Music of Smiles\" Kaoru Seta",
@@ -139,7 +139,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E005.png"
     },
     {
         "name": "Turning Trembles into Strength, Aya Maruyama",
@@ -168,7 +168,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E006.png"
     },
     {
         "name": "An Enticing Invitation, Kaoru Seta",
@@ -195,7 +195,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E007.png"
     },
     {
         "name": "Engine On! Misaki Okusawa",
@@ -225,7 +225,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E008.png"
     },
     {
         "name": "Sincere Feelings, Eve Wakamiya",
@@ -255,7 +255,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E009.png"
     },
     {
         "name": "\"Music of Smiles\" Kanon Matsubara",
@@ -284,7 +284,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E010.png"
     },
     {
         "name": "No Sense of Direction, Kanon Matsubara",
@@ -311,7 +311,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E011.png"
     },
     {
         "name": "Determined Challenge, Hagumi Kitazawa",
@@ -338,7 +338,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E012.png"
     },
     {
         "name": "Usual Catchphrase, Kokoro Tsurumaki",
@@ -367,7 +367,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E013.png"
     },
     {
         "name": "After-school Strategy Meeting",
@@ -395,7 +395,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E014.png"
     },
     {
         "name": "Smile in the Night Sky",
@@ -424,7 +424,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E015.png"
     },
     {
         "name": "Tonight, When the Stars Shine",
@@ -454,7 +454,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E016.png"
     },
     {
         "name": "\"Our Music\" Ran Mitake",
@@ -481,7 +481,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E017.png"
     },
     {
         "name": "\"Supreme Music\" LAYER",
@@ -508,7 +508,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E018.png"
     },
     {
         "name": "\"Our Music\" Tsugumi Hazawa",
@@ -538,7 +538,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E019.png"
     },
     {
         "name": "\"Supreme Music\" LOCK",
@@ -568,7 +568,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E020.png"
     },
     {
         "name": "\"Our Music\" Tomoe Udagawa",
@@ -595,7 +595,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E021.png"
     },
     {
         "name": "\"Our Music\" Moca Aoba",
@@ -622,7 +622,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E022.png"
     },
     {
         "name": "\"Interweaving Music\" Eve Wakamiya",
@@ -649,7 +649,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E023.png"
     },
     {
         "name": "\"Supreme Music\" MASKING",
@@ -676,7 +676,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E024.png"
     },
     {
         "name": "Desperate Invitation, LOCK",
@@ -705,7 +705,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E025.png"
     },
     {
         "name": "Overwhelming Vocal Ability, LAYER",
@@ -735,7 +735,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E026.png"
     },
     {
         "name": "\"Our Music\" Himari Uehara",
@@ -764,7 +764,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E027.png"
     },
     {
         "name": "RAISE YOUR HANDS, LOCK",
@@ -791,7 +791,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E028.png"
     },
     {
         "name": "RAISE YOUR HANDS, LAYER",
@@ -818,7 +818,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E029.png"
     },
     {
         "name": "My Own Pace, Moca Aoba",
@@ -844,7 +844,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E030.png"
     },
     {
         "name": "Blunt Kindness, MASKING",
@@ -873,7 +873,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E031.png"
     },
     {
         "name": "Unchanging Bonds, Ran Mitake",
@@ -902,7 +902,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E032.png"
     },
     {
         "name": "Hard Worker, Tsugumi Hazawa",
@@ -931,7 +931,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E033.png"
     },
     {
         "name": "Usual Cheers, Himari Uehara",
@@ -958,7 +958,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E034.png"
     },
     {
         "name": "Exceptional Ability to Take Action, Hina Hikawa",
@@ -985,7 +985,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E035.png"
     },
     {
         "name": "Freshmen, LOCK & Asuka",
@@ -1011,7 +1011,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E036.png"
     },
     {
         "name": "Shining Admiration, LOCK",
@@ -1038,7 +1038,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E037.png"
     },
     {
         "name": "Handling Difficult Demands, LOCK",
@@ -1065,7 +1065,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E038.png"
     },
     {
         "name": "Powerful Eyes, Ran Mitake",
@@ -1092,7 +1092,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E039.png"
     },
     {
         "name": "Full of Spirit, Tomoe Udagawa",
@@ -1119,7 +1119,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E040.png"
     },
     {
         "name": "RAISE YOUR HANDS, MASKING",
@@ -1146,7 +1146,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E041.png"
     },
     {
         "name": "Request, Aya Maruyama",
@@ -1175,7 +1175,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E042.png"
     },
     {
         "name": "Childhood Promise, LAYER",
@@ -1204,7 +1204,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E043.png"
     },
     {
         "name": "Mad Dog, MASKING",
@@ -1233,7 +1233,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E044.png"
     },
     {
         "name": "An Eternal Sunset",
@@ -1261,7 +1261,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E045.png"
     },
     {
         "name": "Promise From Before",
@@ -1290,7 +1290,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E046.png"
     },
     {
         "name": "Our Melody",
@@ -1319,7 +1319,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E047.png"
     },
     {
         "name": "The View on That Day",
@@ -1348,7 +1348,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E048.png"
     },
     {
         "name": "\"Music of Bonds\" Kasumi Toyama",
@@ -1375,7 +1375,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E049.png"
     },
     {
         "name": "\"Interweaving Music\" Hina Hikawa",
@@ -1401,7 +1401,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E050.png"
     },
     {
         "name": "\"Music of Bonds\" Saya Yamabuki",
@@ -1428,7 +1428,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E051.png"
     },
     {
         "name": "\"Music of Bonds\" Rimi Ushigome",
@@ -1458,7 +1458,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E052.png"
     },
     {
         "name": "Time for Our Live! Kasumi Toyama",
@@ -1487,7 +1487,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E053.png"
     },
     {
         "name": "Pounding Heart, Rimi Ushigome",
@@ -1514,7 +1514,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E054.png"
     },
     {
         "name": "All Together, Chisato Shirasagi",
@@ -1541,7 +1541,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E055.png"
     },
     {
         "name": "\"Interweaving Music\" Maya Yamato",
@@ -1571,7 +1571,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E056.png"
     },
     {
         "name": "New Sticks, Saya Yamabuki",
@@ -1597,7 +1597,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E057.png"
     },
     {
         "name": "Practice Interval, Kasumi Toyama",
@@ -1623,7 +1623,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E058.png"
     },
     {
         "name": "Hype! Saya Yamabuki",
@@ -1652,7 +1652,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E059.png"
     },
     {
         "name": "Teary Eyes, Rimi Ushigome",
@@ -1681,7 +1681,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E060.png"
     },
     {
         "name": "Overlapping Palms",
@@ -1707,7 +1707,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E061.png"
     },
     {
         "name": "Enthusiastic Huddle",
@@ -1733,7 +1733,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E062.png"
     },
     {
         "name": "Melody of Bonds",
@@ -1763,7 +1763,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E063.png"
     },
     {
         "name": "Interweaving Melodies",
@@ -1792,7 +1792,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E064.png"
     },
     {
         "name": "\"Interweaving Music\" Aya Maruyama",
@@ -1819,7 +1819,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E065.png"
     },
     {
         "name": "\"Unwavering Music\" Yukina Minato",
@@ -1846,7 +1846,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E066.png"
     },
     {
         "name": "\"Music of Bonds\" Tae Hanazono",
@@ -1873,7 +1873,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E067.png"
     },
     {
         "name": "\"Unwavering Music\" Sayo Hikawa",
@@ -1900,7 +1900,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E068.png"
     },
     {
         "name": "Here is Where I Belong, Tae Hanazono",
@@ -1927,7 +1927,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E069.png"
     },
     {
         "name": "\"Supreme Music\" CHU2",
@@ -1954,7 +1954,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E070.png"
     },
     {
         "name": "\"Unwavering Music\" Ako Udagawa",
@@ -1981,7 +1981,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E071.png"
     },
     {
         "name": "Competent Producer, CHU2",
@@ -2008,7 +2008,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E072.png"
     },
     {
         "name": "\"Supreme Music\" PAREO",
@@ -2037,7 +2037,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E073.png"
     },
     {
         "name": "\"Interweaving Music\" Chisato Shirasagi",
@@ -2067,7 +2067,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E074.png"
     },
     {
         "name": "Quiet Passion, Yukina Minato",
@@ -2096,7 +2096,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E075.png"
     },
     {
         "name": "\"Unwavering Music\" Lisa Imai",
@@ -2125,7 +2125,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E076.png"
     },
     {
         "name": "Watching Over Nearby, Lisa Imai",
@@ -2152,7 +2152,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E077.png"
     },
     {
         "name": "Cheerful Smile, PAREO",
@@ -2178,7 +2178,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E078.png"
     },
     {
         "name": "\"Unwavering Music\" Rinko Shirokane",
@@ -2205,7 +2205,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E079.png"
     },
     {
         "name": "\"Music of Bonds\" Arisa Ichigaya",
@@ -2233,7 +2233,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E080.png"
     },
     {
         "name": "Playing a Melody, Tae Hanazono",
@@ -2262,7 +2262,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E081.png"
     },
     {
         "name": "Festive Mood CHU2",
@@ -2292,7 +2292,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E082.png"
     },
     {
         "name": "Cool and Collected, Sayo Hikawa",
@@ -2321,7 +2321,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E083.png"
     },
     {
         "name": "Embarassing Feelings, Arisa Ichigaya",
@@ -2350,7 +2350,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E084.png"
     },
     {
         "name": "Courage Little by Little, Rinko Shirokane",
@@ -2377,7 +2377,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E085.png"
     },
     {
         "name": "RAISE YOUR HANDS, CHU2",
@@ -2403,7 +2403,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E086.png"
     },
     {
         "name": "Turning Individuality into Strength, Maya Yamato",
@@ -2430,7 +2430,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E087.png"
     },
     {
         "name": "Beginning of a Legend, PAREO",
@@ -2457,7 +2457,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E088.png"
     },
     {
         "name": "Puzzled, Arisa Ichigaya",
@@ -2483,7 +2483,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E089.png"
     },
     {
         "name": "More Power, Ako Udagawa",
@@ -2512,7 +2512,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E090.png"
     },
     {
         "name": "Real Feelings Behind Harsh Words, Yukina Minato",
@@ -2541,7 +2541,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E091.png"
     },
     {
         "name": "RAISE YOUR HANDS, PAREO",
@@ -2570,7 +2570,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E092.png"
     },
     {
         "name": "Throbbing, Tae Hanazono",
@@ -2599,7 +2599,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E093.png"
     },
     {
         "name": "Aiming for the Top as Five",
@@ -2627,7 +2627,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E094.png"
     },
     {
         "name": "Yes!! You Guys Are the Best!!",
@@ -2653,7 +2653,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E095.png"
     },
     {
         "name": "Jumpin' Girls!",
@@ -2683,7 +2683,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E096.png"
     },
     {
         "name": "Unwavering Melody",
@@ -2713,7 +2713,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E097.png"
     },
     {
         "name": "Supreme Melody",
@@ -2742,7 +2742,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E098.png"
     },
     {
         "name": "After the Rain",
@@ -2772,7 +2772,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E099.png"
     },
     {
         "name": "School Festival",
@@ -2802,7 +2802,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E100.png"
     },
     {
         "name": "Never-Ending Music, Kokoro Tsurumaki",
@@ -2828,7 +2828,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E101.png"
     },
     {
         "name": "Never-Ending Music, Aya Maruyama",
@@ -2856,7 +2856,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E102.png"
     },
     {
         "name": "Never-Ending Music, LAYER",
@@ -2883,7 +2883,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E103.png"
     },
     {
         "name": "Never-Ending Music, Ran Mitake",
@@ -2910,7 +2910,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E104.png"
     },
     {
         "name": "Never-Ending Music, Kasumi Toyama",
@@ -2937,7 +2937,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E105.png"
     },
     {
         "name": "Never-Ending Music, Yukina Minato",
@@ -2964,7 +2964,7 @@
         "set": "BD",
         "release": "73",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_E106.png"
     },
     {
         "name": "\"UNSTOPPABLE\" LAYER",
@@ -2991,7 +2991,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE01.png"
     },
     {
         "name": "Amidst Loud Cheers, LOCK",
@@ -3018,7 +3018,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE02.png"
     },
     {
         "name": "Firm Passion, MASKING",
@@ -3045,7 +3045,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE03.png"
     },
     {
         "name": "\"UNSTOPPABLE\" LOCK",
@@ -3072,7 +3072,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE04.png"
     },
     {
         "name": "Strumming Melodies, LAYER",
@@ -3098,7 +3098,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE05.png"
     },
     {
         "name": "On Stage, MASKING",
@@ -3126,7 +3126,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE06.png"
     },
     {
         "name": "\"UNSTOPPABLE\" MASKING",
@@ -3155,7 +3155,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE07.png"
     },
     {
         "name": "Firm Emotions, LOCK",
@@ -3184,7 +3184,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE08.png"
     },
     {
         "name": "On Stage, LAYER",
@@ -3213,7 +3213,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE09.png"
     },
     {
         "name": "Firm Abilities, LAYER",
@@ -3242,7 +3242,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE10.png"
     },
     {
         "name": "Intense Performance",
@@ -3271,7 +3271,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE11.png"
     },
     {
         "name": "Rising Enthusiasm",
@@ -3300,7 +3300,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE12.png"
     },
     {
         "name": "Firm Perceptions, CHU2",
@@ -3327,7 +3327,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE13.png"
     },
     {
         "name": "\"UNSTOPPABLE\" CHU2",
@@ -3354,7 +3354,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE14.png"
     },
     {
         "name": "\"UNSTOPPABLE\" PAREO",
@@ -3380,7 +3380,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE15.png"
     },
     {
         "name": "Firm Trust, PAREO",
@@ -3406,7 +3406,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE16.png"
     },
     {
         "name": "Unceasing Cheers, CHU2",
@@ -3433,7 +3433,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE17.png"
     },
     {
         "name": "On Stage, PAREO",
@@ -3462,7 +3462,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE18.png"
     },
     {
         "name": "Change the world!",
@@ -3491,7 +3491,7 @@
         "set": "BD",
         "release": "73",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE19.png"
     },
     {
         "name": "Ultimate Sound",
@@ -3520,6 +3520,6 @@
         "set": "BD",
         "release": "73",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W73_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w73/BD_W73_TE20.png"
     }
 ]

--- a/DB/BDG_W54.json
+++ b/DB/BDG_W54.json
@@ -23,7 +23,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E001.png"
     },
     {
         "name": "\"Model Mode\" Eve Wakamiya",
@@ -50,7 +50,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E002.png"
     },
     {
         "name": "\"Maritime Detective\" Kokoro Tsurumaki",
@@ -79,7 +79,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E003.png"
     },
     {
         "name": "\"Everybody, On Three!\" Hagumi Kitazawa",
@@ -106,7 +106,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E004.png"
     },
     {
         "name": "\"Confession of Love\" Misaki Okusawa",
@@ -133,7 +133,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E005.png"
     },
     {
         "name": "\"Make the World Smile!\" Kokoro Tsurumaki",
@@ -159,7 +159,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E006.png"
     },
     {
         "name": "\"First Step\" Kanon Matsubara",
@@ -186,7 +186,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E007.png"
     },
     {
         "name": "\"Onstage\" Hagumi Kitazawa",
@@ -212,7 +212,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E008.png"
     },
     {
         "name": "\"Onstage\" Kanon Matsubara",
@@ -239,7 +239,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E009.png"
     },
     {
         "name": "\"Onstage\" Kokoro Tsurumaki",
@@ -266,7 +266,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E010.png"
     },
     {
         "name": "\"Yes, I'm Michelle!\" Misaki Okusawa",
@@ -296,7 +296,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E011.png"
     },
     {
         "name": "\"Onstage\" Kaoru Seta",
@@ -326,7 +326,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E012.png"
     },
     {
         "name": "\"Captive Princess\" Kanon Matsubara",
@@ -353,7 +353,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E013.png"
     },
     {
         "name": "\"Twin Problems\" Hina Hikawa",
@@ -380,7 +380,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E014.png"
     },
     {
         "name": "\"Invincible Hero\" Kokoro Tsurumaki",
@@ -407,7 +407,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E015.png"
     },
     {
         "name": "\"My First Drums\" Maya Yamato",
@@ -434,7 +434,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E016.png"
     },
     {
         "name": "\"Michelle's Secret\" Misaki Okusawa",
@@ -461,7 +461,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E017.png"
     },
     {
         "name": "\"Onstage\" Misaki Okusawa",
@@ -490,7 +490,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E018.png"
     },
     {
         "name": "\"Cute Detective\" Hagumi Kitazawa",
@@ -516,7 +516,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E019.png"
     },
     {
         "name": "\"Catch Me If You Can\" Kaoru Seta",
@@ -545,7 +545,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E020.png"
     },
     {
         "name": "Michelle Stickers",
@@ -574,7 +574,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E021.png"
     },
     {
         "name": "Thief! Stop!",
@@ -602,7 +602,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E022.png"
     },
     {
         "name": "Orchestra Of Smiles!",
@@ -630,7 +630,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E023.png"
     },
     {
         "name": "Hello, Happy Phantom Thief!",
@@ -659,7 +659,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E024.png"
     },
     {
         "name": "Samurai Help Each Other",
@@ -688,7 +688,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E025.png"
     },
     {
         "name": "\"Evening Memory\" Ran Mitake",
@@ -715,7 +715,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E026.png"
     },
     {
         "name": "\"Accepting Feelings\" Moca Aoba",
@@ -744,7 +744,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E027.png"
     },
     {
         "name": "\"Glasses Off\" Maya Yamato",
@@ -771,7 +771,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E028.png"
     },
     {
         "name": "\"Pajama Patient\" Tomoe Udagawa",
@@ -798,7 +798,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E029.png"
     },
     {
         "name": "\"Swimming Trio\" Himari Uehara",
@@ -825,7 +825,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E030.png"
     },
     {
         "name": "\"Always Starting\" Tsugumi Hazawa",
@@ -852,7 +852,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E031.png"
     },
     {
         "name": "\"Proof I'm Here\" Ran Mitake",
@@ -881,7 +881,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E032.png"
     },
     {
         "name": "\"Sunset Memory\" Moca Aoba",
@@ -908,7 +908,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E033.png"
     },
     {
         "name": "\"Onstage\" Aya Maruyama",
@@ -935,7 +935,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E034.png"
     },
     {
         "name": "\"Onstage\" Tomoe Udagawa",
@@ -962,7 +962,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E035.png"
     },
     {
         "name": "\"Act, Don't Think!\" Tsugumi Hazawa",
@@ -992,7 +992,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E036.png"
     },
     {
         "name": "\"Present For You♪\" Himari Uehara",
@@ -1021,7 +1021,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E037.png"
     },
     {
         "name": "\"No Hesitation\" Ran Mitake",
@@ -1050,7 +1050,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E038.png"
     },
     {
         "name": "\"Onstage\" Ran Mitake",
@@ -1076,7 +1076,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E039.png"
     },
     {
         "name": "\"Onstage\" Tsugumi Hazawa",
@@ -1103,7 +1103,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E040.png"
     },
     {
         "name": "\"Onstage\" Himari Uehara",
@@ -1130,7 +1130,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E041.png"
     },
     {
         "name": "\"Onstage\" Moca Aoba",
@@ -1156,7 +1156,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E042.png"
     },
     {
         "name": "\"Tanabata Clerk\" Aya Maruyama",
@@ -1185,7 +1185,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E043.png"
     },
     {
         "name": "\"Mysterious Charm\" Himari Uehara",
@@ -1212,7 +1212,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E044.png"
     },
     {
         "name": "\"Hard Strike\" Tomoe Udagawa",
@@ -1241,7 +1241,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E045.png"
     },
     {
         "name": "Hard Being Honest",
@@ -1267,7 +1267,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E046.png"
     },
     {
         "name": "Enthusiastic Cry",
@@ -1295,7 +1295,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E047.png"
     },
     {
         "name": "That is How I Roll!",
@@ -1323,7 +1323,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E048.png"
     },
     {
         "name": "Let's Start a Band!",
@@ -1351,7 +1351,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E049.png"
     },
     {
         "name": "Shuwarin☆Dreaming",
@@ -1379,7 +1379,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E050.png"
     },
     {
         "name": "\"The Sister I Adore\" Rimi Ushigome",
@@ -1406,7 +1406,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E051.png"
     },
     {
         "name": "\"Sound Of The Beginning\" Kasumi Toyama",
@@ -1435,7 +1435,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E052.png"
     },
     {
         "name": "\"Absolute Idol Pose☆\" Aya Maruyama",
@@ -1464,7 +1464,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E053.png"
     },
     {
         "name": "\"Secret Pose☆\" Aya Maruyama",
@@ -1490,7 +1490,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E054.png"
     },
     {
         "name": "\"Theme Park Fun!\" Kasumi Toyama",
@@ -1516,7 +1516,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E055.png"
     },
     {
         "name": "\"Place Of Purity\" Chisato Shirasagi",
@@ -1543,7 +1543,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E056.png"
     },
     {
         "name": "\"Bride For A Day\" Saya Yamabuki",
@@ -1572,7 +1572,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E057.png"
     },
     {
         "name": "\"Matching Scrunchies\" Saya Yamabuki",
@@ -1599,7 +1599,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E058.png"
     },
     {
         "name": "\"Onstage\" Rimi Ushigome",
@@ -1628,7 +1628,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E059.png"
     },
     {
         "name": "\"Onstage\" Saya Yamabuki",
@@ -1654,7 +1654,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E060.png"
     },
     {
         "name": "\"Time for Chocolate Cornets\" Rimi Ushigome",
@@ -1682,7 +1682,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E061.png"
     },
     {
         "name": "\"Onstage\" Kasumi Toyama",
@@ -1711,7 +1711,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E062.png"
     },
     {
         "name": "\"Onstage\" Chisato Shirasagi",
@@ -1740,7 +1740,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E063.png"
     },
     {
         "name": "Something in the Warehouse",
@@ -1765,7 +1765,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E064.png"
     },
     {
         "name": "Buns For Luck",
@@ -1790,7 +1790,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E065.png"
     },
     {
         "name": "STAR BEAT!",
@@ -1818,7 +1818,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E066.png"
     },
     {
         "name": "The One I Admire",
@@ -1846,7 +1846,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E067.png"
     },
     {
         "name": "Chocolate Cornet Love",
@@ -1874,7 +1874,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E068.png"
     },
     {
         "name": "\"Pure Enthusiasm\" Rinko Shirokane",
@@ -1901,7 +1901,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E069.png"
     },
     {
         "name": "\"Birdcage Diva\" Yukina Minato",
@@ -1931,7 +1931,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E070.png"
     },
     {
         "name": "\"Shared Happiness\" Tae Hanazono",
@@ -1958,7 +1958,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E071.png"
     },
     {
         "name": "\"Four In The Cafeteria\" Yukina Minato",
@@ -1985,7 +1985,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E072.png"
     },
     {
         "name": "\"Indispensable\" Lisa Imai",
@@ -2012,7 +2012,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E073.png"
     },
     {
         "name": "\"Private Nurse\" Ako Udagawa",
@@ -2041,7 +2041,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E074.png"
     },
     {
         "name": "\"Tanabata Pair\" Sayo Hikawa",
@@ -2071,7 +2071,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E075.png"
     },
     {
         "name": "\"Cute Friends\" Arisa Ichigaya",
@@ -2101,7 +2101,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E076.png"
     },
     {
         "name": "\"Unknown Presence\" Hina Hikawa",
@@ -2131,7 +2131,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E077.png"
     },
     {
         "name": "\"Selected Swimsuit\" Rinko Shirokane",
@@ -2158,7 +2158,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E078.png"
     },
     {
         "name": "\"Reliable Companion\" Arisa Ichigaya",
@@ -2186,7 +2186,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E079.png"
     },
     {
         "name": "\"Prepared Diva\" Yukina Minato",
@@ -2213,7 +2213,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E080.png"
     },
     {
         "name": "\"Good Sound\" Sayo Hikawa",
@@ -2239,7 +2239,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E081.png"
     },
     {
         "name": "\"Perfect Smile\" Chisato Shirasagi",
@@ -2266,7 +2266,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E082.png"
     },
     {
         "name": "\"Silver Fairy\" Eve Wakamiya",
@@ -2292,7 +2292,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E083.png"
     },
     {
         "name": "\"Little Demon\" Ako Udagawa",
@@ -2319,7 +2319,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E084.png"
     },
     {
         "name": "\"Our Song\" Tae Hanazono",
@@ -2346,7 +2346,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E085.png"
     },
     {
         "name": "\"Dazzling Sunshine\" Lisa Imai",
@@ -2373,7 +2373,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E086.png"
     },
     {
         "name": "\"Onstage\" Maya Yamato",
@@ -2403,7 +2403,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E087.png"
     },
     {
         "name": "\"Onstage\" Hina Hikawa",
@@ -2432,7 +2432,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E088.png"
     },
     {
         "name": "\"Connected Pair\" Lisa Imai",
@@ -2459,7 +2459,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E089.png"
     },
     {
         "name": "\"Pajama Party\" Tae Hanazono",
@@ -2486,7 +2486,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E090.png"
     },
     {
         "name": "\"Aimed Journey\" Chisato Shirasagi",
@@ -2513,7 +2513,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E091.png"
     },
     {
         "name": "\"Onstage\" Eve Wakamiya",
@@ -2540,7 +2540,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E092.png"
     },
     {
         "name": "\"Sincere Ambition\" Ako Udagawa",
@@ -2569,7 +2569,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E093.png"
     },
     {
         "name": "\"Onstage\" Arisa Ichigaya",
@@ -2598,7 +2598,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E094.png"
     },
     {
         "name": "\"What Should I...?\" Rinko Shirokane",
@@ -2627,7 +2627,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E095.png"
     },
     {
         "name": "\"Onstage\" Tae Hanazono",
@@ -2657,7 +2657,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E096.png"
     },
     {
         "name": "\"Twin Problems\" Sayo Hikawa",
@@ -2686,7 +2686,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E097.png"
     },
     {
         "name": "Intense Shout",
@@ -2715,7 +2715,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E098.png"
     },
     {
         "name": "Always With You",
@@ -2743,7 +2743,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E099.png"
     },
     {
         "name": "Under The Blossoming Sakura",
@@ -2772,7 +2772,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E100.png"
     },
     {
         "name": "\"Chibi Character\" Kokoro Tsurumaki",
@@ -2801,7 +2801,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E101.png"
     },
     {
         "name": "\"Chibi Character\" Ran Mitake",
@@ -2827,7 +2827,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E102.png"
     },
     {
         "name": "\"Chibi Character\" Kasumi Toyama",
@@ -2856,7 +2856,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E103.png"
     },
     {
         "name": "\"Chibi Character\" Aya Maruyama",
@@ -2882,7 +2882,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E104.png"
     },
     {
         "name": "\"Chibi Character\" Yukina Minato",
@@ -2908,7 +2908,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E105.png"
     },
     {
         "name": "Twinkle Twinkle Little Star",
@@ -2936,7 +2936,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E106.png"
     },
     {
         "name": "Aspired Stage",
@@ -2964,7 +2964,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E107.png"
     },
     {
         "name": "Exchanged Promise",
@@ -2992,7 +2992,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E108.png"
     },
     {
         "name": "Moved With Everyone",
@@ -3021,7 +3021,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E109.png"
     },
     {
         "name": "Heart Pounding Star",
@@ -3050,7 +3050,7 @@
         "set": "BD",
         "release": "54",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_E110.png"
     },
     {
         "name": "\"Sparkling Chords\" Kasumi Toyama",
@@ -3078,7 +3078,7 @@
         "set": "BD",
         "release": "54",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_PE01.png"
     },
     {
         "name": "\"First Fan\" Kasumi Toyama",
@@ -3104,7 +3104,7 @@
         "set": "BD",
         "release": "54",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_PE02.png"
     },
     {
         "name": "\"Hidden Feelings\" Minato Yukina",
@@ -3131,7 +3131,7 @@
         "set": "BD",
         "release": "54",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_PE03.png"
     },
     {
         "name": "\"Ritardando\" Arisa Ichigaya",
@@ -3159,7 +3159,7 @@
         "set": "BD",
         "release": "54",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-PE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_PE04.png"
     },
     {
         "name": "\"Twenty Rabbits\" Tae Hanazono",
@@ -3212,7 +3212,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE01.png"
     },
     {
         "name": "\"Firm Resolution\" Sayo Hikawa",
@@ -3239,7 +3239,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE02.png"
     },
     {
         "name": "\"Angel's Smile\" Ako Udagawa",
@@ -3266,7 +3266,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE03.png"
     },
     {
         "name": "\"I Don't Like Crowds\" Rinko Shirokane",
@@ -3292,7 +3292,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE04.png"
     },
     {
         "name": "\"Onstage\" Rinko Shirokane",
@@ -3318,7 +3318,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE05.png"
     },
     {
         "name": "\"Mood Maker☆\" Lisa Imai",
@@ -3344,7 +3344,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE06.png"
     },
     {
         "name": "\"Onstage\" Ako Udagawa",
@@ -3370,7 +3370,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE07.png"
     },
     {
         "name": "\"Crystal Song\" Yukina Minato",
@@ -3396,7 +3396,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE08.png"
     },
     {
         "name": "\"Onstage\" Sayo Hikawa",
@@ -3422,7 +3422,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE09.png"
     },
     {
         "name": "\"Onstage\" Lisa Imai",
@@ -3448,7 +3448,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE10.png"
     },
     {
         "name": "\"The Coolest Drummer!\" Ako Udagawa",
@@ -3476,7 +3476,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE11.png"
     },
     {
         "name": "\"All That I Hear\" Rinko Shirokane",
@@ -3505,7 +3505,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE12.png"
     },
     {
         "name": "\"Hard Worker\" Sayo Hikawa",
@@ -3534,7 +3534,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE13.png"
     },
     {
         "name": "\"Onstage\" Yukina Minato",
@@ -3563,7 +3563,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE14.png"
     },
     {
         "name": "\"Trace of Effort\" Lisa Imai",
@@ -3592,7 +3592,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE15.png"
     },
     {
         "name": "Phone-Shy",
@@ -3621,7 +3621,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE16.png"
     },
     {
         "name": "Zeit",
@@ -3649,7 +3649,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE17.png"
     },
     {
         "name": "1st Live Show Pre-Party",
@@ -3678,7 +3678,7 @@
         "set": "BD",
         "release": "54",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE18.png"
     },
     {
         "name": "What a Fun Song!",
@@ -3706,6 +3706,6 @@
         "set": "BD",
         "release": "54",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W54-TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w54/BD_W54_TE19.png"
     }
 ]

--- a/DB/BDG_W63.json
+++ b/DB/BDG_W63.json
@@ -24,7 +24,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E001.png"
     },
     {
         "name": "\"On the Path to Dreams\" Chisato Shirasagi",
@@ -55,7 +55,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E002.png"
     },
     {
         "name": "\"This Is Where I Belong\" Misaki Okusawa",
@@ -84,7 +84,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E003.png"
     },
     {
         "name": "\"For the Smiles!\" Hagumi Kitazawa",
@@ -111,7 +111,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E004.png"
     },
     {
         "name": "\"With Everyone's Help\" Kanon Matsubara",
@@ -139,7 +139,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E005.png"
     },
     {
         "name": "\"I Am Me\" Kaoru Seta",
@@ -168,7 +168,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E006.png"
     },
     {
         "name": "\"What an Idol Is\" Maya Yamato",
@@ -197,7 +197,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E007.png"
     },
     {
         "name": "\"Happy Adventure\" Kokoro Tsurumaki",
@@ -226,7 +226,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E008.png"
     },
     {
         "name": "\"I'm a Human, You Know.\" Hagumi Kitazawa",
@@ -253,7 +253,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E009.png"
     },
     {
         "name": "\"Heave, Ho? Heave, Ho!\" Aya Maruyama",
@@ -279,7 +279,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E010.png"
     },
     {
         "name": "\"Can You Comprehend?\" Kaoru Seta",
@@ -305,7 +305,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E011.png"
     },
     {
         "name": "\"To Become More Admired\" Eve Wakamiya",
@@ -332,7 +332,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E012.png"
     },
     {
         "name": "\"Getting Dizzy...\" Kanon Matsubara",
@@ -362,7 +362,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E013.png"
     },
     {
         "name": "\"Keep Running Until the End\" Misaki Okusawa",
@@ -391,7 +391,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E014.png"
     },
     {
         "name": "\"Rendezvous of Smiles\" Kokoro Tsurumaki",
@@ -418,7 +418,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E015.png"
     },
     {
         "name": "\"Tea Ceremony Excellence\" Kanon Matsubara",
@@ -445,7 +445,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E016.png"
     },
     {
         "name": "\"A Penguin? A Bear?\" Misaki Okusawa",
@@ -471,7 +471,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E017.png"
     },
     {
         "name": "\"Rules of Being an Idol\" Chisato Shirasagi",
@@ -498,7 +498,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E018.png"
     },
     {
         "name": "\"Grand Adventure!\" Hagumi Kitazawa",
@@ -525,7 +525,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E019.png"
     },
     {
         "name": "\"Fragrance of a Caffe Latte\" Kaoru Seta",
@@ -551,7 +551,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E020.png"
     },
     {
         "name": "\"I Love Fluffy Mascots!\" Kokoro Tsurumaki",
@@ -580,7 +580,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E021.png"
     },
     {
         "name": "Message from Michelle",
@@ -607,7 +607,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E022.png"
     },
     {
         "name": "Moment in the Sun",
@@ -634,7 +634,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E023.png"
     },
     {
         "name": "An Idol that Inspires",
@@ -664,7 +664,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E024.png"
     },
     {
         "name": "Glistening Sun",
@@ -694,7 +694,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E025.png"
     },
     {
         "name": "A Forced Dance",
@@ -724,7 +724,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E026.png"
     },
     {
         "name": "\"Frozen in Time\" Himari Uehara",
@@ -752,7 +752,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E027.png"
     },
     {
         "name": "\"Don't Stop, Keep Going\" Ran Mitake",
@@ -782,7 +782,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E028.png"
     },
     {
         "name": "\"Our Sunset\" Tomoe Udagawa",
@@ -810,7 +810,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E029.png"
     },
     {
         "name": "\"By Your Side\" Moca Aoba",
@@ -840,7 +840,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E030.png"
     },
     {
         "name": "\"Noticing Change\" Tsugumi Hazawa",
@@ -870,7 +870,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E031.png"
     },
     {
         "name": "\"Moderation is Key!\" Tsugumi Hazawa",
@@ -897,7 +897,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E032.png"
     },
     {
         "name": "\"Sign of Youth\" Tomoe Udagawa",
@@ -924,7 +924,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E033.png"
     },
     {
         "name": "\"I'll Hold Them Off!\" Moca Aoba",
@@ -951,7 +951,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E034.png"
     },
     {
         "name": "\"It's So Hot...\" Ran Mitake",
@@ -977,7 +977,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E035.png"
     },
     {
         "name": "\"We're Here!\" Himari Uehara",
@@ -1006,7 +1006,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E036.png"
     },
     {
         "name": "\"The Modest Idol\" Maya Yamato",
@@ -1033,7 +1033,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E037.png"
     },
     {
         "name": "\"Always Being Ourselves\" Ran Mitake",
@@ -1060,7 +1060,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E038.png"
     },
     {
         "name": "\"My Own Kind of Good\" Himari Uehara",
@@ -1087,7 +1087,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E039.png"
     },
     {
         "name": "\"Longtime Childhood Friend\" Tomoe Udagawa",
@@ -1113,7 +1113,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E040.png"
     },
     {
         "name": "\"A Little Bit of Growth?\" Moca Aoba",
@@ -1140,7 +1140,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E041.png"
     },
     {
         "name": "\"Forgetting Something Important\" Tsugumi Hazawa",
@@ -1166,7 +1166,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E042.png"
     },
     {
         "name": "\"Poppin' & Happy\" Ran Mitake",
@@ -1195,7 +1195,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E043.png"
     },
     {
         "name": "An Eternal Sunset",
@@ -1221,7 +1221,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E044.png"
     },
     {
         "name": "The Dessert Instructor",
@@ -1248,7 +1248,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E045.png"
     },
     {
         "name": "A Leader's Proposal",
@@ -1277,7 +1277,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E046.png"
     },
     {
         "name": "Ever-Changing Sky",
@@ -1306,7 +1306,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E047.png"
     },
     {
         "name": "A Quick Detour",
@@ -1335,7 +1335,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E048.png"
     },
     {
         "name": "\"The Fruits of Labor\" Aya Maruyama",
@@ -1362,7 +1362,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E049.png"
     },
     {
         "name": "\"Star-Shaped Tambourine\" Kasumi Toyama",
@@ -1390,7 +1390,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E050.png"
     },
     {
         "name": "\"A Sparkly Smile\" Saya Yamabuki",
@@ -1420,7 +1420,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E051.png"
     },
     {
         "name": "\"Day Off with Chocolate\" Rimi Ushigome",
@@ -1447,7 +1447,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E052.png"
     },
     {
         "name": "\"Hina's Request\" Hina Hikawa",
@@ -1477,7 +1477,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E053.png"
     },
     {
         "name": "\"Enthusiastic Huddle\" Kasumi Toyama",
@@ -1507,7 +1507,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E054.png"
     },
     {
         "name": "\"Aya Maruyama, The Idol!\" Aya Maruyama",
@@ -1537,7 +1537,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E055.png"
     },
     {
         "name": "\"CiRCLE Storage Expedition\" Saya Yamabuki",
@@ -1564,7 +1564,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E056.png"
     },
     {
         "name": "\"Self-Taught Survival\" Maya Yamato",
@@ -1591,7 +1591,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E057.png"
     },
     {
         "name": "\"I'm Me\" Hina Hikawa",
@@ -1617,7 +1617,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E058.png"
     },
     {
         "name": "\"In a Place as Big as This...?!\" Rimi Ushigome",
@@ -1644,7 +1644,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E059.png"
     },
     {
         "name": "\"Important Moment\" Saya Yamabuki",
@@ -1671,7 +1671,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E060.png"
     },
     {
         "name": "\"Important Opportunity\" Hina Hikawa",
@@ -1698,7 +1698,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E061.png"
     },
     {
         "name": "\"Call for Courage\" Rimi Ushigome",
@@ -1725,7 +1725,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E062.png"
     },
     {
         "name": "\"Origami Fun\" Kasumi Toyama",
@@ -1751,7 +1751,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E063.png"
     },
     {
         "name": "\"Like That!\" Kasumi Toyama",
@@ -1779,7 +1779,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E064.png"
     },
     {
         "name": "\"First Time Latte Art\" Aya Maruyama",
@@ -1807,7 +1807,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E065.png"
     },
     {
         "name": "Our Beginnings",
@@ -1834,7 +1834,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E066.png"
     },
     {
         "name": "My Bushido!",
@@ -1860,7 +1860,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E067.png"
     },
     {
         "name": "A Sparkly Smile",
@@ -1890,7 +1890,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E068.png"
     },
     {
         "name": "Let's Sing𝅘𝅥𝅮",
@@ -1919,7 +1919,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E069.png"
     },
     {
         "name": "Serious Survivor",
@@ -1948,7 +1948,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E070.png"
     },
     {
         "name": "The One and Only Me",
@@ -1977,7 +1977,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E071.png"
     },
     {
         "name": "\"Searching for Answers\" Yukina Minato",
@@ -2004,7 +2004,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E072.png"
     },
     {
         "name": "\"Making Cookies Once More\" Lisa Imai",
@@ -2034,7 +2034,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E073.png"
     },
     {
         "name": "\"Secret Spot\" Arisa Ichigaya",
@@ -2060,7 +2060,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E074.png"
     },
     {
         "name": "\"Teatime with the Band\" Ako Udagawa",
@@ -2087,7 +2087,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E075.png"
     },
     {
         "name": "\"I'll Stay Up This Time\" Chisato Shirasagi",
@@ -2114,7 +2114,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E076.png"
     },
     {
         "name": "\"Sharing Something with You\" Eve Wakamiya",
@@ -2140,7 +2140,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E077.png"
     },
     {
         "name": "\"This Time, I Will\" Sayo Hikawa",
@@ -2166,7 +2166,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E078.png"
     },
     {
         "name": "\"Seeing Rabbits\" Tae Hanazono",
@@ -2192,7 +2192,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E079.png"
     },
     {
         "name": "\"Tears Overflowing\" Yukina Minato",
@@ -2222,7 +2222,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E080.png"
     },
     {
         "name": "\"Determined Cries\" Rinko Shirokane",
@@ -2252,7 +2252,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E081.png"
     },
     {
         "name": "\"A Real Challenge\" Lisa Imai",
@@ -2279,7 +2279,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E082.png"
     },
     {
         "name": "\"... H-Hello...?\" Rinko Shirokane",
@@ -2306,7 +2306,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E083.png"
     },
     {
         "name": "\"Ugh, Seriously...?\" Arisa Ichigaya",
@@ -2333,7 +2333,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E084.png"
     },
     {
         "name": "\"The Coolest in the World!\" Ako Udagawa",
@@ -2360,7 +2360,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E085.png"
     },
     {
         "name": "\"No Way Except Forward\" Tae Hanazono",
@@ -2389,7 +2389,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E086.png"
     },
     {
         "name": "\"Dense Cookies\" Sayo Hikawa",
@@ -2419,7 +2419,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E087.png"
     },
     {
         "name": "\"Serious Mind\" Eve Wakamiya",
@@ -2446,7 +2446,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E088.png"
     },
     {
         "name": "\"My First Pair of Cat Ears\" Yukina Minato",
@@ -2473,7 +2473,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E089.png"
     },
     {
         "name": "\"Bunny Strategy\" Tae Hanazono",
@@ -2499,7 +2499,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E090.png"
     },
     {
         "name": "\"Ice Cream In Summer\" Sayo Hikawa",
@@ -2526,7 +2526,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E091.png"
     },
     {
         "name": "\"Protective Gaze\" Yukina Minato",
@@ -2553,7 +2553,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E092.png"
     },
     {
         "name": "\"Quietly Worrying\" Rinko Shirokane",
@@ -2582,7 +2582,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E093.png"
     },
     {
         "name": "\"Arisa In Wonderland\" Arisa Ichigaya",
@@ -2611,7 +2611,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E094.png"
     },
     {
         "name": "\"A Crucial Member\" Lisa Imai",
@@ -2639,7 +2639,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E095.png"
     },
     {
         "name": "\"Relaxing With Friends\" Ako Udagawa",
@@ -2668,7 +2668,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E096.png"
     },
     {
         "name": "Teardrops and Rainfall",
@@ -2696,7 +2696,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E097.png"
     },
     {
         "name": "Lisa-like Lyrics",
@@ -2723,7 +2723,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E098.png"
     },
     {
         "name": "Temporary Club Member",
@@ -2753,7 +2753,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E099.png"
     },
     {
         "name": "Making Cookies",
@@ -2782,7 +2782,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E100.png"
     },
     {
         "name": "\"Sakura Special!\" Kokoro Tsurumaki",
@@ -2808,7 +2808,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E101.png"
     },
     {
         "name": "\"Maruyama is Here!\" Aya Maruyama",
@@ -2834,7 +2834,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E102.png"
     },
     {
         "name": "\"Octopus Towel\" Ran Mitake",
@@ -2861,7 +2861,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E103.png"
     },
     {
         "name": "\"Look! Cherry Blossoms!\" Kasumi Toyama",
@@ -2888,7 +2888,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E104.png"
     },
     {
         "name": "\"Beyond Clear Autumn Skies\" Yukina Minato",
@@ -2917,7 +2917,7 @@
         "set": "BD",
         "release": "63",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_E105.png"
     },
     {
         "name": "\"Kasumi-chan & Haa-chan\" Kasumi Toyama",
@@ -2944,6 +2944,6 @@
         "set": "BD",
         "release": "63",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W63_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w63/BD_W63_PE01.png"
     }
 ]

--- a/DB/BDML_W03.json
+++ b/DB/BDML_W03.json
@@ -24,7 +24,7 @@
         "set": "BD",
         "release": "03",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-001.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_001.png",
         "price": "5.00"
     },
     {
@@ -54,7 +54,7 @@
         "set": "BD",
         "release": "03",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-002.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_002.png",
         "price": "4.00"
     },
     {
@@ -82,7 +82,7 @@
         "set": "BD",
         "release": "03",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-003.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_003.png",
         "price": "1.00"
     },
     {
@@ -110,7 +110,7 @@
         "set": "BD",
         "release": "03",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-004.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_004.png",
         "price": "1.00"
     },
     {
@@ -138,7 +138,7 @@
         "set": "BD",
         "release": "03",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-005.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_005.png",
         "price": "1.50"
     },
     {
@@ -165,7 +165,7 @@
         "set": "BD",
         "release": "03",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-006.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_006.png",
         "price": "1.00"
     },
     {
@@ -195,7 +195,7 @@
         "set": "BD",
         "release": "03",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-007.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_007.png",
         "price": "3.00"
     },
     {
@@ -225,7 +225,7 @@
         "set": "BD",
         "release": "03",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-008.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_008.png",
         "price": "1.00"
     },
     {
@@ -253,7 +253,7 @@
         "set": "BD",
         "release": "03",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-009.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_009.png",
         "price": "0.50"
     },
     {
@@ -280,7 +280,7 @@
         "set": "BD",
         "release": "03",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-010.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_010.png",
         "price": "0.50"
     },
     {
@@ -308,7 +308,7 @@
         "set": "BD",
         "release": "03",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-011.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_011.png",
         "price": "2.00"
     },
     {
@@ -335,7 +335,7 @@
         "set": "BD",
         "release": "03",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-012.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_012.png",
         "price": "0.50"
     },
     {
@@ -366,7 +366,7 @@
         "set": "BD",
         "release": "03",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-013.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_013.png",
         "price": "0.50"
     },
     {
@@ -394,7 +394,7 @@
         "set": "BD",
         "release": "03",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-014.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_014.png",
         "price": "0.25"
     },
     {
@@ -421,7 +421,7 @@
         "set": "BD",
         "release": "03",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-015.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_015.png",
         "price": "0.25"
     },
     {
@@ -448,7 +448,7 @@
         "set": "BD",
         "release": "03",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-016.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_016.png",
         "price": "0.25"
     },
     {
@@ -475,7 +475,7 @@
         "set": "BD",
         "release": "03",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-017.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_017.png",
         "price": "0.25"
     },
     {
@@ -502,7 +502,7 @@
         "set": "BD",
         "release": "03",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-018.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_018.png",
         "price": "0.25"
     },
     {
@@ -532,7 +532,7 @@
         "set": "BD",
         "release": "03",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-019.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_019.png",
         "price": "0.25"
     },
     {
@@ -562,7 +562,7 @@
         "set": "BD",
         "release": "03",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-020.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_020.png",
         "price": "0.25"
     },
     {
@@ -591,7 +591,7 @@
         "set": "BD",
         "release": "03",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-021.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_021.png",
         "price": "0.25"
     },
     {
@@ -620,7 +620,7 @@
         "set": "BD",
         "release": "03",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-022.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_022.png",
         "price": "0.50"
     },
     {
@@ -651,7 +651,7 @@
         "set": "BD",
         "release": "03",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-023.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_023.png",
         "price": "1.00"
     },
     {
@@ -681,7 +681,7 @@
         "set": "BD",
         "release": "03",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-024.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_024.png",
         "price": "0.50"
     },
     {
@@ -712,7 +712,7 @@
         "set": "BD",
         "release": "03",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-025.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_025.png",
         "price": "0.50"
     },
     {
@@ -743,7 +743,7 @@
         "set": "BD",
         "release": "03",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-026.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_026.png",
         "price": "1.00"
     },
     {
@@ -771,7 +771,7 @@
         "set": "BD",
         "release": "03",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-027.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_027.png",
         "price": "15.00"
     },
     {
@@ -799,7 +799,7 @@
         "set": "BD",
         "release": "03",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-028.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_028.png",
         "price": "4.00"
     },
     {
@@ -827,7 +827,7 @@
         "set": "BD",
         "release": "03",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-029.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_029.png",
         "price": "5.00"
     },
     {
@@ -857,7 +857,7 @@
         "set": "BD",
         "release": "03",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-030.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_030.png",
         "price": "3.00"
     },
     {
@@ -885,7 +885,7 @@
         "set": "BD",
         "release": "03",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-031.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_031.png",
         "price": "1.00"
     },
     {
@@ -913,7 +913,7 @@
         "set": "BD",
         "release": "03",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-032.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_032.png",
         "price": "1.00"
     },
     {
@@ -941,7 +941,7 @@
         "set": "BD",
         "release": "03",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-033.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_033.png",
         "price": "3.00"
     },
     {
@@ -969,7 +969,7 @@
         "set": "BD",
         "release": "03",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-034.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_034.png",
         "price": "1.00"
     },
     {
@@ -1000,7 +1000,7 @@
         "set": "BD",
         "release": "03",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-035.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_035.png",
         "price": "3.00"
     },
     {
@@ -1030,7 +1030,7 @@
         "set": "BD",
         "release": "03",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-036.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_036.png",
         "price": "1.00"
     },
     {
@@ -1060,7 +1060,7 @@
         "set": "BD",
         "release": "03",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-037.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_037.png",
         "price": "1.00"
     },
     {
@@ -1088,7 +1088,7 @@
         "set": "BD",
         "release": "03",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-038.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_038.png",
         "price": "0.50"
     },
     {
@@ -1116,7 +1116,7 @@
         "set": "BD",
         "release": "03",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-039.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_039.png",
         "price": "0.50"
     },
     {
@@ -1144,7 +1144,7 @@
         "set": "BD",
         "release": "03",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-040.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_040.png",
         "price": "0.50"
     },
     {
@@ -1171,7 +1171,7 @@
         "set": "BD",
         "release": "03",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-041.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_041.png",
         "price": "0.50"
     },
     {
@@ -1199,7 +1199,7 @@
         "set": "BD",
         "release": "03",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-042.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_042.png",
         "price": "0.50"
     },
     {
@@ -1226,7 +1226,7 @@
         "set": "BD",
         "release": "03",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-043.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_043.png",
         "price": "1.00"
     },
     {
@@ -1256,7 +1256,7 @@
         "set": "BD",
         "release": "03",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-044.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_044.png",
         "price": "0.50"
     },
     {
@@ -1286,7 +1286,7 @@
         "set": "BD",
         "release": "03",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-045.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_045.png",
         "price": "0.50"
     },
     {
@@ -1316,7 +1316,7 @@
         "set": "BD",
         "release": "03",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-046.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_046.png",
         "price": "0.50"
     },
     {
@@ -1343,7 +1343,7 @@
         "set": "BD",
         "release": "03",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-047.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_047.png",
         "price": "0.25"
     },
     {
@@ -1370,7 +1370,7 @@
         "set": "BD",
         "release": "03",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-048.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_048.png",
         "price": "0.25"
     },
     {
@@ -1397,7 +1397,7 @@
         "set": "BD",
         "release": "03",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-049.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_049.png",
         "price": "0.25"
     },
     {
@@ -1424,7 +1424,7 @@
         "set": "BD",
         "release": "03",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-050.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_050.png",
         "price": "0.25"
     },
     {
@@ -1451,7 +1451,7 @@
         "set": "BD",
         "release": "03",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-051.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_051.png",
         "price": "0.25"
     },
     {
@@ -1479,7 +1479,7 @@
         "set": "BD",
         "release": "03",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-052.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_052.png",
         "price": "0.25"
     },
     {
@@ -1508,7 +1508,7 @@
         "set": "BD",
         "release": "03",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-053.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_053.png",
         "price": "0.25"
     },
     {
@@ -1538,7 +1538,7 @@
         "set": "BD",
         "release": "03",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-054.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_054.png",
         "price": "0.25"
     },
     {
@@ -1566,7 +1566,7 @@
         "set": "BD",
         "release": "03",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-055.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_055.png",
         "price": "0.50"
     },
     {
@@ -1593,7 +1593,7 @@
         "set": "BD",
         "release": "03",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-056.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_056.png",
         "price": "0.50"
     },
     {
@@ -1623,7 +1623,7 @@
         "set": "BD",
         "release": "03",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-057.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_057.png",
         "price": "1.00"
     },
     {
@@ -1653,7 +1653,7 @@
         "set": "BD",
         "release": "03",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-058.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_058.png",
         "price": "1.00"
     },
     {
@@ -1683,7 +1683,7 @@
         "set": "BD",
         "release": "03",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-059.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_059.png",
         "price": "0.50"
     },
     {
@@ -1713,7 +1713,7 @@
         "set": "BD",
         "release": "03",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-060.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_060.png",
         "price": "0.50"
     },
     {
@@ -1743,7 +1743,7 @@
         "set": "BD",
         "release": "03",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-061.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_061.png",
         "price": "0.50"
     },
     {
@@ -1773,7 +1773,7 @@
         "set": "BD",
         "release": "03",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-062.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_062.png",
         "price": "1.00"
     },
     {
@@ -1801,7 +1801,7 @@
         "set": "BD",
         "release": "03",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-063.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_063.png",
         "price": "15.00"
     },
     {
@@ -1831,7 +1831,7 @@
         "set": "BD",
         "release": "03",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-064.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_064.png",
         "price": "3.00"
     },
     {
@@ -1859,7 +1859,7 @@
         "set": "BD",
         "release": "03",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-065.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_065.png",
         "price": "1.00"
     },
     {
@@ -1887,7 +1887,7 @@
         "set": "BD",
         "release": "03",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-066.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_066.png",
         "price": "1.00"
     },
     {
@@ -1918,7 +1918,7 @@
         "set": "BD",
         "release": "03",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-067.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_067.png",
         "price": "1.00"
     },
     {
@@ -1948,7 +1948,7 @@
         "set": "BD",
         "release": "03",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-068.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_068.png",
         "price": "1.00"
     },
     {
@@ -1978,7 +1978,7 @@
         "set": "BD",
         "release": "03",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-069.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_069.png",
         "price": "3.00"
     },
     {
@@ -2005,7 +2005,7 @@
         "set": "BD",
         "release": "03",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-070.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_070.png",
         "price": "0.50"
     },
     {
@@ -2035,7 +2035,7 @@
         "set": "BD",
         "release": "03",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-071.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_071.png",
         "price": "0.50"
     },
     {
@@ -2065,7 +2065,7 @@
         "set": "BD",
         "release": "03",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-072.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_072.png",
         "price": "0.50"
     },
     {
@@ -2094,7 +2094,7 @@
         "set": "BD",
         "release": "03",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-073.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_073.png",
         "price": "0.50"
     },
     {
@@ -2124,7 +2124,7 @@
         "set": "BD",
         "release": "03",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-074.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_074.png",
         "price": "0.50"
     },
     {
@@ -2155,7 +2155,7 @@
         "set": "BD",
         "release": "03",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-075.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_075.png",
         "price": "0.50"
     },
     {
@@ -2183,7 +2183,7 @@
         "set": "BD",
         "release": "03",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-076.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_076.png",
         "price": "0.25"
     },
     {
@@ -2211,7 +2211,7 @@
         "set": "BD",
         "release": "03",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-077.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_077.png",
         "price": "0.25"
     },
     {
@@ -2238,7 +2238,7 @@
         "set": "BD",
         "release": "03",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-078.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_078.png",
         "price": "0.25"
     },
     {
@@ -2266,7 +2266,7 @@
         "set": "BD",
         "release": "03",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-079.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_079.png",
         "price": "0.25"
     },
     {
@@ -2293,7 +2293,7 @@
         "set": "BD",
         "release": "03",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-080.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_080.png",
         "price": "0.25"
     },
     {
@@ -2320,7 +2320,7 @@
         "set": "BD",
         "release": "03",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-081.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_081.png",
         "price": "0.25"
     },
     {
@@ -2347,7 +2347,7 @@
         "set": "BD",
         "release": "03",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-082.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_082.png",
         "price": "0.25"
     },
     {
@@ -2375,7 +2375,7 @@
         "set": "BD",
         "release": "03",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-083.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_083.png",
         "price": "0.25"
     },
     {
@@ -2404,7 +2404,7 @@
         "set": "BD",
         "release": "03",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-084.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_084.png",
         "price": "0.25"
     },
     {
@@ -2434,7 +2434,7 @@
         "set": "BD",
         "release": "03",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-085.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_085.png",
         "price": "0.25"
     },
     {
@@ -2463,7 +2463,7 @@
         "set": "BD",
         "release": "03",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-086.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_086.png",
         "price": "1.00"
     },
     {
@@ -2493,7 +2493,7 @@
         "set": "BD",
         "release": "03",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-087.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_087.png",
         "price": "0.50"
     },
     {
@@ -2522,7 +2522,7 @@
         "set": "BD",
         "release": "03",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-088.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_088.png",
         "price": "0.50"
     },
     {
@@ -2553,7 +2553,7 @@
         "set": "BD",
         "release": "03",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-089.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_089.png",
         "price": "1.00"
     },
     {
@@ -2581,7 +2581,7 @@
         "set": "BD",
         "release": "03",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-090.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_090.png",
         "price": "3.00"
     },
     {
@@ -2608,7 +2608,7 @@
         "set": "BD",
         "release": "03",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-091.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_091.png",
         "price": "3.00"
     },
     {
@@ -2636,7 +2636,7 @@
         "set": "BD",
         "release": "03",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-092.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_092.png",
         "price": "1.00"
     },
     {
@@ -2664,7 +2664,7 @@
         "set": "BD",
         "release": "03",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-093.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_093.png",
         "price": "3.00"
     },
     {
@@ -2691,7 +2691,7 @@
         "set": "BD",
         "release": "03",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-094.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_094.png",
         "price": "3.00"
     },
     {
@@ -2721,7 +2721,7 @@
         "set": "BD",
         "release": "03",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-095.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_095.png",
         "price": "1.00"
     },
     {
@@ -2752,7 +2752,7 @@
         "set": "BD",
         "release": "03",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-096.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_096.png",
         "price": "1.00"
     },
     {
@@ -2782,7 +2782,7 @@
         "set": "BD",
         "release": "03",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-097.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_097.png",
         "price": "0.50"
     },
     {
@@ -2812,7 +2812,7 @@
         "set": "BD",
         "release": "03",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-098.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_098.png",
         "price": "0.50"
     },
     {
@@ -2842,7 +2842,7 @@
         "set": "BD",
         "release": "03",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-099.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_099.png",
         "price": "2.00"
     },
     {
@@ -2870,7 +2870,7 @@
         "set": "BD",
         "release": "03",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-100.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_100.png",
         "price": "0.50"
     },
     {
@@ -2897,7 +2897,7 @@
         "set": "BD",
         "release": "03",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-101.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_101.png",
         "price": "0.50"
     },
     {
@@ -2925,7 +2925,7 @@
         "set": "BD",
         "release": "03",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-102.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_102.png",
         "price": "0.50"
     },
     {
@@ -2953,7 +2953,7 @@
         "set": "BD",
         "release": "03",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-103.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_103.png",
         "price": "0.50"
     },
     {
@@ -2980,7 +2980,7 @@
         "set": "BD",
         "release": "03",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-104.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_104.png",
         "price": "0.50"
     },
     {
@@ -3008,7 +3008,7 @@
         "set": "BD",
         "release": "03",
         "sid": "105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-105.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_105.png",
         "price": "0.50"
     },
     {
@@ -3038,7 +3038,7 @@
         "set": "BD",
         "release": "03",
         "sid": "106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-106.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_106.png",
         "price": "0.50"
     },
     {
@@ -3068,7 +3068,7 @@
         "set": "BD",
         "release": "03",
         "sid": "107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-107.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_107.png",
         "price": "0.50"
     },
     {
@@ -3098,7 +3098,7 @@
         "set": "BD",
         "release": "03",
         "sid": "108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-108.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_108.png",
         "price": "0.50"
     },
     {
@@ -3126,7 +3126,7 @@
         "set": "BD",
         "release": "03",
         "sid": "109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-109.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_109.png",
         "price": "0.25"
     },
     {
@@ -3154,7 +3154,7 @@
         "set": "BD",
         "release": "03",
         "sid": "110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-110.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_110.png",
         "price": "0.25"
     },
     {
@@ -3182,7 +3182,7 @@
         "set": "BD",
         "release": "03",
         "sid": "111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-111.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_111.png",
         "price": "0.25"
     },
     {
@@ -3209,7 +3209,7 @@
         "set": "BD",
         "release": "03",
         "sid": "112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-112.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_112.png",
         "price": "0.25"
     },
     {
@@ -3236,7 +3236,7 @@
         "set": "BD",
         "release": "03",
         "sid": "113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-113.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_113.png",
         "price": "0.25"
     },
     {
@@ -3263,7 +3263,7 @@
         "set": "BD",
         "release": "03",
         "sid": "114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-114.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_114.png",
         "price": "0.25"
     },
     {
@@ -3290,7 +3290,7 @@
         "set": "BD",
         "release": "03",
         "sid": "115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-115.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_115.png",
         "price": "0.25"
     },
     {
@@ -3317,7 +3317,7 @@
         "set": "BD",
         "release": "03",
         "sid": "116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-116.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_116.png",
         "price": "0.25"
     },
     {
@@ -3344,7 +3344,7 @@
         "set": "BD",
         "release": "03",
         "sid": "117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-117.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_117.png",
         "price": "0.25"
     },
     {
@@ -3373,7 +3373,7 @@
         "set": "BD",
         "release": "03",
         "sid": "118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-118.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_118.png",
         "price": "0.25"
     },
     {
@@ -3399,7 +3399,7 @@
         "set": "BD",
         "release": "03",
         "sid": "119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-119.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_119.png",
         "price": "0.50"
     },
     {
@@ -3429,7 +3429,7 @@
         "set": "BD",
         "release": "03",
         "sid": "120",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-120.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_120.png",
         "price": "0.50"
     },
     {
@@ -3458,7 +3458,7 @@
         "set": "BD",
         "release": "03",
         "sid": "121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-121.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_121.png",
         "price": "1.00"
     },
     {
@@ -3488,7 +3488,7 @@
         "set": "BD",
         "release": "03",
         "sid": "122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-122.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_122.png",
         "price": "0.50"
     },
     {
@@ -3517,7 +3517,7 @@
         "set": "BD",
         "release": "03",
         "sid": "123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-123.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_123.png",
         "price": "0.50"
     },
     {
@@ -3547,7 +3547,7 @@
         "set": "BD",
         "release": "03",
         "sid": "124",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-124.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_124.png",
         "price": "0.50"
     },
     {
@@ -3578,7 +3578,7 @@
         "set": "BD",
         "release": "03",
         "sid": "125",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-125.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_125.png",
         "price": "0.50"
     },
     {
@@ -3608,7 +3608,7 @@
         "set": "BD",
         "release": "03",
         "sid": "126",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-EN-W03-126.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_en_w03/BD_EN_W03_126.png",
         "price": "0.50"
     }
 ]

--- a/DB/BD_W47.json
+++ b/DB/BD_W47.json
@@ -24,7 +24,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E001.png"
     },
     {
         "name": "Glitter*Green, Hinako Nijikki",
@@ -54,7 +54,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E002.png"
     },
     {
         "name": "Glitter*Green, Rii Uzawa",
@@ -84,7 +84,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E003.png"
     },
     {
         "name": "Glitter*Green, Yuri Ushigome",
@@ -113,7 +113,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E004.png"
     },
     {
         "name": "Hinako Nijikki",
@@ -140,7 +140,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E005.png"
     },
     {
         "name": "Friend of Saya, Natsuki",
@@ -166,7 +166,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E006.png"
     },
     {
         "name": "Gentle Stare, Yuri",
@@ -192,7 +192,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E007.png"
     },
     {
         "name": "On the Stage, Rii",
@@ -218,7 +218,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E008.png"
     },
     {
         "name": "Student Council President, Nanana",
@@ -245,7 +245,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E009.png"
     },
     {
         "name": "Yuri Ushigome",
@@ -272,7 +272,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E010.png"
     },
     {
         "name": "Senior of Kasumi and Gang, Hinako",
@@ -298,7 +298,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E011.png"
     },
     {
         "name": "Reliable Elder Sister, Yuri",
@@ -324,7 +324,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E012.png"
     },
     {
         "name": "Together with Debeko, Rii",
@@ -351,7 +351,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E013.png"
     },
     {
         "name": "On Keyboards, Nanana",
@@ -377,7 +377,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E014.png"
     },
     {
         "name": "\"Club Show\" Yuri",
@@ -403,7 +403,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E015.png"
     },
     {
         "name": "Rii Uzawa",
@@ -431,7 +431,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E016.png"
     },
     {
         "name": "Nanana Wanibe",
@@ -460,7 +460,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E017.png"
     },
     {
         "name": "Our Stage!",
@@ -489,7 +489,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E018.png"
     },
     {
         "name": "Moment Between Sisters",
@@ -518,7 +518,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E019.png"
     },
     {
         "name": "Happy Christmas♪ Kasumi",
@@ -545,7 +545,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E020.png"
     },
     {
         "name": "Happy Christmas♪ Saya",
@@ -575,7 +575,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E021.png"
     },
     {
         "name": "Under the Fullmoon, Kasumi & Rimi",
@@ -605,7 +605,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E022.png"
     },
     {
         "name": "Saya Yamabuki",
@@ -634,7 +634,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E023.png"
     },
     {
         "name": "Rimi Ushigome",
@@ -663,7 +663,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E024.png"
     },
     {
         "name": "Kasumi Toyama",
@@ -693,7 +693,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E025.png"
     },
     {
         "name": "Starrin'PARTY, Saya Yamabuki",
@@ -720,7 +720,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E026.png"
     },
     {
         "name": "First Feeling of \"Heart Race\", Kasumi",
@@ -747,7 +747,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E027.png"
     },
     {
         "name": "Live House at Sunset, Rimi",
@@ -774,7 +774,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E028.png"
     },
     {
         "name": "\"Twinkle Star\" Kasumi",
@@ -800,7 +800,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E029.png"
     },
     {
         "name": "Melancholic Awakening, Rimi",
@@ -828,7 +828,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E030.png"
     },
     {
         "name": "Happy Halloween♪ Kasumi",
@@ -855,7 +855,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E031.png"
     },
     {
         "name": "Heart-pounding Stage, Rimi",
@@ -882,7 +882,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E032.png"
     },
     {
         "name": "High School Girl, Saya",
@@ -908,7 +908,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E033.png"
     },
     {
         "name": "Caring for Friends, Saya",
@@ -937,7 +937,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E034.png"
     },
     {
         "name": "In the Sunlight Forest, Saya",
@@ -966,7 +966,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E035.png"
     },
     {
         "name": "Starrin'PARTY, Kasumi Toyama",
@@ -995,7 +995,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E036.png"
     },
     {
         "name": "Starrin'PARTY, Rimi Ushigome",
@@ -1024,7 +1024,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E037.png"
     },
     {
         "name": "Suggestion, Rimi",
@@ -1051,7 +1051,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E038.png"
     },
     {
         "name": "Under the Night Sky, Kasumi",
@@ -1078,7 +1078,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E039.png"
     },
     {
         "name": "Asuka Toyama",
@@ -1104,7 +1104,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E040.png"
     },
     {
         "name": "Girl Band Mecca, Kasumi",
@@ -1130,7 +1130,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E041.png"
     },
     {
         "name": "A New Start, Saya",
@@ -1157,7 +1157,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E042.png"
     },
     {
         "name": "Good at Housework, Saya",
@@ -1183,7 +1183,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E043.png"
     },
     {
         "name": "Emotions Gushing Out, Saya",
@@ -1209,7 +1209,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E044.png"
     },
     {
         "name": "Midsummer Beachside, Saya & Rimi",
@@ -1235,7 +1235,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E045.png"
     },
     {
         "name": "Discovering Sparkles, Rimi",
@@ -1264,7 +1264,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E046.png"
     },
     {
         "name": "Choco Cornet Song, Rimi",
@@ -1293,7 +1293,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E047.png"
     },
     {
         "name": "Sprin'PARTY, Saya Yamabuki",
@@ -1322,7 +1322,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E048.png"
     },
     {
         "name": "Good Morning Kasumi",
@@ -1351,7 +1351,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E049.png"
     },
     {
         "name": "Satisfied Kasumi",
@@ -1380,7 +1380,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E050.png"
     },
     {
         "name": "A Scene at Sunset, Rimi",
@@ -1408,7 +1408,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E051.png"
     },
     {
         "name": "\"Club Show\" Saya",
@@ -1435,7 +1435,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E052.png"
     },
     {
         "name": "Shy Girl, Rimi",
@@ -1462,7 +1462,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E053.png"
     },
     {
         "name": "“Weirdo” Kasumi",
@@ -1489,7 +1489,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E054.png"
     },
     {
         "name": "Caring for Elder Sister, Asuka",
@@ -1516,7 +1516,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E055.png"
     },
     {
         "name": "Morning Events, Rimi",
@@ -1543,7 +1543,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E056.png"
     },
     {
         "name": "\"Club Show\" Kasumi",
@@ -1570,7 +1570,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E057.png"
     },
     {
         "name": "Wrapped in Curtains, Rimi",
@@ -1597,7 +1597,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E058.png"
     },
     {
         "name": "Self-introduction, Saya",
@@ -1624,7 +1624,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E059.png"
     },
     {
         "name": "Invitation, Saya",
@@ -1650,7 +1650,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E060.png"
     },
     {
         "name": "Sprin'PARTY, Rimi Ushigome",
@@ -1676,7 +1676,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E061.png"
     },
     {
         "name": "Trading Parts of Their Lunch, Kasumi",
@@ -1703,7 +1703,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E062.png"
     },
     {
         "name": "A Scene in the Morning, Saya",
@@ -1731,7 +1731,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E063.png"
     },
     {
         "name": "\"Club Show\" Rimi",
@@ -1757,7 +1757,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E064.png"
     },
     {
         "name": "Saya Handing Over Choco Cornets",
@@ -1784,7 +1784,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E065.png"
     },
     {
         "name": "Kasumi's Younger Sister, Asuka",
@@ -1811,7 +1811,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E066.png"
     },
     {
         "name": "First Live, Kasumi",
@@ -1837,7 +1837,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E067.png"
     },
     {
         "name": "Real Feelings, Saya",
@@ -1865,7 +1865,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E068.png"
     },
     {
         "name": "Sprin'PARTY, Kasumi Toyama",
@@ -1894,7 +1894,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E069.png"
     },
     {
         "name": "One Day Manager, Kasumi",
@@ -1923,7 +1923,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E070.png"
     },
     {
         "name": "Something in the Warehouse",
@@ -1949,7 +1949,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E071.png"
     },
     {
         "name": "Under the Night Sky",
@@ -1976,7 +1976,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E072.png"
     },
     {
         "name": "Letter from Kasumi",
@@ -2002,7 +2002,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E073.png"
     },
     {
         "name": "STAR BEAT!",
@@ -2031,7 +2031,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E074.png"
     },
     {
         "name": "Exchanged Promise",
@@ -2060,7 +2060,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E075.png"
     },
     {
         "name": "Twinkle Twinkle Little Star",
@@ -2089,7 +2089,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E076.png"
     },
     {
         "name": "A Big Step",
@@ -2118,7 +2118,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E077.png"
     },
     {
         "name": "Aspired Stage",
@@ -2147,7 +2147,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E078.png"
     },
     {
         "name": "Gentle Elder Sis",
@@ -2176,7 +2176,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E079.png"
     },
     {
         "name": "We Are Poppin'Party",
@@ -2206,7 +2206,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E080.png"
     },
     {
         "name": "Tae Staring at the Stage",
@@ -2233,7 +2233,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E081.png"
     },
     {
         "name": "Arisa Ichigaya",
@@ -2263,7 +2263,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E082.png"
     },
     {
         "name": "Swimsuit Arisa",
@@ -2293,7 +2293,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E083.png"
     },
     {
         "name": "Tae Hanazono",
@@ -2323,7 +2323,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E084.png"
     },
     {
         "name": "Way Home, Arisa",
@@ -2350,7 +2350,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E085.png"
     },
     {
         "name": "A Scene in the Morning, Tae",
@@ -2376,7 +2376,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E086.png"
     },
     {
         "name": "Sprin'PARTY, Tae Hanazono",
@@ -2404,7 +2404,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E087.png"
     },
     {
         "name": "Bonsai Girl, Arisa",
@@ -2430,7 +2430,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E088.png"
     },
     {
         "name": "\"Club Show\" Tae",
@@ -2456,7 +2456,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E089.png"
     },
     {
         "name": "Arisa Trying Not to Laugh",
@@ -2486,7 +2486,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E090.png"
     },
     {
         "name": "Starrin'PARTY, Arisa Ichigaya",
@@ -2515,7 +2515,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E091.png"
     },
     {
         "name": "Starrin'PARTY, Tae Hanazono",
@@ -2545,7 +2545,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E092.png"
     },
     {
         "name": "Lunch Break, Tae",
@@ -2572,7 +2572,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E093.png"
     },
     {
         "name": "Sprin'PARTY, Arisa Ichigaya",
@@ -2599,7 +2599,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E094.png"
     },
     {
         "name": "\"SPACE\" Owner, Shizen Tsuzuki",
@@ -2625,7 +2625,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E095.png"
     },
     {
         "name": "Full of Sparkles, Arisa",
@@ -2651,7 +2651,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E096.png"
     },
     {
         "name": "First Live, Arisa",
@@ -2678,7 +2678,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E097.png"
     },
     {
         "name": "Part Time Job at SPACE, Tae",
@@ -2707,7 +2707,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E098.png"
     },
     {
         "name": "\"Club Show\" Arisa",
@@ -2736,7 +2736,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E099.png"
     },
     {
         "name": "Tsundere, Arisa",
@@ -2765,7 +2765,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E100.png"
     },
     {
         "name": "Well-prepared, Tae",
@@ -2794,7 +2794,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E101.png"
     },
     {
         "name": "Explosive Summer♪ Tae & Arisa & Kasumi",
@@ -2822,7 +2822,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E102.png"
     },
     {
         "name": "Remedial Classroom, Tae",
@@ -2849,7 +2849,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E103.png"
     },
     {
         "name": "High School Girl, Tae",
@@ -2875,7 +2875,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E104.png"
     },
     {
         "name": "Happy Halloween♪ Arisa",
@@ -2901,7 +2901,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E105.png"
     },
     {
         "name": "Heart-pounding Feeling, Tae",
@@ -2927,7 +2927,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E106.png"
     },
     {
         "name": "Bewitching Omelet, Arisa",
@@ -2953,7 +2953,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E107.png"
     },
     {
         "name": "Yesterday's Events, Arisa",
@@ -2980,7 +2980,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E108.png"
     },
     {
         "name": "Childhood Tae",
@@ -3006,7 +3006,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E109.png"
     },
     {
         "name": "High School Student, Arisa",
@@ -3032,7 +3032,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E110.png"
     },
     {
         "name": "First Live, Tae",
@@ -3058,7 +3058,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E111.png"
     },
     {
         "name": "Boggy Arisa",
@@ -3087,7 +3087,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E112.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E112.png"
     },
     {
         "name": "Panicking Arisa",
@@ -3116,7 +3116,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E113.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E113.png"
     },
     {
         "name": "That Irritating Girl",
@@ -3144,7 +3144,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E114.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E114.png"
     },
     {
         "name": "Hearing a Guitar for the First Time",
@@ -3171,7 +3171,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E115.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E115.png"
     },
     {
         "name": "Heart Pounding Star",
@@ -3201,7 +3201,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E116.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E116.png"
     },
     {
         "name": "Moved With Everyone",
@@ -3231,7 +3231,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E117.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E117.png"
     },
     {
         "name": "Real Intentions",
@@ -3260,7 +3260,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E118.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E118.png"
     },
     {
         "name": "Arisa Selling Off Tonegawa",
@@ -3289,7 +3289,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E119.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E119.png"
     },
     {
         "name": "Poppin'Party, First LIVE",
@@ -3319,7 +3319,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E120",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E120.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E120.png"
     },
     {
         "name": "Petit Kasumi",
@@ -3346,7 +3346,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E121.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E121.png"
     },
     {
         "name": "Petit Rimi",
@@ -3375,7 +3375,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E122.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E122.png"
     },
     {
         "name": "Petit Saya",
@@ -3404,7 +3404,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E123.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E123.png"
     },
     {
         "name": "Petit Arisa",
@@ -3430,7 +3430,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E124",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E124.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E124.png"
     },
     {
         "name": "Petit Tae",
@@ -3457,7 +3457,7 @@
         "set": "BD",
         "release": "47",
         "sid": "E125",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-E125.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_E125.png"
     },
     {
         "name": "Nice to Meet You Poppin'Party",
@@ -3534,7 +3534,7 @@
         "set": "BD",
         "release": "47",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_PE03.png"
     },
     {
         "name": "Sparkling Kasumi",
@@ -3560,7 +3560,7 @@
         "set": "BD",
         "release": "47",
         "sid": "PE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD-W47-PE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_PE17.png"
     },
     {
         "name": "Session at the Beach",
@@ -3617,7 +3617,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE01.png"
     },
     {
         "name": "“Poppin’Party” Saya Yamabuki",
@@ -3644,7 +3644,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE02.png"
     },
     {
         "name": "Self-introduction, Kasumi",
@@ -3671,7 +3671,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE03.png"
     },
     {
         "name": "“STAR BEAT!” Rimi Ushigome",
@@ -3697,7 +3697,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE04.png"
     },
     {
         "name": "“Poppin’Party” Rimi Ushigome",
@@ -3723,7 +3723,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE05a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE05a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE05a.png"
     },
     {
         "name": "“Poppin’Party” Rimi Ushigome",
@@ -3749,7 +3749,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE05b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE05b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE05b.png"
     },
     {
         "name": "Premonition of a Beginning, Kasumi Toyama",
@@ -3775,7 +3775,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE06.png"
     },
     {
         "name": "Nervous Self-introduction, Rimi",
@@ -3801,7 +3801,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE07.png"
     },
     {
         "name": "“STAR BEAT!” Kasumi Toyama",
@@ -3829,7 +3829,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE08.png"
     },
     {
         "name": "“STAR BEAT!” Saya Yamabuki",
@@ -3858,7 +3858,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE09.png"
     },
     {
         "name": "“Poppin’Party” Kasumi Toyama",
@@ -3887,7 +3887,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE10.png"
     },
     {
         "name": "My Favorite Item",
@@ -3912,7 +3912,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE11a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE11a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE11a.png"
     },
     {
         "name": "My Favorite Item",
@@ -3937,7 +3937,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE11b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE11b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE11b.png"
     },
     {
         "name": "My Favorite Item",
@@ -3962,7 +3962,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE11c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE11c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE11c.png"
     },
     {
         "name": "My Favorite Item",
@@ -3987,7 +3987,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE11d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE11d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE11d.png"
     },
     {
         "name": "My Favorite Item",
@@ -4012,7 +4012,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE11e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE11e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE11e.png"
     },
     {
         "name": "Racing-heart! Heart-racing!",
@@ -4040,7 +4040,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE12.png"
     },
     {
         "name": "Let's! Poppin’Party",
@@ -4068,7 +4068,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE13.png"
     },
     {
         "name": "“STAR BEAT!” Tae Hanazono",
@@ -4094,7 +4094,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE14.png"
     },
     {
         "name": "Raise Both Hands! Arisa",
@@ -4120,7 +4120,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE15.png"
     },
     {
         "name": "“STAR BEAT!” Arisa Ichigaya",
@@ -4146,7 +4146,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE16.png"
     },
     {
         "name": "Tae Shows No Interest",
@@ -4173,7 +4173,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE17.png"
     },
     {
         "name": "“Poppin’Party” Arisa Ichigaya",
@@ -4202,7 +4202,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE18a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE18a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE18a.png"
     },
     {
         "name": "“Poppin’Party” Arisa Ichigaya",
@@ -4231,7 +4231,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE18b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE18b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE18b.png"
     },
     {
         "name": "“Poppin’Party” Tae Hanazono",
@@ -4260,7 +4260,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE19a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE19a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE19a.png"
     },
     {
         "name": "“Poppin’Party” Tae Hanazono",
@@ -4289,7 +4289,7 @@
         "set": "BD",
         "release": "47",
         "sid": "TE19b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE19b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE19b.png"
     },
     {
         "name": "STAR BEAT!",
@@ -4317,6 +4317,6 @@
         "set": "BD",
         "release": "47",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BD_W47_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bd_w47/BD_W47_TE20.png"
     }
 ]

--- a/DB/BM_S15.json
+++ b/DB/BM_S15.json
@@ -26,7 +26,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E001.png"
     },
     {
         "name": "Mayoi Hachikuji",
@@ -55,7 +55,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E002.png"
     },
     {
         "name": "Koyomi Araragi on Mother's Day",
@@ -82,7 +82,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E003.png"
     },
     {
         "name": "Wandering Girl, Mayoi Hachikuji",
@@ -109,7 +109,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E004.png"
     },
     {
         "name": "Lost Cattle, Mayoi Hachikuji",
@@ -135,7 +135,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E005.png"
     },
     {
         "name": "Girl Lost in the Snail, Mayoi Hachikuji",
@@ -163,7 +163,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E006.png"
     },
     {
         "name": "Shinobu Oshino the Vampire",
@@ -192,7 +192,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E007.png"
     },
     {
         "name": "Enthusiastic Girl, Nadeko Sengoku",
@@ -218,7 +218,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E008.png"
     },
     {
         "name": "Wreck of a Former Vampire, Shinobu Oshino",
@@ -244,7 +244,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E009.png"
     },
     {
         "name": "Shy Girl, Nadeko Sengoku",
@@ -271,7 +271,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E010.png"
     },
     {
         "name": "Looking Down on Koyomi, Mayoi Hachikuji",
@@ -297,7 +297,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E011.png"
     },
     {
         "name": "Wandering Spirit, Mayoi Hachikuji",
@@ -325,7 +325,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E012.png"
     },
     {
         "name": "\"Not on Purpose\"Mayoi Hachikuji",
@@ -352,7 +352,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E013.png"
     },
     {
         "name": "Human-looking Vampire, Shinobu Oshino",
@@ -379,7 +379,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E014.png"
     },
     {
         "name": "Infatuation, Nadeko Sengoku",
@@ -405,7 +405,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E015.png"
     },
     {
         "name": "Vampire-looking Human, Koyomi Araragi",
@@ -432,7 +432,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E016.png"
     },
     {
         "name": "Shinobu Oshino",
@@ -458,7 +458,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E017.png"
     },
     {
         "name": "Likes Donuts, Shinobu Oshino",
@@ -484,7 +484,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E018.png"
     },
     {
         "name": "Hungry, Mayoi Hachikuji",
@@ -512,7 +512,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E019.png"
     },
     {
         "name": "Self-proclaimed 500 Years Old, Shinobu Oshino",
@@ -540,7 +540,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E020.png"
     },
     {
         "name": "Real Fight",
@@ -566,7 +566,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E021.png"
     },
     {
         "name": "Tongue Twister",
@@ -592,7 +592,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E022.png"
     },
     {
         "name": "Maintaining Existence",
@@ -622,7 +622,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E023.png"
     },
     {
         "name": "MAYOI Mai Mai",
@@ -652,7 +652,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E024.png"
     },
     {
         "name": "Cursed Girl",
@@ -681,7 +681,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E025.png"
     },
     {
         "name": "Family Circumstance, Tsubasa Hanekawa",
@@ -710,7 +710,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E026.png"
     },
     {
         "name": "Girl Who Wished on the Monkey, Suruga Kanbaru",
@@ -738,7 +738,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E027.png"
     },
     {
         "name": "Suruga Kanbaru Had a Breakthrough",
@@ -764,7 +764,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E028.png"
     },
     {
         "name": "Hitagi Senjyogahara on Holiday",
@@ -790,7 +790,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E029.png"
     },
     {
         "name": "Sharp Tongue, Hitagi Senjyogahara",
@@ -816,7 +816,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E030.png"
     },
     {
         "name": "Koyomi's Lover, Hitagi Senjyogahara",
@@ -844,7 +844,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E031.png"
     },
     {
         "name": "Suruga Kanbaru",
@@ -873,7 +873,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E032.png"
     },
     {
         "name": "Monkey's Paw? Suruga Kanbaru",
@@ -900,7 +900,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E033.png"
     },
     {
         "name": "Honest With Yourself, Suruga Kanbaru",
@@ -926,7 +926,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E034.png"
     },
     {
         "name": "During a Date, Hitagi Senjyogahara",
@@ -955,7 +955,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E035.png"
     },
     {
         "name": "Dislikes Mornings, Koyomi Araragi",
@@ -981,7 +981,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E036.png"
     },
     {
         "name": "Aggressive Hitagi Senjyogahara",
@@ -1010,7 +1010,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E037.png"
     },
     {
         "name": "Good Knowledge and Memory, Tsubasa Hanekawa",
@@ -1036,7 +1036,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E038.png"
     },
     {
         "name": "Former Basketball Ace, Suruga Kanbaru",
@@ -1062,7 +1062,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E039.png"
     },
     {
         "name": "Great With Women, Suruga Kanbaru",
@@ -1088,7 +1088,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E040.png"
     },
     {
         "name": "Protagonist Who Helps All, Koyomi Araragi",
@@ -1114,7 +1114,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E041.png"
     },
     {
         "name": "Great Voice Imitation? Hitagi Senjyogahara",
@@ -1140,7 +1140,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E042.png"
     },
     {
         "name": "Very Honest, Suruga Kanbaru",
@@ -1166,7 +1166,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E043.png"
     },
     {
         "name": "Proper Manners, Tsubasa Hanekawa",
@@ -1194,7 +1194,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E044.png"
     },
     {
         "name": "The Best Class Rep, Tsubasa Hanekawa",
@@ -1222,7 +1222,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E045.png"
     },
     {
         "name": "Stalking",
@@ -1248,7 +1248,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E046.png"
     },
     {
         "name": "Rainy Devil",
@@ -1274,7 +1274,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E047.png"
     },
     {
         "name": "SURUGA Monkey",
@@ -1303,7 +1303,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E048.png"
     },
     {
         "name": "Girl With No Weight",
@@ -1332,7 +1332,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E049.png"
     },
     {
         "name": "Secret Reward",
@@ -1361,7 +1361,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E050.png"
     },
     {
         "name": "Girl With Twintails, Mayoi Hachikuji",
@@ -1388,7 +1388,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E051.png"
     },
     {
         "name": "Girl Who Met a Crab, Hitagi Senjyogahara",
@@ -1417,7 +1417,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E052.png"
     },
     {
         "name": "Criticizing Role, Koyomi Araragi",
@@ -1444,7 +1444,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E053.png"
     },
     {
         "name": "Big Backpack, Mayoi Hachikuji",
@@ -1471,7 +1471,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E054.png"
     },
     {
         "name": "Girl Who Cannot Be Left Alone, Hitagi Senjyogahara",
@@ -1497,7 +1497,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E055.png"
     },
     {
         "name": "Demon's Left Hand, Suruga Kanbaru",
@@ -1526,7 +1526,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E056.png"
     },
     {
         "name": "Fully Armed, Hitagi Senjyogahara",
@@ -1555,7 +1555,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E057.png"
     },
     {
         "name": "Tsukihi Araragi",
@@ -1582,7 +1582,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E058U.png"
     },
     {
         "name": "Honest Feelings, Hitagi Senjyogahara",
@@ -1609,7 +1609,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E059.png"
     },
     {
         "name": "Sports Girl, Suruga Kanbaru",
@@ -1635,7 +1635,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E060.png"
     },
     {
         "name": "Battle Ready, Hitagi Senjyogahara",
@@ -1661,7 +1661,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E061.png"
     },
     {
         "name": "Karen Araragi",
@@ -1688,7 +1688,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E062.png"
     },
     {
         "name": "Karen Araragi & Tsukihi Araragi",
@@ -1714,7 +1714,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E063.png"
     },
     {
         "name": "Suruga Kanbaru in Regular Clothes",
@@ -1740,7 +1740,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E064.png"
     },
     {
         "name": "Shy Mayoi Hachikuji",
@@ -1768,7 +1768,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E065.png"
     },
     {
         "name": "Girl Who Lost All Weight, Hitagi Senjyogahara",
@@ -1794,7 +1794,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E066.png"
     },
     {
         "name": "Hitagi Senjyogahara in Regular Clothes",
@@ -1822,7 +1822,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E067.png"
     },
     {
         "name": "Elementary Student, Mayoi Hachikuji",
@@ -1850,7 +1850,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E068.png"
     },
     {
         "name": "Reply to a Confession, Koyomi Araragi",
@@ -1878,7 +1878,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E069.png"
     },
     {
         "name": "Loves BL, Suruga Kanbaru",
@@ -1906,7 +1906,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E070.png"
     },
     {
         "name": "Awakening Ritual",
@@ -1932,7 +1932,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E071.png"
     },
     {
         "name": "Tsundere?",
@@ -1958,7 +1958,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E072.png"
     },
     {
         "name": "HITAGI Crab",
@@ -1987,7 +1987,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E073.png"
     },
     {
         "name": "Flubbing Girl",
@@ -2016,7 +2016,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E074.png"
     },
     {
         "name": "After The Demon Has Left",
@@ -2045,7 +2045,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E075.png"
     },
     {
         "name": "Girl Charmed By a Cat, Tsubasa Hanekawa",
@@ -2074,7 +2074,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E076.png"
     },
     {
         "name": "Girl Bound By a Snake, Nadeko Sengoku",
@@ -2103,7 +2103,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E077RR.png"
     },
     {
         "name": "Classmate of Tsukihi, Nadeko Sengoku",
@@ -2130,7 +2130,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E078.png"
     },
     {
         "name": "Inner Feelings, Tsubasa Hanekawa",
@@ -2157,7 +2157,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E079.png"
     },
     {
         "name": "Lovers, Koyomi Araragi & Hitagi Senjyogahara",
@@ -2184,7 +2184,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E080.png"
     },
     {
         "name": "Black Hanekawa",
@@ -2212,7 +2212,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E081.png"
     },
     {
         "name": "Curse-lifting Gratitude, Nadeko Sengoku",
@@ -2240,7 +2240,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E082.png"
     },
     {
         "name": "Nadeko Sengoku",
@@ -2267,7 +2267,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E083.png"
     },
     {
         "name": "Meme Oshino",
@@ -2293,7 +2293,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E084.png"
     },
     {
         "name": "Tsubasa Hanekawa in Pajamas",
@@ -2319,7 +2319,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E085.png"
     },
     {
         "name": "Paranormal Authority, Meme Oshino",
@@ -2345,7 +2345,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E086.png"
     },
     {
         "name": "Girl Under a Curse, Nadeko Sengoku",
@@ -2372,7 +2372,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E087.png"
     },
     {
         "name": "Ambush, Nadeko Sengoku",
@@ -2400,7 +2400,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E088.png"
     },
     {
         "name": "Koyomi Araragi Running Around",
@@ -2427,7 +2427,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E089.png"
     },
     {
         "name": "Curse-lifting Ritual, Nadeko Sengoku",
@@ -2453,7 +2453,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E090.png"
     },
     {
         "name": "Tsubasa Hanekawa Knows Everything",
@@ -2479,7 +2479,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E091.png"
     },
     {
         "name": "Cat Ears, Tsubasa Hanekawa",
@@ -2505,7 +2505,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E092.png"
     },
     {
         "name": "Maturing Girl, Nadeko Sengoku",
@@ -2531,7 +2531,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E093.png"
     },
     {
         "name": "Tsubasa Hanekawa",
@@ -2560,7 +2560,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E094.png"
     },
     {
         "name": "All-seeing Guy, Meme Oshino",
@@ -2588,7 +2588,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E095.png"
     },
     {
         "name": "\"Energy Drain\"Black Hanekawa",
@@ -2616,7 +2616,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E096.png"
     },
     {
         "name": "Keep This a Secret",
@@ -2643,7 +2643,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E097.png"
     },
     {
         "name": "NADEKO Snake",
@@ -2672,7 +2672,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E098.png"
     },
     {
         "name": "Everything About Me",
@@ -2701,7 +2701,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E099.png"
     },
     {
         "name": "TSUBASA Cat",
@@ -2730,7 +2730,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E100.png"
     },
     {
         "name": "Motionless Silence, Koyomi Araragi",
@@ -2756,7 +2756,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e101.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E101.png"
     },
     {
         "name": "Highly Suspicious Hitagi Senjyogahara",
@@ -2782,7 +2782,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e102.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E102.png"
     },
     {
         "name": "Daughter of a Proper Family, Senjyogahara Hitagi",
@@ -2811,7 +2811,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E103.png"
     },
     {
         "name": "Weight Crab",
@@ -2840,7 +2840,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e104.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E104.png"
     },
     {
         "name": "Ultimate Honor Student, Tsubasa Hanekawa",
@@ -2866,7 +2866,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_e105.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E105.png"
     },
     {
         "name": "Energetic Girl, Mayoi Hachikuji",
@@ -3020,7 +3020,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_BM_S15_E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E111.png"
     },
     {
         "name": "\"Scathing Words\"Hitagi Senjyogahara",
@@ -3046,7 +3046,7 @@
         "set": "BM",
         "release": "15",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_BM_S15_E112.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_E112.png"
     },
     {
         "name": "Karen Araragi & Tsukihi Araragi",
@@ -3072,7 +3072,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE01.png"
     },
     {
         "name": "Suruga Kanbaru in Regular Clothes",
@@ -3098,7 +3098,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE02.png"
     },
     {
         "name": "Battle Ready, Hitagi Senjyogahara",
@@ -3124,7 +3124,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE03.png"
     },
     {
         "name": "Shy Mayoi Hachikuji",
@@ -3152,7 +3152,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE04.png"
     },
     {
         "name": "Girl Who Lost All Weight, Hitagi Senjyogahara",
@@ -3178,7 +3178,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE05.png"
     },
     {
         "name": "Hitagi Senjyogahara in Regular Clothes",
@@ -3206,7 +3206,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE06.png"
     },
     {
         "name": "Elementary Student, Mayoi Hachikuji",
@@ -3234,7 +3234,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE07.png"
     },
     {
         "name": "Loves BL, Suruga Kanbaru",
@@ -3262,7 +3262,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE08.png"
     },
     {
         "name": "HITAGI Crab",
@@ -3291,7 +3291,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE09.png"
     },
     {
         "name": "Curse-lifting Ritual, Nadeko Sengoku",
@@ -3317,7 +3317,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE10.png"
     },
     {
         "name": "Tsubasa Hanekawa in Pajamas",
@@ -3343,7 +3343,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE11.png"
     },
     {
         "name": "Cat Ears, Tsubasa Hanekawa",
@@ -3369,7 +3369,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE12.png"
     },
     {
         "name": "Maturing Girl, Nadeko Sengoku",
@@ -3395,7 +3395,7 @@
         "set": "BM",
         "release": "15",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE13.png"
     },
     {
         "name": "Everything About Me",
@@ -3424,6 +3424,6 @@
         "set": "BM",
         "release": "15",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_bm_s15_te14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bm_s15/BM_S15_TE14.png"
     }
 ]

--- a/DB/BNJ_SX01.json
+++ b/DB/BNJ_SX01.json
@@ -25,7 +25,7 @@
         "set": "BNJ",
         "release": "BCS2019",
         "sid": "02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_BCS2019_02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_BCS2019_02.png"
     },
     {
         "name": "Joker: The Final Showdown",
@@ -52,7 +52,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_001.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_001.png",
         "price": "7.00"
     },
     {
@@ -83,7 +83,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_002.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_002.png",
         "price": "5.00"
     },
     {
@@ -113,7 +113,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_003.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_003.png",
         "price": "2.00"
     },
     {
@@ -140,7 +140,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_004.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_004.png",
         "price": "1.50"
     },
     {
@@ -167,7 +167,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_005.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_005.png",
         "price": "1.50"
     },
     {
@@ -195,7 +195,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_006.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_006.png",
         "price": "1.00"
     },
     {
@@ -225,7 +225,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_007.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_007.png",
         "price": "1.00"
     },
     {
@@ -253,7 +253,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_008.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_008.png",
         "price": "1.00"
     },
     {
@@ -283,7 +283,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_009.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_009.png",
         "price": "1.00"
     },
     {
@@ -313,7 +313,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_010.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_010.png",
         "price": "1.00"
     },
     {
@@ -343,7 +343,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_011.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_011.png",
         "price": "1.00"
     },
     {
@@ -373,7 +373,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_012.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_012.png",
         "price": "1.00"
     },
     {
@@ -401,7 +401,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_013.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_013.png",
         "price": "0.50"
     },
     {
@@ -428,7 +428,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_014.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_014.png",
         "price": "0.50"
     },
     {
@@ -455,7 +455,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_015.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_015.png",
         "price": "0.50"
     },
     {
@@ -482,7 +482,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_016.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_016.png",
         "price": "0.50"
     },
     {
@@ -512,7 +512,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_017.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_017.png",
         "price": "0.50"
     },
     {
@@ -542,7 +542,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_018.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_018.png",
         "price": "0.50"
     },
     {
@@ -570,7 +570,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_019.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_019.png",
         "price": "0.25"
     },
     {
@@ -598,7 +598,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_020.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_020.png",
         "price": "0.25"
     },
     {
@@ -625,7 +625,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_021.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_021.png",
         "price": "0.25"
     },
     {
@@ -653,7 +653,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_022.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_022.png",
         "price": "0.25"
     },
     {
@@ -681,7 +681,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_023.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_023.png",
         "price": "0.25"
     },
     {
@@ -708,7 +708,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_024.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_024.png",
         "price": "0.25"
     },
     {
@@ -736,7 +736,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_025.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_025.png",
         "price": "0.25"
     },
     {
@@ -763,7 +763,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_026.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_026.png",
         "price": "0.25"
     },
     {
@@ -793,7 +793,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_027.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_027.png",
         "price": "0.25"
     },
     {
@@ -820,7 +820,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_028.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_028.png",
         "price": "0.75"
     },
     {
@@ -848,7 +848,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_029.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_029.png",
         "price": "0.50"
     },
     {
@@ -877,7 +877,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_030.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_030.png",
         "price": "0.50"
     },
     {
@@ -904,7 +904,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_031.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_031.png",
         "price": "0.50"
     },
     {
@@ -934,7 +934,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_032.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_032.png",
         "price": "1.00"
     },
     {
@@ -964,7 +964,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_033.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_033.png",
         "price": "0.50"
     },
     {
@@ -994,7 +994,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_034.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_034.png",
         "price": "0.50"
     },
     {
@@ -1024,7 +1024,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_035.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_035.png",
         "price": "0.50"
     },
     {
@@ -1052,7 +1052,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_036.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_036.png",
         "price": "10.00"
     },
     {
@@ -1080,7 +1080,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_037.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_037.png",
         "price": "5.00"
     },
     {
@@ -1111,7 +1111,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_038.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_038.png",
         "price": "9.00"
     },
     {
@@ -1139,7 +1139,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_039.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_039.png",
         "price": "3.00"
     },
     {
@@ -1167,7 +1167,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_040.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_040.png",
         "price": "1.00"
     },
     {
@@ -1195,7 +1195,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_041.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_041.png",
         "price": "1.00"
     },
     {
@@ -1225,7 +1225,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_042.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_042.png",
         "price": "1.00"
     },
     {
@@ -1255,7 +1255,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_043.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_043.png",
         "price": "1.00"
     },
     {
@@ -1285,7 +1285,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_044.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_044.png",
         "price": "2.00"
     },
     {
@@ -1313,7 +1313,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_045.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_045.png",
         "price": "0.50"
     },
     {
@@ -1341,7 +1341,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_046.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_046.png",
         "price": "0.50"
     },
     {
@@ -1371,7 +1371,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_047.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_047.png",
         "price": "0.50"
     },
     {
@@ -1399,7 +1399,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_048.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_048.png",
         "price": "0.25"
     },
     {
@@ -1427,7 +1427,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_049.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_049.png",
         "price": "0.50"
     },
     {
@@ -1454,7 +1454,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_050.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_050.png",
         "price": "0.25"
     },
     {
@@ -1481,7 +1481,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_051.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_051.png",
         "price": "0.25"
     },
     {
@@ -1508,7 +1508,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_052.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_052.png",
         "price": "0.25"
     },
     {
@@ -1535,7 +1535,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_053.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_053.png",
         "price": "0.25"
     },
     {
@@ -1563,7 +1563,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_054.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_054.png",
         "price": "0.25"
     },
     {
@@ -1593,7 +1593,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_055.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_055.png",
         "price": "0.25"
     },
     {
@@ -1623,7 +1623,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_056.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_056.png",
         "price": "0.25"
     },
     {
@@ -1650,7 +1650,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_057.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_057.png",
         "price": "0.50"
     },
     {
@@ -1677,7 +1677,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_058.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_058.png",
         "price": "0.50"
     },
     {
@@ -1707,7 +1707,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_059.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_059.png",
         "price": "1.00"
     },
     {
@@ -1737,7 +1737,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_060.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_060.png",
         "price": "0.50"
     },
     {
@@ -1767,7 +1767,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_061.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_061.png",
         "price": "0.50"
     },
     {
@@ -1797,7 +1797,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_062.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_062.png",
         "price": "0.50"
     },
     {
@@ -1825,7 +1825,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_063.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_063.png",
         "price": "15.00"
     },
     {
@@ -1853,7 +1853,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_064.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_064.png",
         "price": "18.00"
     },
     {
@@ -1881,7 +1881,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_065.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_065.png",
         "price": "5.00"
     },
     {
@@ -1912,7 +1912,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_066.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_066.png",
         "price": "5.00"
     },
     {
@@ -1940,7 +1940,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_067.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_067.png",
         "price": "1.00"
     },
     {
@@ -1969,7 +1969,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_068.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_068.png",
         "price": "1.00"
     },
     {
@@ -1996,7 +1996,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_069.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_069.png",
         "price": "2.00"
     },
     {
@@ -2023,7 +2023,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_070.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_070.png",
         "price": "1.00"
     },
     {
@@ -2053,7 +2053,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_071.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_071.png",
         "price": "1.00"
     },
     {
@@ -2084,7 +2084,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_072.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_072.png",
         "price": "1.00"
     },
     {
@@ -2115,7 +2115,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_073.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_073.png",
         "price": "2.00"
     },
     {
@@ -2145,7 +2145,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_074.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_074.png",
         "price": "1.50"
     },
     {
@@ -2173,7 +2173,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_075.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_075.png",
         "price": "0.50"
     },
     {
@@ -2201,7 +2201,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_076.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_076.png",
         "price": "0.50"
     },
     {
@@ -2229,7 +2229,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_077.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_077.png",
         "price": "0.50"
     },
     {
@@ -2257,7 +2257,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "078a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_078a.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_078a.png",
         "price": "2.00"
     },
     {
@@ -2285,7 +2285,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "078b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_078b.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_078b.png",
         "price": "2.00"
     },
     {
@@ -2313,7 +2313,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "078c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_078c.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_078c.png",
         "price": "2.00"
     },
     {
@@ -2341,7 +2341,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "078d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_078d.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_078d.png",
         "price": "2.00"
     },
     {
@@ -2369,7 +2369,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_079.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_079.png",
         "price": "0.50"
     },
     {
@@ -2397,7 +2397,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_080.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_080.png",
         "price": "0.50"
     },
     {
@@ -2427,7 +2427,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_081.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_081.png",
         "price": "0.50"
     },
     {
@@ -2457,7 +2457,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_082.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_082.png",
         "price": "0.50"
     },
     {
@@ -2487,7 +2487,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_083.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_083.png",
         "price": "0.50"
     },
     {
@@ -2518,7 +2518,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_084.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_084.png",
         "price": "0.50"
     },
     {
@@ -2546,7 +2546,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_085.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_085.png",
         "price": "0.25"
     },
     {
@@ -2574,7 +2574,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_086.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_086.png",
         "price": "0.25"
     },
     {
@@ -2601,7 +2601,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_087.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_087.png",
         "price": "1.00"
     },
     {
@@ -2629,7 +2629,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_088.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_088.png",
         "price": "0.25"
     },
     {
@@ -2656,7 +2656,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_089.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_089.png",
         "price": "0.25"
     },
     {
@@ -2684,7 +2684,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_090.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_090.png",
         "price": "0.25"
     },
     {
@@ -2712,7 +2712,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_091.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_091.png",
         "price": "0.25"
     },
     {
@@ -2740,7 +2740,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_092.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_092.png",
         "price": "0.50"
     },
     {
@@ -2767,7 +2767,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_093.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_093.png",
         "price": "0.25"
     },
     {
@@ -2797,7 +2797,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_094.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_094.png",
         "price": "0.25"
     },
     {
@@ -2825,7 +2825,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_095.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_095.png",
         "price": "0.50"
     },
     {
@@ -2852,7 +2852,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_096.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_096.png",
         "price": "0.50"
     },
     {
@@ -2883,7 +2883,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_097.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_097.png",
         "price": "1.00"
     },
     {
@@ -2913,7 +2913,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_098.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_098.png",
         "price": "1.00"
     },
     {
@@ -2944,7 +2944,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_099.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_099.png",
         "price": "0.50"
     },
     {
@@ -2974,7 +2974,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_100.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_100.png",
         "price": "0.50"
     },
     {
@@ -3001,7 +3001,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_101.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_101.png",
         "price": "3.00"
     },
     {
@@ -3029,7 +3029,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_102.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_102.png",
         "price": "3.00"
     },
     {
@@ -3056,7 +3056,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_103.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_103.png",
         "price": "3.00"
     },
     {
@@ -3084,7 +3084,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_104.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_104.png",
         "price": "5.00"
     },
     {
@@ -3111,7 +3111,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_105.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_105.png",
         "price": "3.00"
     },
     {
@@ -3141,7 +3141,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_106.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_106.png",
         "price": "4.00"
     },
     {
@@ -3171,7 +3171,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_107.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_107.png",
         "price": "4.00"
     },
     {
@@ -3198,7 +3198,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A01.png"
     },
     {
         "name": "Red Hood",
@@ -3224,7 +3224,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A02.png"
     },
     {
         "name": "Red Robin: Battle on the Big Boat",
@@ -3250,7 +3250,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A03.png"
     },
     {
         "name": "Gunslinger",
@@ -3279,7 +3279,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A04.png"
     },
     {
         "name": "Batman: Missionary Disguise",
@@ -3305,7 +3305,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A05.png"
     },
     {
         "name": "Nightwing: Coordinated Assault",
@@ -3331,7 +3331,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A06.png"
     },
     {
         "name": "Batman: Ancient Armor",
@@ -3357,7 +3357,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A07.png"
     },
     {
         "name": "Catwoman: Unimpressed",
@@ -3383,7 +3383,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A08.png"
     },
     {
         "name": "Batman: Information Extraction",
@@ -3411,7 +3411,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A09.png"
     },
     {
         "name": "Catwoman: Battle on the Big Boat",
@@ -3439,7 +3439,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A10.png"
     },
     {
         "name": "Batman: Infiltration",
@@ -3467,7 +3467,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A11.png"
     },
     {
         "name": "Donning the Mask",
@@ -3493,7 +3493,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A12.png"
     },
     {
         "name": "Unleash the Bat!",
@@ -3522,7 +3522,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "A13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_A13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_A13.png"
     },
     {
         "name": "Batman: Back in Time",
@@ -3549,7 +3549,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "P01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_P01.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_P01.png",
         "price": "2.00"
     },
     {
@@ -3577,7 +3577,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "P01A",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_P01A.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_P01A.png"
     },
     {
         "name": "Joker: Innate Insanity",
@@ -3604,7 +3604,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "P02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_P02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_P02.png"
     },
     {
         "name": "Red Robin: Reliable Ally",
@@ -3631,7 +3631,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T01.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T01.png",
         "price": "0.50"
     },
     {
@@ -3659,7 +3659,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T02.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T02.png",
         "price": "0.25"
     },
     {
@@ -3686,7 +3686,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T03.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T03.png",
         "price": "0.25"
     },
     {
@@ -3713,7 +3713,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T04.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T04.png",
         "price": "0.50"
     },
     {
@@ -3742,7 +3742,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T05.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T05.png",
         "price": "0.50"
     },
     {
@@ -3772,7 +3772,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T06.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T06.png",
         "price": "0.50"
     },
     {
@@ -3802,7 +3802,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T07.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T07.png",
         "price": "0.50"
     },
     {
@@ -3830,7 +3830,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T08.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T08.png",
         "price": "0.50"
     },
     {
@@ -3858,7 +3858,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T09.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T09.png",
         "price": "3.00"
     },
     {
@@ -3885,7 +3885,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T10.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T10.png",
         "price": "0.50"
     },
     {
@@ -3913,7 +3913,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T11.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T11.png",
         "price": "1.00"
     },
     {
@@ -3940,7 +3940,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T12.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T12.png",
         "price": "0.25"
     },
     {
@@ -3968,7 +3968,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T13.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T13.png",
         "price": "0.50"
     },
     {
@@ -3997,7 +3997,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T14.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T14.png",
         "price": "0.50"
     },
     {
@@ -4027,7 +4027,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T15.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T15.png",
         "price": "0.50"
     },
     {
@@ -4057,7 +4057,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T16.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T16.png",
         "price": "1.00"
     },
     {
@@ -4087,7 +4087,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T17.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T17.png",
         "price": "4.00"
     },
     {
@@ -4114,7 +4114,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T18.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T18.png",
         "price": "1.00"
     },
     {
@@ -4144,7 +4144,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T19.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T19.png",
         "price": "0.50"
     },
     {
@@ -4175,7 +4175,7 @@
         "set": "BNJ",
         "release": "X01",
         "sid": "T20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_SX01_T20.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/b/bnj_sx01/BNJ_SX01_T20.png",
         "price": "0.50"
     }
 ]

--- a/DB/BNJ_SX01.json
+++ b/DB/BNJ_SX01.json
@@ -23,7 +23,7 @@
         ],
         "flavor_text": "Don't be afraid. It's just a little cat call.",
         "set": "BNJ",
-        "release": "CS2019",
+        "release": "BCS2019",
         "sid": "02",
         "image": "https://en.ws-tcg.com/cardlist/cardimages/BNJ_BCS2019_02.png"
     },

--- a/DB/CCS_WX01.json
+++ b/DB/CCS_WX01.json
@@ -24,7 +24,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_001.png"
     },
     {
         "name": "Sakura: Got You Covered",
@@ -51,7 +51,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_002.png"
     },
     {
         "name": "Cardcaptor Sakura: GALE",
@@ -80,7 +80,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_003.png"
     },
     {
         "name": "Tomoyo: Enamored Friend",
@@ -109,7 +109,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_004.png"
     },
     {
         "name": "Sakura: Sudden Showers",
@@ -136,7 +136,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_005.png"
     },
     {
         "name": "Sakura: Whipping Up a Storm",
@@ -162,7 +162,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_006.png"
     },
     {
         "name": "Sakura: Dexterous",
@@ -188,7 +188,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_007.png"
     },
     {
         "name": "Sakura: Not Very Effective",
@@ -214,7 +214,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_008.png"
     },
     {
         "name": "Sakura Kinomoto",
@@ -243,7 +243,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_009.png"
     },
     {
         "name": "Sakura: Lost in the Labyrinth",
@@ -273,7 +273,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_010.png"
     },
     {
         "name": "Toya: Concerned Big Brother",
@@ -302,7 +302,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_011.png"
     },
     {
         "name": "Cardcaptor Sakura: GRAVITATION",
@@ -329,7 +329,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_012.png"
     },
     {
         "name": "Tomoyo: Ever Ready",
@@ -356,7 +356,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_013.png"
     },
     {
         "name": "Sakura: Middle School Life",
@@ -385,7 +385,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "014a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_014a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_014a.png"
     },
     {
         "name": "Sakura: Middle School Life",
@@ -414,7 +414,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "014b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_014b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_014b.png"
     },
     {
         "name": "Sakura: Middle School Life",
@@ -443,7 +443,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "014c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_014c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_014c.png"
     },
     {
         "name": "Sakura: Middle School Life",
@@ -472,7 +472,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "014d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_014d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_014d.png"
     },
     {
         "name": "Toya: Mean Big Brother",
@@ -501,7 +501,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "015a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_015a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_015a.png"
     },
     {
         "name": "Toya: Mean Big Brother",
@@ -530,7 +530,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "015b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_015b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_015b.png"
     },
     {
         "name": "Sonomi Daidouji",
@@ -558,7 +558,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_016.png"
     },
     {
         "name": "Rika Sasaki",
@@ -586,7 +586,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_017.png"
     },
     {
         "name": "Takashi Yamazaki",
@@ -614,7 +614,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_018.png"
     },
     {
         "name": "Kinomoto Family",
@@ -640,7 +640,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "019a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_019a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_019a.png"
     },
     {
         "name": "Kinomoto Family",
@@ -666,7 +666,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "019b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_019b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_019b.png"
     },
     {
         "name": "Kinomoto Family",
@@ -692,7 +692,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "019c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_019c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_019c.png"
     },
     {
         "name": "Akiho: Flower Viewing",
@@ -719,7 +719,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_020.png"
     },
     {
         "name": "Naoko: Flower Viewing",
@@ -746,7 +746,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_021.png"
     },
     {
         "name": "Sakura: Flower Viewing",
@@ -773,7 +773,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_022.png"
     },
     {
         "name": "Tomoyo: Flower Viewing",
@@ -799,7 +799,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_023.png"
     },
     {
         "name": "Chiharu Mihara",
@@ -825,7 +825,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_024.png"
     },
     {
         "name": "Syaoran: Flower Viewing",
@@ -851,7 +851,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_025.png"
     },
     {
         "name": "Sakura: Elemetary School Play",
@@ -880,7 +880,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_026.png"
     },
     {
         "name": "Speaking of Which…",
@@ -908,7 +908,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_027.png"
     },
     {
         "name": "Rare Cheesecake Recipe",
@@ -934,7 +934,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_028.png"
     },
     {
         "name": "Clear Card: GALE",
@@ -962,7 +962,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_029.png"
     },
     {
         "name": "Lunch Break",
@@ -992,7 +992,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_030.png"
     },
     {
         "name": "Flower Viewing",
@@ -1021,7 +1021,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_031.png"
     },
     {
         "name": "Release! GALE!",
@@ -1051,7 +1051,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_032.png"
     },
     {
         "name": "Syaoran Li",
@@ -1078,7 +1078,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_033.png"
     },
     {
         "name": "Cardcaptor Sakura: RECORD",
@@ -1108,7 +1108,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_034.png"
     },
     {
         "name": "Sakura: Pure White Dress",
@@ -1135,7 +1135,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_035.png"
     },
     {
         "name": "Sakura: Stunned",
@@ -1164,7 +1164,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_036.png"
     },
     {
         "name": "Syaoran: Sword Summoning",
@@ -1193,7 +1193,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_037.png"
     },
     {
         "name": "Syaoran & Sakura",
@@ -1219,7 +1219,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_038.png"
     },
     {
         "name": "Meiling Li",
@@ -1245,7 +1245,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_039.png"
     },
     {
         "name": "Sakura: Aquarium Date",
@@ -1272,7 +1272,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_040.png"
     },
     {
         "name": "Syaoran: Aquarium Date",
@@ -1299,7 +1299,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_041.png"
     },
     {
         "name": "Sakura: Befriending the Card",
@@ -1328,7 +1328,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_042.png"
     },
     {
         "name": "Syaoran",
@@ -1356,7 +1356,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_043.png"
     },
     {
         "name": "Sakura: Not a Polyglot",
@@ -1383,7 +1383,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_044.png"
     },
     {
         "name": "Syaoran: Beloved Bento",
@@ -1410,7 +1410,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_045.png"
     },
     {
         "name": "Nakuru Akizuki",
@@ -1436,7 +1436,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_046.png"
     },
     {
         "name": "Eriol Hiiragizawa",
@@ -1463,7 +1463,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_047.png"
     },
     {
         "name": "Cardcaptor Sakura: FLIGHT",
@@ -1489,7 +1489,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_048.png"
     },
     {
         "name": "Spinny",
@@ -1515,7 +1515,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_049.png"
     },
     {
         "name": "Syaoran: Ice God, Come Forth!",
@@ -1542,7 +1542,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_050.png"
     },
     {
         "name": "Kaho Mizuki",
@@ -1570,7 +1570,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_051.png"
     },
     {
         "name": "Treasured Teddy",
@@ -1598,7 +1598,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_052.png"
     },
     {
         "name": "Clear Card: RECORD",
@@ -1626,7 +1626,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_053.png"
     },
     {
         "name": "Release! RECORD!",
@@ -1655,7 +1655,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_054.png"
     },
     {
         "name": "Intertwining Hearts",
@@ -1684,7 +1684,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_055.png"
     },
     {
         "name": "Fire God, Come Forth!",
@@ -1713,7 +1713,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_056.png"
     },
     {
         "name": "Cardcaptor Sakura: REFLECT",
@@ -1743,7 +1743,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_057.png"
     },
     {
         "name": "Kero",
@@ -1772,7 +1772,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_058.png"
     },
     {
         "name": "Tomoyo",
@@ -1799,7 +1799,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_059.png"
     },
     {
         "name": "Sakura: Slip of the Tongue",
@@ -1825,7 +1825,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_060.png"
     },
     {
         "name": "Tomoyo: Best Friend",
@@ -1852,7 +1852,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_061.png"
     },
     {
         "name": "Kero: Insatiable Hunger",
@@ -1879,7 +1879,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_062.png"
     },
     {
         "name": "Cardcaptor Sakura: LUCID",
@@ -1908,7 +1908,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_063.png"
     },
     {
         "name": "Kero: Beast Mode",
@@ -1937,7 +1937,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_064.png"
     },
     {
         "name": "Sakura: Invisible Books",
@@ -1963,7 +1963,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_065.png"
     },
     {
         "name": "Sakura: In the Torrential Flame",
@@ -1991,7 +1991,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_066.png"
     },
     {
         "name": "Tomoyo: Carefree Camerawoman",
@@ -2019,7 +2019,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_067.png"
     },
     {
         "name": "Sakura: D?j? Vu",
@@ -2045,7 +2045,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_068.png"
     },
     {
         "name": "Kero: Plushie Mode",
@@ -2072,7 +2072,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_069.png"
     },
     {
         "name": "Sakura: Caught Off-Guard",
@@ -2099,7 +2099,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_070.png"
     },
     {
         "name": "Sakura: Irresistible Pull",
@@ -2128,7 +2128,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_071.png"
     },
     {
         "name": "Secure!",
@@ -2154,7 +2154,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_072.png"
     },
     {
         "name": "Clear Card: REFLECT",
@@ -2182,7 +2182,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_073.png"
     },
     {
         "name": "Release! REFLECT!",
@@ -2211,7 +2211,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_074.png"
     },
     {
         "name": "Hunger Overwhelming",
@@ -2240,7 +2240,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_075.png"
     },
     {
         "name": "Dress Designer's Delight",
@@ -2269,7 +2269,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_076.png"
     },
     {
         "name": "Cardcaptor Sakura: SIEGE",
@@ -2299,7 +2299,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_077.png"
     },
     {
         "name": "Yue: Moon Guardian",
@@ -2329,7 +2329,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_078.png"
     },
     {
         "name": "Sakura: Abashed",
@@ -2356,7 +2356,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_079.png"
     },
     {
         "name": "Akiho: Just Visiting",
@@ -2382,7 +2382,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_080.png"
     },
     {
         "name": "Yue",
@@ -2409,7 +2409,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_081.png"
     },
     {
         "name": "Yukito: Just Visiting",
@@ -2436,7 +2436,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_082.png"
     },
     {
         "name": "Sakura: Choices, Choices",
@@ -2465,7 +2465,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_083.png"
     },
     {
         "name": "Yukito: Dual Identity",
@@ -2494,7 +2494,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_084.png"
     },
     {
         "name": "Yukito & Toya",
@@ -2521,7 +2521,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_085.png"
     },
     {
         "name": "Sakura: Lunch Break",
@@ -2547,7 +2547,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_086.png"
     },
     {
         "name": "Akiho: New Transfer Student",
@@ -2574,7 +2574,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_087.png"
     },
     {
         "name": "Sakura: Hospitable",
@@ -2603,7 +2603,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_088.png"
     },
     {
         "name": "Cardcaptor Sakura: AQUA",
@@ -2629,7 +2629,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_089.png"
     },
     {
         "name": "Kaito: Warm Invitation",
@@ -2655,7 +2655,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_090.png"
     },
     {
         "name": "Momo",
@@ -2682,7 +2682,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_091.png"
     },
     {
         "name": "Sakura: A New Key",
@@ -2709,7 +2709,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_092.png"
     },
     {
         "name": "Sakura: Topsy-Turvy",
@@ -2736,7 +2736,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_093.png"
     },
     {
         "name": "Yuna D. Kaito",
@@ -2764,7 +2764,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_094.png"
     },
     {
         "name": "Kaito & Akiho",
@@ -2793,7 +2793,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_095.png"
     },
     {
         "name": "Clear Card: SIEGE",
@@ -2821,7 +2821,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_096.png"
     },
     {
         "name": "Mysterious Hooded Figure",
@@ -2847,7 +2847,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_097.png"
     },
     {
         "name": "Release! SIEGE!",
@@ -2877,7 +2877,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_098.png"
     },
     {
         "name": "Otherworldly Encounter",
@@ -2906,7 +2906,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_099.png"
     },
     {
         "name": "Birds of a Feather",
@@ -2935,7 +2935,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_100.png"
     },
     {
         "name": "Mini Sakura: School Uniform",
@@ -2964,7 +2964,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_101.png"
     },
     {
         "name": "Mini Sakura: White Dress",
@@ -2990,7 +2990,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_102.png"
     },
     {
         "name": "Mini Sakura: Pink Dress",
@@ -3016,7 +3016,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_103.png"
     },
     {
         "name": "Mini Sakura: Oriental Dress",
@@ -3042,7 +3042,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_104.png"
     },
     {
         "name": "Sakura: Amphibian Apparel",
@@ -3145,7 +3145,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T01.png"
     },
     {
         "name": "Sakura: Brimming with Butterflies",
@@ -3171,7 +3171,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T02.png"
     },
     {
         "name": "Syaoran: Wide-Eyed Wonder",
@@ -3198,7 +3198,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T03.png"
     },
     {
         "name": "Syaoran: I'll Be Back",
@@ -3227,7 +3227,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T04.png"
     },
     {
         "name": "Kero: Pretending He's a Plushie",
@@ -3254,7 +3254,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T05.png"
     },
     {
         "name": "Tomoyo: Over-Supportive Friend",
@@ -3281,7 +3281,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T06.png"
     },
     {
         "name": "Tomoyo: Ain't No Dream",
@@ -3308,7 +3308,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T07.png"
     },
     {
         "name": "Kero: Euphoria",
@@ -3335,7 +3335,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T08.png"
     },
     {
         "name": "Sakura: Athletic",
@@ -3362,7 +3362,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T09.png"
     },
     {
         "name": "Tomoyo: Dressmaker On Duty",
@@ -3388,7 +3388,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T10.png"
     },
     {
         "name": "Cardcaptor Sakura",
@@ -3415,7 +3415,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T11.png"
     },
     {
         "name": "Sakura: Key of Dreams",
@@ -3442,7 +3442,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T12.png"
     },
     {
         "name": "Tomoyo: Mesmerized",
@@ -3471,7 +3471,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T13.png"
     },
     {
         "name": "Sakura: Spiky Solution",
@@ -3499,7 +3499,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T14.png"
     },
     {
         "name": "Kero: One-Two Punch",
@@ -3527,7 +3527,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T15.png"
     },
     {
         "name": "Cardcaptor Sakura: Clear Card",
@@ -3556,7 +3556,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T16.png"
     },
     {
         "name": "Key of Dreams",
@@ -3582,7 +3582,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T17.png"
     },
     {
         "name": "Staff of Dreams",
@@ -3611,7 +3611,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T18.png"
     },
     {
         "name": "Costumed Creature",
@@ -3640,7 +3640,7 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T19.png"
     },
     {
         "name": "Cheesecake Complete!",
@@ -3669,6 +3669,6 @@
         "set": "CCS",
         "release": "X01",
         "sid": "T20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/CCS_WX01_T20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/c/ccs_wx01/CCS_WX01_T20.png"
     }
 ]

--- a/DB/DG_S03.json
+++ b/DB/DG_S03.json
@@ -23,7 +23,7 @@
         "set": "DG",
         "release": "02",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_e103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_E103.png"
     },
     {
         "name": "Raspberyl & Sapphire All Ready for Gym",
@@ -51,7 +51,7 @@
         "set": "DG",
         "release": "02",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_e104.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_E104.png"
     },
     {
         "name": "Angel Trainee Flonne",
@@ -78,7 +78,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE01.png"
     },
     {
         "name": "Petty Thief",
@@ -104,7 +104,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE02.png"
     },
     {
         "name": "Etna & Flonne",
@@ -130,7 +130,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE03.png"
     },
     {
         "name": "Flonne, the Love Maniac",
@@ -159,7 +159,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE04.png"
     },
     {
         "name": "Laharl & Flonne",
@@ -185,7 +185,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE05.png"
     },
     {
         "name": "Samurai Legend",
@@ -213,7 +213,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE06.png"
     },
     {
         "name": "Seraph Lamington",
@@ -241,7 +241,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE07.png"
     },
     {
         "name": "Even a Demon Needs Love",
@@ -270,7 +270,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE08.png"
     },
     {
         "name": "Vyers, the Dark Adonis Mid-Boss",
@@ -297,7 +297,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE09.png"
     },
     {
         "name": "Prince Laharl of the Netherworld",
@@ -324,7 +324,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE10.png"
     },
     {
         "name": "Supreme Overlord Laharl",
@@ -353,7 +353,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE11.png"
     },
     {
         "name": "Etna , the Overlord Assassin",
@@ -379,7 +379,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE12.png"
     },
     {
         "name": "Elite Red Mage",
@@ -405,7 +405,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE13.png"
     },
     {
         "name": "Super Robot Thursday",
@@ -432,7 +432,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE14.png"
     },
     {
         "name": "Captain Gordon, Defender of Earth",
@@ -460,7 +460,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE15.png"
     },
     {
         "name": "Demon Girl Etna, the Ultimate Beauty",
@@ -488,7 +488,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE16.png"
     },
     {
         "name": "Mecha-Jennifer",
@@ -514,7 +514,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE17.png"
     },
     {
         "name": "King of the Earth",
@@ -543,7 +543,7 @@
         "set": "DG",
         "release": "02",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dg_s02_te18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_s02/DG_S02_TE18.png"
     },
     {
         "name": "Fuka Kazamatsuri",
@@ -573,7 +573,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E001_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E001.png"
     },
     {
         "name": "Ｒａｓｐｂｅｒｙｌ & Flonne",
@@ -599,7 +599,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E002_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E002.png"
     },
     {
         "name": "“Devil Buster” Adell",
@@ -628,7 +628,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E003_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E003.png"
     },
     {
         "name": "Prinny X-Terminators' Leader, Fuka",
@@ -657,7 +657,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E004_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E004.png"
     },
     {
         "name": "Mystery Angel, Sicily",
@@ -683,7 +683,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E005_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E005.png"
     },
     {
         "name": "“Beliefs of a Maiden” Fuka",
@@ -712,7 +712,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E006_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E006.png"
     },
     {
         "name": "Overlord Mao",
@@ -741,7 +741,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E007_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E007.png"
     },
     {
         "name": "Asuka Cranekicker",
@@ -767,7 +767,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E008_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E008.png"
     },
     {
         "name": "“Younger Sister Aura” Sicily",
@@ -794,7 +794,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E009_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E009.png"
     },
     {
         "name": "Death Emizel",
@@ -823,7 +823,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E010_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E010.png"
     },
     {
         "name": "Kyoko Needleworker",
@@ -849,7 +849,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E011_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E011.png"
     },
     {
         "name": "Childhood Friend Raspberyl",
@@ -875,7 +875,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E012_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E012.png"
     },
     {
         "name": "Fallen Angel Flonne",
@@ -904,7 +904,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E013_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E013.png"
     },
     {
         "name": "Salvatore the Magnificent",
@@ -932,7 +932,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E014_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E014.png"
     },
     {
         "name": "Legendary Chief Graduate, Beryl",
@@ -961,7 +961,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E015_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E015.png"
     },
     {
         "name": "Overlord Laharl",
@@ -990,7 +990,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E016_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E016.png"
     },
     {
         "name": "Netherworld Honor Student, Mao",
@@ -1016,7 +1016,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E017_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E017.png"
     },
     {
         "name": "“Big Sis” Fuka",
@@ -1043,7 +1043,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E018_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E018.png"
     },
     {
         "name": "Pampered Child, Emizel",
@@ -1069,7 +1069,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E019_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E019.png"
     },
     {
         "name": "Special Assassination Task Force Leader, Emizel",
@@ -1095,7 +1095,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E020_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E020.png"
     },
     {
         "name": "Girl in a Prinny Cap, Fuka",
@@ -1121,7 +1121,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E021_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E021.png"
     },
     {
         "name": "Like a Picnic, Sicily",
@@ -1148,7 +1148,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E022_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E022.png"
     },
     {
         "name": "“Overlord's Spot” Sicily",
@@ -1174,7 +1174,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E023_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E023.png"
     },
     {
         "name": "Middle Schooler Who Fell to Hades, Fuka",
@@ -1200,7 +1200,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E024_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E024.png"
     },
     {
         "name": "Netherworld President Jr, Emizel",
@@ -1229,7 +1229,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E025_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E025.png"
     },
     {
         "name": "Package from Celestia, Sicily",
@@ -1255,7 +1255,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E026_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E026.png"
     },
     {
         "name": "Adell & Rozalin",
@@ -1283,7 +1283,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E027_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E027.png"
     },
     {
         "name": "President Raspberyl",
@@ -1312,7 +1312,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E028_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E028.png"
     },
     {
         "name": "“Overlord” Sicily",
@@ -1340,7 +1340,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E029_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E029.png"
     },
     {
         "name": "Mao & Raspberyl",
@@ -1366,7 +1366,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E030_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E030.png"
     },
     {
         "name": "Delinquent Student, Raspberyl",
@@ -1392,7 +1392,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E031_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E031.png"
     },
     {
         "name": "Sexy Demon Wish, Hanako",
@@ -1418,7 +1418,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E032_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E032.png"
     },
     {
         "name": "Majin Etna",
@@ -1444,7 +1444,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E033_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E033.png"
     },
     {
         "name": "Geoffrey",
@@ -1470,7 +1470,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E034_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E034.png"
     },
     {
         "name": "Battle Maniac, Adell",
@@ -1498,7 +1498,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E035_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E035.png"
     },
     {
         "name": "Overthrow! God of All Overlords!",
@@ -1524,7 +1524,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E036_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E036.png"
     },
     {
         "name": "Strongest Overlord",
@@ -1550,7 +1550,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E037_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E037.png"
     },
     {
         "name": "Important… Allies?",
@@ -1576,7 +1576,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E038_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E038.png"
     },
     {
         "name": "Battle Arena Begins!",
@@ -1602,7 +1602,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E039_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E039.png"
     },
     {
         "name": "And trust this!",
@@ -1632,7 +1632,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E040_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E040.png"
     },
     {
         "name": "Prinny Wars",
@@ -1661,7 +1661,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E041_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E041.png"
     },
     {
         "name": "To my lab---!!",
@@ -1690,7 +1690,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E042_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E042.png"
     },
     {
         "name": "And have become legend……",
@@ -1719,7 +1719,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E043_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E043.png"
     },
     {
         "name": "Vow of the Phoenix",
@@ -1749,7 +1749,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E044_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E044.png"
     },
     {
         "name": "Birth of a New Overlord",
@@ -1779,7 +1779,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E045_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E045.png"
     },
     {
         "name": "“Aloof Majin” Etna",
@@ -1808,7 +1808,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E046_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E046.png"
     },
     {
         "name": "Unemployed Etna",
@@ -1837,7 +1837,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E047_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E047.png"
     },
     {
         "name": "Tyrant Etna",
@@ -1866,7 +1866,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E048_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E048.png"
     },
     {
         "name": "Evangelist of Love, Flonne",
@@ -1892,7 +1892,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E049_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E049.png"
     },
     {
         "name": "Thief Angel, Artina",
@@ -1918,7 +1918,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E050_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E050.png"
     },
     {
         "name": "Archangel, Flonne",
@@ -1947,7 +1947,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E051_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E051.png"
     },
     {
         "name": "Cute Little Demon, Etna",
@@ -1976,7 +1976,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E052_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E052.png"
     },
     {
         "name": "Awakened Angel, Pure Flonne",
@@ -2004,7 +2004,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E053_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E053.png"
     },
     {
         "name": "Pringer X",
@@ -2034,7 +2034,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E054_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E054.png"
     },
     {
         "name": "Big Sis Prinny",
@@ -2061,7 +2061,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E055_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E055.png"
     },
     {
         "name": "Laharl & Etna",
@@ -2089,7 +2089,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E056_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E056.png"
     },
     {
         "name": "Super Alloy Great Flonzor X",
@@ -2117,7 +2117,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E057_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E057.png"
     },
     {
         "name": "Young Etna",
@@ -2144,7 +2144,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E058_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E058.png"
     },
     {
         "name": "Angel Trainee Flonne",
@@ -2171,7 +2171,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E059_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E059.png"
     },
     {
         "name": "Ordinary Cleric",
@@ -2197,7 +2197,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E060_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E060.png"
     },
     {
         "name": "Petty Thief",
@@ -2223,7 +2223,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E061_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E061.png"
     },
     {
         "name": "Flonne, the Love Maniac",
@@ -2252,7 +2252,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E062_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E062.png"
     },
     {
         "name": "Supreme Overlord Baal",
@@ -2280,7 +2280,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E063_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E063.png"
     },
     {
         "name": "Nurse, Altina",
@@ -2306,7 +2306,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E064_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E064.png"
     },
     {
         "name": "Judge Nemo",
@@ -2332,7 +2332,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E065_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E065.png"
     },
     {
         "name": "Nice-Bodied Etna",
@@ -2358,7 +2358,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E066_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E066.png"
     },
     {
         "name": "Mystery Demon, Xenolith",
@@ -2384,7 +2384,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E067_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E067.png"
     },
     {
         "name": "Player 2, Etna",
@@ -2410,7 +2410,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E068_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E068.png"
     },
     {
         "name": "Samurai Legend",
@@ -2438,7 +2438,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E069_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E069.png"
     },
     {
         "name": "Trespasser from Celestia, Artina",
@@ -2465,7 +2465,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E070_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E070.png"
     },
     {
         "name": "Unkind Demon, Etna",
@@ -2492,7 +2492,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E071_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E071.png"
     },
     {
         "name": "Elusive, Artina",
@@ -2521,7 +2521,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E072_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E072.png"
     },
     {
         "name": "“Out-of-control Artifact” Xenolith",
@@ -2550,7 +2550,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E073_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E073.png"
     },
     {
         "name": "Dumbfounded Etna",
@@ -2578,7 +2578,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E074_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E074.png"
     },
     {
         "name": "Prinny Squad",
@@ -2605,7 +2605,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E075_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E075.png"
     },
     {
         "name": "Genius Magic Knight",
@@ -2631,7 +2631,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E076_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E076.png"
     },
     {
         "name": "Etna & Flonne",
@@ -2657,7 +2657,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E077_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E077.png"
     },
     {
         "name": "Space Detective Guardian Flonne",
@@ -2684,7 +2684,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E078_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E078.png"
     },
     {
         "name": "Helplessly Useless Archer",
@@ -2712,7 +2712,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E079_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E079.png"
     },
     {
         "name": "Seraph Lamington",
@@ -2740,7 +2740,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E080_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E080.png"
     },
     {
         "name": "Winged Slayer",
@@ -2767,7 +2767,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E081_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E081.png"
     },
     {
         "name": "They are all mine",
@@ -2793,7 +2793,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E082_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E082.png"
     },
     {
         "name": "Conspiracy of the School Board",
@@ -2819,7 +2819,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E083_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E083.png"
     },
     {
         "name": "Bow Revival!",
@@ -2845,7 +2845,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E084_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E084.png"
     },
     {
         "name": "Supreme Overlord Girl",
@@ -2874,7 +2874,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E085_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E085.png"
     },
     {
         "name": "Siblings' Conversation",
@@ -2903,7 +2903,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E086_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E086.png"
     },
     {
         "name": "Even a Demon Needs Love",
@@ -2932,7 +2932,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E087_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E087.png"
     },
     {
         "name": "Assassin from Celestia",
@@ -2961,7 +2961,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E088_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E088.png"
     },
     {
         "name": "Demon and Angel Bond",
@@ -2990,7 +2990,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E089_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E089.png"
     },
     {
         "name": "Most Evil Overlord, Laharl",
@@ -3019,7 +3019,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E090_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E090.png"
     },
     {
         "name": "Laharl & Mao",
@@ -3045,7 +3045,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E091_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E091.png"
     },
     {
         "name": "“Power of Sardines” Valvatorez",
@@ -3071,7 +3071,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E092_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E092.png"
     },
     {
         "name": "Werewolf Butler, Fenrich",
@@ -3097,7 +3097,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E093_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E093.png"
     },
     {
         "name": "Reborn Krichevskoy",
@@ -3152,7 +3152,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E095_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E095.png"
     },
     {
         "name": "Tyrant, Valvatorez",
@@ -3181,7 +3181,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E096_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E096.png"
     },
     {
         "name": "Likes Superhero Shows, Flonne",
@@ -3210,7 +3210,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E097_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E097.png"
     },
     {
         "name": "Supreme Overlord Laharl",
@@ -3239,7 +3239,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E098_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E098.png"
     },
     {
         "name": "Former Angel Flonne",
@@ -3266,7 +3266,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E099_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E099.png"
     },
     {
         "name": "“Dark Adonis”Mid-Boss",
@@ -3294,7 +3294,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E100_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E100.png"
     },
     {
         "name": "Caretaker of Prinnies, Fenrich",
@@ -3321,7 +3321,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E101_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E101.png"
     },
     {
         "name": "Trainer of Prinnies, Valvatorez",
@@ -3348,7 +3348,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E102_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E102.png"
     },
     {
         "name": "Self-centered Overlord, Laharl",
@@ -3374,7 +3374,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E103_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E103.png"
     },
     {
         "name": "Absolute Loyalty, Fenrich",
@@ -3400,7 +3400,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E104_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E104.png"
     },
     {
         "name": "Sharp Criticism, Etna",
@@ -3426,7 +3426,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E105_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E105.png"
     },
     {
         "name": "Rebel Against God, Valvatorez",
@@ -3456,7 +3456,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E106_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E106.png"
     },
     {
         "name": "Master Big Star",
@@ -3482,7 +3482,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E107_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E107.png"
     },
     {
         "name": "Fake Laharl",
@@ -3508,7 +3508,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E108_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E108.png"
     },
     {
         "name": "Vyers, the Dark Adonis Mid-Boss",
@@ -3535,7 +3535,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E109_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E109.png"
     },
     {
         "name": "Prince Laharl of the Netherworld",
@@ -3562,7 +3562,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E110_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E110.png"
     },
     {
         "name": "Defender of Earth, Kurtis",
@@ -3590,7 +3590,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E111_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E111.png"
     },
     {
         "name": "Overlord Laharl and his Vassal Etna",
@@ -3616,7 +3616,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E112_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E112.png"
     },
     {
         "name": "“Busty” Girl Laharl",
@@ -3642,7 +3642,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E113_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E113.png"
     },
     {
         "name": "“Overlord's Dignity” Laharl",
@@ -3669,7 +3669,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E114_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E114.png"
     },
     {
         "name": "“Sadistic” Etna",
@@ -3696,7 +3696,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E115_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E115.png"
     },
     {
         "name": "My Lord's Advisor, Fenrich",
@@ -3724,7 +3724,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E116_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E116.png"
     },
     {
         "name": "New Overlord, Laharl",
@@ -3752,7 +3752,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E117_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E117.png"
     },
     {
         "name": "Demon Girl Etna, the Ultimate Beauty",
@@ -3780,7 +3780,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E118_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E118.png"
     },
     {
         "name": "Demon Awaiting Instructions, Barbara",
@@ -3808,7 +3808,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E119_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E119.png"
     },
     {
         "name": "“Strongest In the World” Etna",
@@ -3834,7 +3834,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E120",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E120_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E120.png"
     },
     {
         "name": "Elite Red Mage",
@@ -3860,7 +3860,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E121_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E121.png"
     },
     {
         "name": "Super Robot Thursday",
@@ -3887,7 +3887,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E122_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E122.png"
     },
     {
         "name": "Captain Gordon, Defender of Earth",
@@ -3915,7 +3915,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E123_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E123.png"
     },
     {
         "name": "Jennifer, Defender of Earth's Assistant",
@@ -3943,7 +3943,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E124",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E124_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E124.png"
     },
     {
         "name": "Dissection Experiment",
@@ -3969,7 +3969,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E125",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E125_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E125.png"
     },
     {
         "name": "The Dark Assembly",
@@ -3995,7 +3995,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E126",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E126_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E126.png"
     },
     {
         "name": "Back Together",
@@ -4021,7 +4021,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E127",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E127_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E127.png"
     },
     {
         "name": "Coming Up Next",
@@ -4049,7 +4049,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E128",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E128_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E128.png"
     },
     {
         "name": "King of the Earth",
@@ -4078,7 +4078,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E129",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E129_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E129.png"
     },
     {
         "name": "Overlord Passing Through",
@@ -4107,7 +4107,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E130",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E130_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E130.png"
     },
     {
         "name": "Vow of the Moon",
@@ -4136,7 +4136,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E131",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E131_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E131.png"
     },
     {
         "name": "Aspiring Final Boss, Desco",
@@ -4163,7 +4163,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E132",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E132_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E132.png"
     },
     {
         "name": "“Final Weapon Girl ＤＥＳＣＯ”",
@@ -4193,7 +4193,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E133",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E133_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E133.png"
     },
     {
         "name": "Sapphire Rhodonite",
@@ -4220,7 +4220,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E134",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E134_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E134.png"
     },
     {
         "name": "Final Boss Training, Desco",
@@ -4249,7 +4249,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E135",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E135_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E135.png"
     },
     {
         "name": "“Ding-Dong-Ditches” Axel",
@@ -4275,7 +4275,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E136",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E136_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E136.png"
     },
     {
         "name": "63nd Netherworld President,Axel",
@@ -4301,7 +4301,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E137",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E137_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E137.png"
     },
     {
         "name": "Fancy Dreamy, Desco",
@@ -4327,7 +4327,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E138",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E138_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E138.png"
     },
     {
         "name": "Raspberyl & Sapphire",
@@ -4353,7 +4353,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E139",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E139_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E139.png"
     },
     {
         "name": "Almaz Von Almandine Adamant",
@@ -4380,7 +4380,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E140",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E140_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E140.png"
     },
     {
         "name": "Secretive Teacher, Mr. Champloo",
@@ -4406,7 +4406,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E141",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E141_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E141.png"
     },
     {
         "name": "Sheltered Lady, Rozalin",
@@ -4433,7 +4433,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E142",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E142_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E142.png"
     },
     {
         "name": "Obstinate Rozalin",
@@ -4460,7 +4460,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E143",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E143_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E143.png"
     },
     {
         "name": "Girl Ninja, Yukimaru",
@@ -4486,7 +4486,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E144",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E144_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E144.png"
     },
     {
         "name": "Unusual Frog, Tink",
@@ -4515,7 +4515,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E145",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E145_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E145.png"
     },
     {
         "name": "Rozalin & Sapphire",
@@ -4543,7 +4543,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E146",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E146_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E146.png"
     },
     {
         "name": "Killing Machine, Sapphire",
@@ -4572,7 +4572,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E147",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E147_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E147.png"
     },
     {
         "name": "Overlord's Daughter, Rozalin",
@@ -4601,7 +4601,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E148",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E148_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E148.png"
     },
     {
         "name": "Master of the Forbidden Chamber, Desco",
@@ -4627,7 +4627,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E149",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E149_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E149.png"
     },
     {
         "name": "Hades' Warden, Axel",
@@ -4653,7 +4653,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E150",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E150_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E150.png"
     },
     {
         "name": "“Perfect Version” DES X",
@@ -4681,7 +4681,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E151",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E151_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E151.png"
     },
     {
         "name": "Robust Princess, Sapphire",
@@ -4707,7 +4707,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E152",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E152_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E152.png"
     },
     {
         "name": "Rozalin's Servant, Taro",
@@ -4734,7 +4734,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E153",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E153_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E153.png"
     },
     {
         "name": "Hero, Almaz",
@@ -4761,7 +4761,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E154",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E154_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E154.png"
     },
     {
         "name": "Dark Hero, Axel",
@@ -4789,7 +4789,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E155",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E155_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E155.png"
     },
     {
         "name": "Super Hero, Aurum",
@@ -4817,7 +4817,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E156",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E156_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E156.png"
     },
     {
         "name": "Home Economics Teacher, Mr. Champloo",
@@ -4845,7 +4845,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E157",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E157_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E157.png"
     },
     {
         "name": "Cell Phone",
@@ -4871,7 +4871,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E158",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E158_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E158.png"
     },
     {
         "name": "Broadcast Incident",
@@ -4897,7 +4897,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E159",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E159_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E159.png"
     },
     {
         "name": "Pudding Mountain",
@@ -4923,7 +4923,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E160",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E160_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E160.png"
     },
     {
         "name": "Dark Hero",
@@ -4949,7 +4949,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E161",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E161_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E161.png"
     },
     {
         "name": "Newlywed Queen",
@@ -4978,7 +4978,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E162",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E162_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E162.png"
     },
     {
         "name": "Final Weapon Appears",
@@ -5007,7 +5007,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E163",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E163_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E163.png"
     },
     {
         "name": "Overlord Summon",
@@ -5036,7 +5036,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E164",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E164_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E164.png"
     },
     {
         "name": "Overlord Almaz",
@@ -5065,7 +5065,7 @@
         "set": "DG",
         "release": "03",
         "sid": "E165",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_E165_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_E165.png"
     },
     {
         "name": "Prinny Squad",
@@ -5092,7 +5092,7 @@
         "set": "DG",
         "release": "03",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_PE01_PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_PE01.png"
     },
     {
         "name": "The Weakest Protaganist in History, Prinny",
@@ -5118,7 +5118,7 @@
         "set": "DG",
         "release": "03",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_PE02_PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_PE02.png"
     },
     {
         "name": "Disgaea D2",
@@ -5144,7 +5144,7 @@
         "set": "DG",
         "release": "03",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_PE03.png"
     },
     {
         "name": "Laharl & Flonne",
@@ -5170,7 +5170,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE01_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE01.png"
     },
     {
         "name": "Prinny Squad",
@@ -5197,7 +5197,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE02_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE02.png"
     },
     {
         "name": "Fallen Angel of Love. Flonne",
@@ -5223,7 +5223,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE03_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE03.png"
     },
     {
         "name": "“Pinch Revival” Pure Flonne",
@@ -5251,7 +5251,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE04_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE04.png"
     },
     {
         "name": "Raspberyl & Sapphire All Ready for Gym",
@@ -5279,7 +5279,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE05_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE05.png"
     },
     {
         "name": "Netherworld Wrapped in Love",
@@ -5307,7 +5307,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE06_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE06.png"
     },
     {
         "name": "Overlord's Vassal, Etna",
@@ -5334,7 +5334,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE07_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE07.png"
     },
     {
         "name": "Aesthetics of Evil, Valvatorez",
@@ -5360,7 +5360,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE08_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE08.png"
     },
     {
         "name": "Son of the Previous Overlord, Laharl",
@@ -5390,7 +5390,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE09_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE09.png"
     },
     {
         "name": "Etna, the Overlord Assassin",
@@ -5416,7 +5416,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE10_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE10.png"
     },
     {
         "name": "“Angel of Avarice” Vulcanus (?)",
@@ -5442,7 +5442,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE11_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE11.png"
     },
     {
         "name": "Reborn Krichevskoy",
@@ -5469,7 +5469,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE12_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE12.png"
     },
     {
         "name": "Girl Laharl",
@@ -5495,7 +5495,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE13_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE13.png"
     },
     {
         "name": "President Overlord Laharl",
@@ -5521,7 +5521,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE14_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE14.png"
     },
     {
         "name": "Proud Demon, Valvatorez",
@@ -5549,7 +5549,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE15_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE15.png"
     },
     {
         "name": "Idol Overlord, Girl Laharl",
@@ -5577,7 +5577,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE16_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE16.png"
     },
     {
         "name": "Mecha-Jennifer",
@@ -5603,7 +5603,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE17_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE17.png"
     },
     {
         "name": "Ties of \"Camaraderie\"",
@@ -5632,7 +5632,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE18_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE18.png"
     },
     {
         "name": "Eternal Idol",
@@ -5661,7 +5661,7 @@
         "set": "DG",
         "release": "03",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE19_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE19.png"
     },
     {
         "name": "Overlord Zenon Defeated!!",
@@ -5690,6 +5690,6 @@
         "set": "DG",
         "release": "03",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_DG_EN_S03_TE20_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/d/dg_en_s03/DG_EN_S03_TE20.png"
     }
 ]

--- a/DB/FJM_W65.json
+++ b/DB/FJM_W65.json
@@ -24,7 +24,7 @@
         "set": "F35",
         "release": "65",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/F35_W65_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/f35_w65/F35_W65_E034.png"
     },
     {
         "name": "Acting Manager's Aide, Isuzu",
@@ -55,7 +55,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E025.png"
     },
     {
         "name": "First Princess of Maple Land, Latifah",
@@ -84,7 +84,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E026.png"
     },
     {
         "name": "Fairy of Water, Muse",
@@ -112,7 +112,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E029.png"
     },
     {
         "name": "First Time at a School Festival, Isuzu & Latifah",
@@ -141,7 +141,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E032.png"
     },
     {
         "name": "The Four Girls of \"Elementario\", Muse/Salama/Sylphy/Kobory",
@@ -171,7 +171,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E036.png"
     },
     {
         "name": "Welcome to Amagi Brilliant Park!",
@@ -200,7 +200,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E040.png"
     },
     {
         "name": "The AmaBri Triumvirate, Moffle & Macaron & Tiramy",
@@ -228,7 +228,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_E108.png"
     },
     {
         "name": "Duty of the Two, Isuzu & Seiya",
@@ -255,7 +255,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_TE07.png"
     },
     {
         "name": "Maple Kitchen, Latifah",
@@ -282,7 +282,7 @@
         "set": "Fab",
         "release": "65",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fab_W65_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fab_w65/Fab_W65_TE08.png"
     },
     {
         "name": "Girl of Healing, Asia",
@@ -313,7 +313,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E043.png"
     },
     {
         "name": "Red-Haired Ruin Princess, Rias",
@@ -341,7 +341,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E044.png"
     },
     {
         "name": "The Ultimate S, Akeno",
@@ -369,7 +369,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E048.png"
     },
     {
         "name": "Reward Time, Rias",
@@ -397,7 +397,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E049.png"
     },
     {
         "name": "Devilish Smile, Rias",
@@ -427,7 +427,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E052.png"
     },
     {
         "name": "Cross-Dressing Half-Vampire, Gasper",
@@ -455,7 +455,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E054.png"
     },
     {
         "name": "Quiet White Cat, Koneko",
@@ -483,7 +483,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E056.png"
     },
     {
         "name": "Silver-Haired Former Valkyrie, Rossweisse",
@@ -513,7 +513,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E059.png"
     },
     {
         "name": "Master-and-Servant Relationship, Rias & Issei",
@@ -540,7 +540,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E060.png"
     },
     {
         "name": "Gigantis Dragon's Contractor, Asia",
@@ -568,7 +568,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E062.png"
     },
     {
         "name": "Holy Sword User, Xenovia",
@@ -596,7 +596,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E064.png"
     },
     {
         "name": "Swift Sword Skills, Yuuto",
@@ -625,7 +625,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E065.png"
     },
     {
         "name": "Believing in the Same Dream",
@@ -651,7 +651,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E068.png"
     },
     {
         "name": "First Friend",
@@ -681,7 +681,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E071.png"
     },
     {
         "name": "Goddess in Swimwear, Rias",
@@ -711,7 +711,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_E110.png"
     },
     {
         "name": "High-Class Charms, Rias",
@@ -738,7 +738,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_TE09.png"
     },
     {
         "name": "Occult Research Club Head, Rias",
@@ -765,7 +765,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_TE10.png"
     },
     {
         "name": "A Voice Heard",
@@ -794,7 +794,7 @@
         "set": "Fdd",
         "release": "65",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdd_W65_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdd_w65/Fdd_W65_TE13.png"
     },
     {
         "name": "Insane and Beautiful〈Nightmare〉, Kurumi",
@@ -824,7 +824,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E074.png"
     },
     {
         "name": "White-Winged〈Angel〉, Origami",
@@ -851,7 +851,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E076.png"
     },
     {
         "name": "Elegant Clockwork, Kurumi",
@@ -879,7 +879,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E077.png"
     },
     {
         "name": "Pure 〈Princess〉, Touka",
@@ -909,7 +909,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E080.png"
     },
     {
         "name": "〈Ifrit〉of Burning Affection, Kotori",
@@ -936,7 +936,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E083.png"
     },
     {
         "name": "Timid 〈Hermit〉, Yoshino",
@@ -963,7 +963,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E086.png"
     },
     {
         "name": "〈Diva〉of Temptation, Miku",
@@ -994,7 +994,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E088.png"
     },
     {
         "name": "〈Berserk〉of the Whirlwind, Kaguya & Yuzuru",
@@ -1022,7 +1022,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E091.png"
     },
     {
         "name": "Savior of the Girls' Minds, Shidou",
@@ -1049,7 +1049,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E093.png"
     },
     {
         "name": "Saddled with the Past, Origami",
@@ -1075,7 +1075,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E094.png"
     },
     {
         "name": "Demon King's Love",
@@ -1101,7 +1101,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E099.png"
     },
     {
         "name": "Journey to the Afterlife",
@@ -1131,7 +1131,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E101.png"
     },
     {
         "name": "Attack of Steel",
@@ -1160,7 +1160,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E103.png"
     },
     {
         "name": "Maids of Temptation, Origami & Kurumi",
@@ -1189,7 +1189,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_E113.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_E113.png"
     },
     {
         "name": "Mysterious Girl, Touka",
@@ -1217,7 +1217,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_TE16.png"
     },
     {
         "name": "A Cute Side, Kurumi",
@@ -1245,7 +1245,7 @@
         "set": "Fdl",
         "release": "65",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdl_W65_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdi_w65/Fdl_W65_TE17.png"
     },
     {
         "name": "Journey to Find \"Relics of a Legendary Hero\", Ryner & Ferris",
@@ -1273,7 +1273,7 @@
         "set": "Fdy",
         "release": "65",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fdy_W65_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fdy_w65/Fdy_W65_E035.png"
     },
     {
         "name": "High School Girl from Jindai High, Kaname",
@@ -1300,7 +1300,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E023.png"
     },
     {
         "name": "Tuatha de Danaan's Captain, Teresa",
@@ -1330,7 +1330,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E028.png"
     },
     {
         "name": "Call Sign Urzu-7, Sousuke",
@@ -1357,7 +1357,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E030.png"
     },
     {
         "name": "ARX-8 Laevatein",
@@ -1387,7 +1387,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E031.png"
     },
     {
         "name": "Beginning of the Battle",
@@ -1416,7 +1416,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E041.png"
     },
     {
         "name": "Stylish Getup, Bonta-kun",
@@ -1443,7 +1443,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_E107.png"
     },
     {
         "name": "Stand by Me Always, Sousuke & Kaname",
@@ -1470,7 +1470,7 @@
         "set": "Ffp",
         "release": "65",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ffp_W65_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ffp_w65/Ffp_W65_TE02.png"
     },
     {
         "name": "Coffin-Carrying Wizard, Chaika",
@@ -1498,7 +1498,7 @@
         "set": "Fhc",
         "release": "65",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fhc_W65_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fhc_w65/Fhc_W65_E090.png"
     },
     {
         "name": "Sibling Affection, Suzuka",
@@ -1526,7 +1526,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E072.png"
     },
     {
         "name": "Towano Chikai's Rival, Mai",
@@ -1556,7 +1556,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E082.png"
     },
     {
         "name": "Interview for Valentine? Suzuka",
@@ -1584,7 +1584,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E085.png"
     },
     {
         "name": "Blushing Younger Sister, Suzuka",
@@ -1612,7 +1612,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E087.png"
     },
     {
         "name": "Illustrator from United Kingdom, Ahegao W Peace Sensei",
@@ -1641,7 +1641,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E096.png"
     },
     {
         "name": "Love Story of the \"Princess\"",
@@ -1671,7 +1671,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E105.png"
     },
     {
         "name": "Younger-Sister-Style Voice, Sakura",
@@ -1698,7 +1698,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_E111.png"
     },
     {
         "name": "Mai & Ahegao W Peace Sensei in Uniform",
@@ -1726,7 +1726,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_TE15.png"
     },
     {
         "name": "Dangerous Younger Sister, Suzuka",
@@ -1755,7 +1755,7 @@
         "set": "Fii",
         "release": "65",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fii_W65_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fii_w65/Fii_W65_TE19.png"
     },
     {
         "name": "Magical Cannon Swordsman-in-Training, Misora",
@@ -1784,7 +1784,7 @@
         "set": "Fkm",
         "release": "65",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkm_W65_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkm_w65/Fkm_W65_E095.png"
     },
     {
         "name": "Ice Witch, Aliceliese",
@@ -1811,7 +1811,7 @@
         "set": "Fks",
         "release": "65",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fks_W65_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fks_w65/Fks_W65_E015.png"
     },
     {
         "name": "Tsundere Magical Arms Girl, Haruna",
@@ -1841,7 +1841,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E002.png"
     },
     {
         "name": "Silver-Haired Necromancer, Eu",
@@ -1869,7 +1869,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E003.png"
     },
     {
         "name": "Many Different Festivals, Eu",
@@ -1896,7 +1896,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E005.png"
     },
     {
         "name": "Vampire Ninja, Sera",
@@ -1923,7 +1923,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E006.png"
     },
     {
         "name": "Healthy Outdoorsy Girl, Tomonori",
@@ -1952,7 +1952,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E007.png"
     },
     {
         "name": "Broken Heart Magnum, Haruna",
@@ -1979,7 +1979,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E008.png"
     },
     {
         "name": "Ideal Way to Awake, Sera",
@@ -2008,7 +2008,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E011.png"
     },
     {
         "name": "Wide-Open Shirt, Eu",
@@ -2039,7 +2039,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E012.png"
     },
     {
         "name": "Top Student of the Academic Year, Taeko",
@@ -2066,7 +2066,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E014.png"
     },
     {
         "name": "Creepy in a Cute Way, Ayumu",
@@ -2093,7 +2093,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E016.png"
     },
     {
         "name": "Dual-Personality Vampire Ninja, Saras",
@@ -2120,7 +2120,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E018.png"
     },
     {
         "name": "No Coming in Between",
@@ -2146,7 +2146,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E019.png"
     },
     {
         "name": "Absurd Daily Life",
@@ -2176,7 +2176,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E020.png"
     },
     {
         "name": "Solid Situation Panic",
@@ -2206,7 +2206,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_E021.png"
     },
     {
         "name": "In Charge of Year Refrain's Rising Class, Great Teacher",
@@ -2236,7 +2236,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_PE02.png"
     },
     {
         "name": "Troubled Expression, Eu",
@@ -2264,7 +2264,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_TE01.png"
     },
     {
         "name": "Year Refrain's Rising Class, Haruna",
@@ -2293,7 +2293,7 @@
         "set": "Fkz",
         "release": "65",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fkz_W65_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fkz_w65/Fkz_W65_TE05.png"
     },
     {
         "name": "Devoted Magician, Yuna",
@@ -2321,7 +2321,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E024.png"
     },
     {
         "name": "Master of Swordsmanship, Rin",
@@ -2348,7 +2348,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E027.png"
     },
     {
         "name": "Noble Young Woman, Kuriko",
@@ -2378,7 +2378,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E033.png"
     },
     {
         "name": "Hidden Qualities, Kazuki",
@@ -2406,7 +2406,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E038.png"
     },
     {
         "name": "Secrets Inherited from Mother to Child",
@@ -2435,7 +2435,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E039.png"
     },
     {
         "name": "A Moment at the Hot Springs, Yuna & Kuriko & Rin",
@@ -2462,7 +2462,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_E109.png"
     },
     {
         "name": "Heart Magic, Yuna",
@@ -2489,7 +2489,7 @@
         "set": "Fmr",
         "release": "65",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fmr_W65_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fmr_w65/Fmr_W65_TE04.png"
     },
     {
         "name": "Hero's Mom, Mamako",
@@ -2519,7 +2519,7 @@
         "set": "Fos",
         "release": "65",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fos_W65_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fos_w65/Fos_W65_E037.png"
     },
     {
         "name": "Nation Unified by Force, Nobuna",
@@ -2547,7 +2547,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E001.png"
     },
     {
         "name": "Frail Exorcist, Hanbei",
@@ -2575,7 +2575,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E004.png"
     },
     {
         "name": "Queen of Zipang, Nobuna",
@@ -2602,7 +2602,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E009.png"
     },
     {
         "name": "Turbulent Times, Nobuna",
@@ -2632,7 +2632,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E010.png"
     },
     {
         "name": "Center of the Universe, Masamune",
@@ -2659,7 +2659,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E013.png"
     },
     {
         "name": "One Who Fulfils Ambitions",
@@ -2689,7 +2689,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E022.png"
     },
     {
         "name": "Beautiful Swordsman, Mitsuhide",
@@ -2717,7 +2717,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_E106.png"
     },
     {
         "name": "Burdened, Nobuna",
@@ -2744,7 +2744,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_TE03.png"
     },
     {
         "name": "Head of the Oda Family, Nobuna",
@@ -2774,7 +2774,7 @@
         "set": "Foy",
         "release": "65",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Foy_W65_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/foy_w65/Foy_W65_TE06.png"
     },
     {
         "name": "Inherited Magic Talent, Sistine",
@@ -2801,7 +2801,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E073.png"
     },
     {
         "name": "Gentle Smile, Rumia",
@@ -2828,7 +2828,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E075.png"
     },
     {
         "name": "Under One Roof, Rumia & Sistine",
@@ -2855,7 +2855,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E078.png"
     },
     {
         "name": "Unique Mage Corps Member, Re=L",
@@ -2883,7 +2883,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E079.png"
     },
     {
         "name": "Kindness and Strength, Rumia",
@@ -2914,7 +2914,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E081.png"
     },
     {
         "name": "Instantaneous Decision, Glenn",
@@ -2941,7 +2941,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E084.png"
     },
     {
         "name": "Pure White Dress, Sistine",
@@ -2971,7 +2971,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E089.png"
     },
     {
         "name": "Twinkling of the Star, Albert",
@@ -2998,7 +2998,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E092.png"
     },
     {
         "name": "Messing Around, Rumia & Sistine",
@@ -3027,7 +3027,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E097.png"
     },
     {
         "name": "The Greatest Mage of the Continent, Celica",
@@ -3057,7 +3057,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E098.png"
     },
     {
         "name": "Black Magic of Destruction",
@@ -3083,7 +3083,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E100.png"
     },
     {
         "name": "Eden of Everlasting Summer",
@@ -3112,7 +3112,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E102.png"
     },
     {
         "name": "Not Wanting to Lose Precious Things",
@@ -3142,7 +3142,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E104.png"
     },
     {
         "name": "Not That Bad of a Situation, Rumia & Re=L",
@@ -3168,7 +3168,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_E112.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_E112PR.png"
     },
     {
         "name": "Mind Made Up, Sistine",
@@ -3198,7 +3198,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_TE18.png"
     },
     {
         "name": "Silver Key",
@@ -3227,7 +3227,7 @@
         "set": "Fra",
         "release": "65",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fra_W65_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fra_w65/Fra_W65_TE20.png"
     },
     {
         "name": "Hekiyou Academy Student Council Treasurer, Mafuyu",
@@ -3255,7 +3255,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E042.png"
     },
     {
         "name": "Hekiyou Academy Student Council President, Kurimu",
@@ -3283,7 +3283,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E045.png"
     },
     {
         "name": "Absolute God, Kurimu",
@@ -3311,7 +3311,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E047.png"
     },
     {
         "name": "Hekiyou Academy Student Council Vice President, Minatsu",
@@ -3341,7 +3341,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E050.png"
     },
     {
         "name": "Hekiyou Academy Student Council Secretary, Chizuru",
@@ -3371,7 +3371,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E051.png"
     },
     {
         "name": "Tsundere Maid, Minatsu",
@@ -3400,7 +3400,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E053.png"
     },
     {
         "name": "Ungraspable Beauty, Chizuru",
@@ -3428,7 +3428,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E055.png"
     },
     {
         "name": "Naivete, Kurimu",
@@ -3458,7 +3458,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E057.png"
     },
     {
         "name": "Pretty Face and Fair-Skinned, Mafuyu",
@@ -3488,7 +3488,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E058.png"
     },
     {
         "name": "Hekiyou Academy Student Council Vice President, Ken",
@@ -3514,7 +3514,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E061.png"
     },
     {
         "name": "Otaku Girl, Mafuyu",
@@ -3542,7 +3542,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E063.png"
     },
     {
         "name": "Fragrance of Yuri, Chizuru",
@@ -3570,7 +3570,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E066.png"
     },
     {
         "name": "Dazzling, Minatsu",
@@ -3600,7 +3600,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E067.png"
     },
     {
         "name": "In Slumber",
@@ -3629,7 +3629,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E069.png"
     },
     {
         "name": "Irreplaceable Daily Life",
@@ -3659,7 +3659,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_E070.png"
     },
     {
         "name": "President of the Universe, Kurimu",
@@ -3686,7 +3686,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_PE01.png"
     },
     {
         "name": "Ringing Declaration, Kurimu",
@@ -3716,7 +3716,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_TE11.png"
     },
     {
         "name": "I Am Echo of Death",
@@ -3742,7 +3742,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_TE12.png"
     },
     {
         "name": "Student Council's Discretion",
@@ -3771,7 +3771,7 @@
         "set": "Fsi",
         "release": "65",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsi_W65_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsi_w65/Fsi_W65_TE14.png"
     },
     {
         "name": "Genius Mage & Swordswoman, Lina",
@@ -3799,7 +3799,7 @@
         "set": "Fsl",
         "release": "65",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Fsl_W65_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fsl_w65/Fsl_W65_E046.png"
     },
     {
         "name": "Fulfilled Promise, Natsume & Harutora",
@@ -3827,6 +3827,6 @@
         "set": "Ftr",
         "release": "65",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/Ftr_W65_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ftr_w65/ftr_W65_E017_C.png"
     }
 ]

--- a/DB/FSU2_S36.json
+++ b/DB/FSU2_S36.json
@@ -24,7 +24,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E001RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E001.png"
     },
     {
         "name": "“Excalibur” Saber",
@@ -54,7 +54,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E002RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E002.png"
     },
     {
         "name": "“Unlimited Blade Works” Shirou",
@@ -83,7 +83,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E003RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E003.png"
     },
     {
         "name": "“Summoning with a Command Seal” Shirou",
@@ -110,7 +110,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E004R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E004.png"
     },
     {
         "name": "“Contract Concluded” Saber",
@@ -136,7 +136,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E005R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E005.png"
     },
     {
         "name": "“King's Self-esteem” Gilgamesh",
@@ -162,7 +162,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E006R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E006.png"
     },
     {
         "name": "“Tough Strength” Saber",
@@ -189,7 +189,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E007R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E007.png"
     },
     {
         "name": "“Gate of Babylon” Gilgamesh",
@@ -218,7 +218,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E008R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E008.png"
     },
     {
         "name": "“Serious Assault” Shirou",
@@ -247,7 +247,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E009R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E009.png"
     },
     {
         "name": "“Non-intersecting Ideals” Shirou & Archer",
@@ -274,7 +274,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E010U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E010.png"
     },
     {
         "name": "“Divine Construct” Saber",
@@ -301,7 +301,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E011U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E011.png"
     },
     {
         "name": "“Pure White Dress” Saber",
@@ -327,7 +327,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E012U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E012.png"
     },
     {
         "name": "“Top Servant” Saber",
@@ -355,7 +355,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E013U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E013.png"
     },
     {
         "name": "“Using a Command Seal” Shirou",
@@ -381,7 +381,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E014U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E014.png"
     },
     {
         "name": "“Furious Punch” Shirou",
@@ -410,7 +410,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E015U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E015.png"
     },
     {
         "name": "“Defeat's End” Gilgamesh",
@@ -436,7 +436,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E016C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E016.png"
     },
     {
         "name": "“A Battle of Legend” Gilgamesh",
@@ -462,7 +462,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E017C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E017.png"
     },
     {
         "name": "“Greatest Natural Enemy” Gilgamesh",
@@ -488,7 +488,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E018C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E018.png"
     },
     {
         "name": "“Endless Blades” Gilgamesh",
@@ -515,7 +515,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E019C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E019.png"
     },
     {
         "name": "“Highest Class Noble Phantasm” Gilgamesh",
@@ -541,7 +541,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E020C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E020.png"
     },
     {
         "name": "“Dauntless Heart” Shirou",
@@ -567,7 +567,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E021C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E021.png"
     },
     {
         "name": "“New Contract” Saber",
@@ -593,7 +593,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E022C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E022.png"
     },
     {
         "name": "“Neat and Tidy Appearance” Saber",
@@ -622,7 +622,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E023C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E023.png"
     },
     {
         "name": "“Challenging a King” Gilgamesh",
@@ -650,7 +650,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E024C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E024.png"
     },
     {
         "name": "“Ultimate Slash” Saber",
@@ -679,7 +679,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E025C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E025.png"
     },
     {
         "name": "Signal to Counterattack",
@@ -705,7 +705,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E026U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E026.png"
     },
     {
         "name": "Idealism's End",
@@ -731,7 +731,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E027U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E027.png"
     },
     {
         "name": "“Unlimited Blade Works”",
@@ -761,7 +761,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E028CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E028.png"
     },
     {
         "name": "“Gate of Babylon”",
@@ -790,7 +790,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E029CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E029.png"
     },
     {
         "name": "“Excalibur”",
@@ -820,7 +820,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E030CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E030.png"
     },
     {
         "name": "“Battle Mode” Rider",
@@ -849,7 +849,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E031RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E031.png"
     },
     {
         "name": "“Dedicated Junior” Sakura",
@@ -876,7 +876,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E032R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E032.png"
     },
     {
         "name": "“Cold and Ruthless” Rider",
@@ -902,7 +902,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E033R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E033.png"
     },
     {
         "name": "“Gae Bolg” Lancer",
@@ -930,7 +930,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E034R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E034.png"
     },
     {
         "name": "“Gae・Bolg” Lancer",
@@ -956,7 +956,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E035U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E035.png"
     },
     {
         "name": "“Deadly Strike” Lancer",
@@ -982,7 +982,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E036U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E036.png"
     },
     {
         "name": "“Quiet Personality” Sakura",
@@ -1011,7 +1011,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E037U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E037.png"
     },
     {
         "name": "“Battle Continues” Lancer",
@@ -1037,7 +1037,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E038C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E038.png"
     },
     {
         "name": "“Self-defense Class” Luvia",
@@ -1063,7 +1063,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E039C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E039.png"
     },
     {
         "name": "“Complex Emotions” Sakura",
@@ -1089,7 +1089,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E040C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E040.png"
     },
     {
         "name": "“Uneasiness in the Heart” Sakura",
@@ -1115,7 +1115,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E041C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E041.png"
     },
     {
         "name": "“United Battlefront” Lancer",
@@ -1142,7 +1142,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E042C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E042.png"
     },
     {
         "name": "“Invading the Base” Shinji",
@@ -1170,7 +1170,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E043C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E043.png"
     },
     {
         "name": "Shaken",
@@ -1196,7 +1196,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E044U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E044.png"
     },
     {
         "name": "Last Farewell",
@@ -1222,7 +1222,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E045U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E045.png"
     },
     {
         "name": "“Gae Bolg”",
@@ -1251,7 +1251,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E046CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E046.png"
     },
     {
         "name": "Daily Visits",
@@ -1280,7 +1280,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E047CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E047.png"
     },
     {
         "name": "“Invitation to London” Rin",
@@ -1307,7 +1307,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E048RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E048.png"
     },
     {
         "name": "“Idealism's Despair” Archer",
@@ -1337,7 +1337,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E049RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E049.png"
     },
     {
         "name": "“Lord and Retainer” Rin & Archer",
@@ -1366,7 +1366,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E050RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E050.png"
     },
     {
         "name": "“Super First-rate Mage” Rin",
@@ -1393,7 +1393,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E051R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E051.png"
     },
     {
         "name": "“Successor of Tohsaka” Rin",
@@ -1420,7 +1420,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E052R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E052.png"
     },
     {
         "name": "“Counterattack Barrage” Archer",
@@ -1447,7 +1447,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E053R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E053.png"
     },
     {
         "name": "“Caladbolg Ⅱ” Archer",
@@ -1474,7 +1474,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E054R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E054.png"
     },
     {
         "name": "“Fire Support” Archer",
@@ -1501,7 +1501,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E055R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E055.png"
     },
     {
         "name": "“Beautiful and Smart Honor Student” Rin",
@@ -1528,7 +1528,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E056R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E056.png"
     },
     {
         "name": "“Dual-wielding” Archer",
@@ -1557,7 +1557,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E057R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E057.png"
     },
     {
         "name": "“Ideal Existence” Archer",
@@ -1584,7 +1584,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E058U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E058.png"
     },
     {
         "name": "“Jewel Magic” Rin",
@@ -1610,7 +1610,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E059U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E059.png"
     },
     {
         "name": "“Complex Emotions” Rin",
@@ -1637,7 +1637,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E060U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E060.png"
     },
     {
         "name": "“Further Pursuit” Archer",
@@ -1664,7 +1664,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E061U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E061.png"
     },
     {
         "name": "“End of Fight” Archer",
@@ -1690,7 +1690,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E062U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E062.png"
     },
     {
         "name": "“Full Power Pitch” Rin",
@@ -1719,7 +1719,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E063U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E063.png"
     },
     {
         "name": "“Time to Part Ways” Rin",
@@ -1745,7 +1745,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E064C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E064.png"
     },
     {
         "name": "“Center Breakthrough” Rin",
@@ -1774,7 +1774,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E065C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E065.png"
     },
     {
         "name": "“In the Conflict” Archer",
@@ -1803,7 +1803,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E066C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E066.png"
     },
     {
         "name": "“Caladbolg Ⅱ”",
@@ -1829,7 +1829,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E067U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E067.png"
     },
     {
         "name": "Conclusion to the Fight",
@@ -1855,7 +1855,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E068U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E068.png"
     },
     {
         "name": "“Rho Aias”",
@@ -1884,7 +1884,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E069CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E069.png"
     },
     {
         "name": "Last Words",
@@ -1913,7 +1913,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E070CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E070.png"
     },
     {
         "name": "Mischievous Smile",
@@ -1942,7 +1942,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E071CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E071.png"
     },
     {
         "name": "“Snow Fairy” Illya",
@@ -1968,7 +1968,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E072RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E072.png"
     },
     {
         "name": "“Signal to Commence Battle” Illya",
@@ -1995,7 +1995,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E073R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E073.png"
     },
     {
         "name": "“Mage from the Age of Myths” Caster",
@@ -2021,7 +2021,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E074R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E074.png"
     },
     {
         "name": "“Mage of Tragedy” Caster",
@@ -2050,7 +2050,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E075R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E075.png"
     },
     {
         "name": "“Relationship of Trust” Illya & Berserker",
@@ -2080,7 +2080,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E076R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E076.png"
     },
     {
         "name": "“Strong Bond” Illya",
@@ -2107,7 +2107,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E077U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E077.png"
     },
     {
         "name": "“Strongest Warrior” Berserker",
@@ -2135,7 +2135,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E078U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E078.png"
     },
     {
         "name": "“Confronting a King” Illya",
@@ -2162,7 +2162,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E079U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E079.png"
     },
     {
         "name": "“A Battle of Legend” Illya",
@@ -2191,7 +2191,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E080U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E080.png"
     },
     {
         "name": "“Strong Will” Berserker",
@@ -2219,7 +2219,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E081U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E081.png"
     },
     {
         "name": "“Further Attack” Souichirou Kuzuki",
@@ -2246,7 +2246,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E082C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E082.png"
     },
     {
         "name": "“Great Magic” Caster",
@@ -2273,7 +2273,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E083C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E083.png"
     },
     {
         "name": "“Magic Duel” Caster",
@@ -2299,7 +2299,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E084C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E084.png"
     },
     {
         "name": "“Swallow Reversal” Assassin",
@@ -2325,7 +2325,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E085C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E085.png"
     },
     {
         "name": "“Repeated Pursuit” Souichirou Kuzuki",
@@ -2351,7 +2351,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E086C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E086.png"
     },
     {
         "name": "“A Short Rest” Illya",
@@ -2377,7 +2377,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E087C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E087.png"
     },
     {
         "name": "“Sturdy Servant” Berserker",
@@ -2404,7 +2404,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E088C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E088.png"
     },
     {
         "name": "“Fictional Heroic Spirit” Assassin",
@@ -2430,7 +2430,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E089C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E089.png"
     },
     {
         "name": "“Middle of the Final Test” Illya",
@@ -2456,7 +2456,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E090C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E090.png"
     },
     {
         "name": "“Fulfilling the Wish” Souichirou Kuzuki",
@@ -2483,7 +2483,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E091C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E091.png"
     },
     {
         "name": "“A Visitor” Illya",
@@ -2511,7 +2511,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E092C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E092.png"
     },
     {
         "name": "“Priest of Fuyuki Church” Kirei",
@@ -2539,7 +2539,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E093C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E093.png"
     },
     {
         "name": "“Reverberation of Defeat” Assassin",
@@ -2567,7 +2567,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E094C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E094.png"
     },
     {
         "name": "Encounter on a Rainy Day",
@@ -2593,7 +2593,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E095U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E095.png"
     },
     {
         "name": "Berserker's Will",
@@ -2619,7 +2619,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E096U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E096.png"
     },
     {
         "name": "Encounter and Bond",
@@ -2648,7 +2648,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E097CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E097.png"
     },
     {
         "name": "Official Contract",
@@ -2677,7 +2677,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E098CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E098.png"
     },
     {
         "name": "Granted Wish",
@@ -2707,7 +2707,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E099CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E099.png"
     },
     {
         "name": "Swallow Reversal",
@@ -2736,7 +2736,7 @@
         "set": "FS",
         "release": "36",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S36_E100CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s36/FS_S36_E100.png"
     },
     {
         "name": "Petit Gilgamesh",

--- a/DB/FSU_S34.json
+++ b/DB/FSU_S34.json
@@ -24,7 +24,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E001RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E001.png"
     },
     {
         "name": "\"Saber's Master\" Shirou",
@@ -50,7 +50,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E002RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E002.png"
     },
     {
         "name": "A Knight's Oath, Saber",
@@ -79,7 +79,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E003RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E003.png"
     },
     {
         "name": "Resolution to Fight Together, Shirou",
@@ -106,7 +106,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E004R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E004.png"
     },
     {
         "name": "\"Heroic Spirit\" Saber",
@@ -132,7 +132,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E005R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E005.png"
     },
     {
         "name": "Resolution to Fight Together, Saber",
@@ -159,7 +159,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E006R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E006.png"
     },
     {
         "name": "Resolution Not to Fight, Shirou",
@@ -188,7 +188,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E007R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E007.png"
     },
     {
         "name": "Battle with Soichiro, Saber",
@@ -216,7 +216,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E008R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E008.png"
     },
     {
         "name": "Shirou in the Morning Glow",
@@ -245,7 +245,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E009R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E009.png"
     },
     {
         "name": "Battle Within the Field, Saber",
@@ -274,7 +274,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E010R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E010.png"
     },
     {
         "name": "Battle After School, Shirou",
@@ -301,7 +301,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E011U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E011.png"
     },
     {
         "name": "Past Hero, Saber",
@@ -328,7 +328,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E012U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E012.png"
     },
     {
         "name": "Confronting a Servant, Shirou",
@@ -355,7 +355,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E013U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E013.png"
     },
     {
         "name": "Heading for the Rescue, Saber",
@@ -381,7 +381,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E014U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E014.png"
     },
     {
         "name": "Mischievous Smile, Taiga",
@@ -407,7 +407,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E015U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E015.png"
     },
     {
         "name": "\"Servant\" Gilgamesh",
@@ -433,7 +433,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E016U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E016.png"
     },
     {
         "name": "Kind Soul, Shirou",
@@ -462,7 +462,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E017U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E017.png"
     },
     {
         "name": "Archery Club Captain, Mitsuzuri",
@@ -491,7 +491,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E018U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E018.png"
     },
     {
         "name": "Commanding Aura, Saber",
@@ -517,7 +517,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E019C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E019.png"
     },
     {
         "name": "At the School Cafeteria, Mitsuzuri",
@@ -543,7 +543,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E020C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E020.png"
     },
     {
         "name": "Shirou's Close Friend, Issei",
@@ -569,7 +569,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E021C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E021.png"
     },
     {
         "name": "Tinkering with Machines, Shirou",
@@ -595,7 +595,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E022C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E022.png"
     },
     {
         "name": "During Morning Practice, Mitsuzuri",
@@ -621,7 +621,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E023C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E023.png"
     },
     {
         "name": "Usual Morning, Shirou",
@@ -647,7 +647,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E024C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E024.png"
     },
     {
         "name": "Student\nCouncil President, Issei",
@@ -673,7 +673,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E025C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E025.png"
     },
     {
         "name": "Usual Morning, Taiga",
@@ -701,7 +701,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E026C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E026.png"
     },
     {
         "name": "Activating a Command Seal, Shirou",
@@ -729,7 +729,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E027C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E027.png"
     },
     {
         "name": "Servant with Blond Hair",
@@ -757,7 +757,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E028C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E028.png"
     },
     {
         "name": "Hidden Weapon, Saber",
@@ -785,7 +785,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E029C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E029.png"
     },
     {
         "name": "Temporary Rest",
@@ -811,7 +811,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E030U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E030.png"
     },
     {
         "name": "Self-training",
@@ -837,7 +837,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E031C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E031.png"
     },
     {
         "name": "Armor Release",
@@ -867,7 +867,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E032CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E032.png"
     },
     {
         "name": "A Fateful Night",
@@ -896,7 +896,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E033CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E033.png"
     },
     {
         "name": "Anger Towards Evil",
@@ -926,7 +926,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E034CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E034.png"
     },
     {
         "name": "Summoning Saber",
@@ -956,7 +956,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E035CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E035.png"
     },
     {
         "name": "\"Heroic Spirit\" Rider",
@@ -984,7 +984,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E036RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E036.png"
     },
     {
         "name": "Daily Symbol, Sakura",
@@ -1010,7 +1010,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E037R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E037.png"
     },
     {
         "name": "Bewitching Beauty, Rider",
@@ -1036,7 +1036,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E038R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E038.png"
     },
     {
         "name": "\"Heroic Spirit\" Lancer",
@@ -1065,7 +1065,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E039R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E039.png"
     },
     {
         "name": "Morning Greeting, Sakura",
@@ -1091,7 +1091,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E040U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E040.png"
     },
     {
         "name": "Archery Club Member, Sakura",
@@ -1117,7 +1117,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E041U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E041.png"
     },
     {
         "name": "Bystander, Lancer",
@@ -1145,7 +1145,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E042U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E042.png"
     },
     {
         "name": "Self-concious, Shinji",
@@ -1171,7 +1171,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E043C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E043.png"
     },
     {
         "name": "Archery Club Vice-captain, Shinji",
@@ -1197,7 +1197,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E044C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E044.png"
     },
     {
         "name": "Moving Like a Beast, Lancer",
@@ -1223,7 +1223,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E045C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E045.png"
     },
     {
         "name": "Usual Morning, Sakura",
@@ -1251,7 +1251,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E046C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E046.png"
     },
     {
         "name": "Shinji's Servant, Rider",
@@ -1279,7 +1279,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E047C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E047.png"
     },
     {
         "name": "Noble Phantasm Unleashed",
@@ -1306,7 +1306,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E048U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E048.png"
     },
     {
         "name": "Dancing After School",
@@ -1335,7 +1335,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E049CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E049.png"
     },
     {
         "name": "Bounded Field",
@@ -1364,7 +1364,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E050CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E050.png"
     },
     {
         "name": "For Victory, Rin",
@@ -1393,7 +1393,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E051.png"
     },
     {
         "name": "Great Day for a Date, Rin",
@@ -1423,7 +1423,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E052RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E052.png"
     },
     {
         "name": "\"Heroic Spirit\" Archer",
@@ -1453,7 +1453,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E053RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E053.png"
     },
     {
         "name": "Devilish Smile, Rin",
@@ -1479,7 +1479,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E054R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E054.png"
     },
     {
         "name": "As a Mage, Rin",
@@ -1506,7 +1506,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E055R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E055.png"
     },
     {
         "name": "Rin's Servant, Archer",
@@ -1533,7 +1533,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E056R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E056.png"
     },
     {
         "name": "Latecomer, Archer",
@@ -1560,7 +1560,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E057R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E057.png"
     },
     {
         "name": "Cursed Magic Bullet, Rin",
@@ -1586,7 +1586,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E058R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E058.png"
     },
     {
         "name": "A Master's Mental State, Rin",
@@ -1615,7 +1615,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E059R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E059.png"
     },
     {
         "name": "A Bowman's True Value, Archer",
@@ -1644,7 +1644,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E060R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E060.png"
     },
     {
         "name": "Proof of Contract, Rin",
@@ -1671,7 +1671,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E061U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E061.png"
     },
     {
         "name": "Fashionable Glasses, Rin",
@@ -1698,7 +1698,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E062U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E062.png"
     },
     {
         "name": "Proof of Contract, Archer",
@@ -1724,7 +1724,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E063U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E063.png"
     },
     {
         "name": "Archer's Surprise Attack",
@@ -1753,7 +1753,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E064U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E064.png"
     },
     {
         "name": "A Bowman's Speciality, Archer",
@@ -1782,7 +1782,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E065U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E065.png"
     },
     {
         "name": "Cynic, Archer",
@@ -1809,7 +1809,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E066C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E066.png"
     },
     {
         "name": "Rough Summoning, Archer",
@@ -1835,7 +1835,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E067C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E067.png"
     },
     {
         "name": "Dual-wielding Bowman, Archer",
@@ -1861,7 +1861,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E068C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E068.png"
     },
     {
         "name": "A Different Morning, Rin",
@@ -1887,7 +1887,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E069C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E069.png"
     },
     {
         "name": "Summon Rites, Rin",
@@ -1915,7 +1915,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E070C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E070.png"
     },
     {
         "name": "Father's Keepsake",
@@ -1941,7 +1941,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E071U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E071.png"
     },
     {
         "name": "Tohsaka's Magic Crest",
@@ -1970,7 +1970,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E072CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E072.png"
     },
     {
         "name": "Summoning Ritual",
@@ -1999,7 +1999,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E073CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E073.png"
     },
     {
         "name": "Precision Piercing",
@@ -2028,7 +2028,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E074CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E074.png"
     },
     {
         "name": "A Bowman's Speciality",
@@ -2057,7 +2057,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E075CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E075.png"
     },
     {
         "name": "\"Heroic Spirit\" Caster",
@@ -2085,7 +2085,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E076RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E076.png"
     },
     {
         "name": "Mages' Fighting Style, Caster",
@@ -2112,7 +2112,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E077R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E077.png"
     },
     {
         "name": "Silver Thread Alchemy Elgen Lied, Illya",
@@ -2138,7 +2138,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E078R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E078.png"
     },
     {
         "name": "\"Heroic Spirit\" Assassin",
@@ -2164,7 +2164,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E079R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E079.png"
     },
     {
         "name": "\"Caster's Master\" Soichiro Kuzuki",
@@ -2190,7 +2190,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E080U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E080.png"
     },
     {
         "name": "Rin's Classmate, Kane Himuro",
@@ -2217,7 +2217,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E081U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E081.png"
     },
     {
         "name": "Overwhelming Violence, Berserker",
@@ -2243,7 +2243,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E082U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E082.png"
     },
     {
         "name": "Lady, Illya",
@@ -2271,7 +2271,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E083U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E083.png"
     },
     {
         "name": "Hypocritical Courtesy, Kirei",
@@ -2300,7 +2300,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E084U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E084.png"
     },
     {
         "name": "\"Finishing\" Move, Assassin",
@@ -2329,7 +2329,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E085U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E085.png"
     },
     {
         "name": "Tactician, Caster",
@@ -2358,7 +2358,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E086U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E086.png"
     },
     {
         "name": "Warning Before the Battle, Illya",
@@ -2385,7 +2385,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E087C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E087.png"
     },
     {
         "name": "Modern Power, Kirei",
@@ -2411,7 +2411,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E088C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E088.png"
     },
     {
         "name": "\"Heroic Spirit\" Berserker",
@@ -2437,7 +2437,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E089C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E089.png"
     },
     {
         "name": "Rin's Classmate, Yukika Saegusa",
@@ -2464,7 +2464,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E090C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E090.png"
     },
     {
         "name": "\"Berserker's Master\" Illya",
@@ -2490,7 +2490,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E091C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E091.png"
     },
     {
         "name": "Rin's Classmate, Kaede Makidera",
@@ -2516,7 +2516,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E092C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E092.png"
     },
     {
         "name": "Rule-breaking Noble Phantasm, Caster",
@@ -2542,7 +2542,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E093C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E093.png"
     },
     {
         "name": "Overseer of the Holy Grail War, Kirei",
@@ -2568,7 +2568,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E094C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E094.png"
     },
     {
         "name": "Reticent Teacher, Soichiro Kuzuki",
@@ -2597,7 +2597,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E095C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E095.png"
     },
     {
         "name": "Illusion magic",
@@ -2623,7 +2623,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E096U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E096.png"
     },
     {
         "name": "Taken",
@@ -2649,7 +2649,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E097U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E097.png"
     },
     {
         "name": "Immense Power",
@@ -2675,7 +2675,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E098C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E098.png"
     },
     {
         "name": "Illya's Magic, Storch Ritter",
@@ -2705,7 +2705,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E099CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E099.png"
     },
     {
         "name": "Rule-breaking Noble Phantasm",
@@ -2734,7 +2734,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E100CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E100.png"
     },
     {
         "name": "SD Shirou",
@@ -2760,7 +2760,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E101PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E101.png"
     },
     {
         "name": "SD Saber",
@@ -2786,7 +2786,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E102PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E102.png"
     },
     {
         "name": "SD Archer",
@@ -2812,7 +2812,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E103PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E103.png"
     },
     {
         "name": "SD Rin",
@@ -2841,7 +2841,7 @@
         "set": "FS",
         "release": "34",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_E104PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_E104.png"
     },
     {
         "name": "The Ones Fighting Against Fate",
@@ -2867,7 +2867,7 @@
         "set": "FS",
         "release": "34",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_PE01.png"
     },
     {
         "name": "In an Alliance",
@@ -2894,7 +2894,7 @@
         "set": "FS",
         "release": "34",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_PE02.png"
     },
     {
         "name": "Commanding Aura, Saber",
@@ -2922,7 +2922,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE01.png"
     },
     {
         "name": "Tinkering with Machines, Shirou",
@@ -2950,7 +2950,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE02.png"
     },
     {
         "name": "Usual Morning, Shirou",
@@ -2978,7 +2978,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE03.png"
     },
     {
         "name": "Past Hero, Saber",
@@ -3007,7 +3007,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE04.png"
     },
     {
         "name": "Kind Soul, Shirou",
@@ -3036,7 +3036,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE05.png"
     },
     {
         "name": "Hidden Weapon, Saber",
@@ -3064,7 +3064,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE06.png"
     },
     {
         "name": "Self-training",
@@ -3090,7 +3090,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE07.png"
     },
     {
         "name": "A Fateful Night",
@@ -3116,7 +3116,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE08.png"
     },
     {
         "name": "Proof of Contract, Rin",
@@ -3145,7 +3145,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE09.png"
     },
     {
         "name": "Rough Summoning, Archer",
@@ -3173,7 +3173,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE10.png"
     },
     {
         "name": "Dual-wielding Bowman, Archer",
@@ -3201,7 +3201,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE11.png"
     },
     {
         "name": "A Different Morning, Rin",
@@ -3229,7 +3229,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE12.png"
     },
     {
         "name": "Summon Rites, Rin",
@@ -3257,7 +3257,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE13.png"
     },
     {
         "name": "Summoning Ritual",
@@ -3283,7 +3283,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE14.png"
     },
     {
         "name": "A Bowman's Speciality",
@@ -3310,7 +3310,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE15.png"
     },
     {
         "name": "Holy Grail War Entry, Saber",
@@ -3340,7 +3340,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE16.png"
     },
     {
         "name": "Familiar's Work, Archer",
@@ -3370,7 +3370,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE17.png"
     },
     {
         "name": "For Victory, Rin & Archer",
@@ -3399,7 +3399,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE18.png"
     },
     {
         "name": "Jewel Mage, Rin",
@@ -3428,7 +3428,7 @@
         "set": "FS",
         "release": "34",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE19.png"
     },
     {
         "name": "Reinforce Magic, Shirou",
@@ -3454,6 +3454,6 @@
         "set": "FS",
         "release": "34",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FS_S34_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s34/FS_S34_TE20.png"
     }
 ]

--- a/DB/FS_S64.json
+++ b/DB/FS_S64.json
@@ -24,7 +24,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E001.png"
     },
     {
         "name": "Justice On Behalf of Another, Shirou",
@@ -54,7 +54,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E002.png"
     },
     {
         "name": "Entrusted Arm of Archer, Shirou",
@@ -81,7 +81,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E003.png"
     },
     {
         "name": "Reaching for the Grail, Saber",
@@ -110,7 +110,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E004.png"
     },
     {
         "name": "Sword Shrouded by Wind, Saber",
@@ -139,7 +139,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E005.png"
     },
     {
         "name": "Blushing, Shirou",
@@ -166,7 +166,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E006.png"
     },
     {
         "name": "Savage King of Heroes, Gilgamesh",
@@ -193,7 +193,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E007.png"
     },
     {
         "name": "As a Master, Shirou",
@@ -220,7 +220,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E008.png"
     },
     {
         "name": "\"Rain\" Shirou",
@@ -248,7 +248,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E009.png"
     },
     {
         "name": "Injury's Status, Shirou",
@@ -275,7 +275,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E010.png"
     },
     {
         "name": "What I Can Do, Shirou",
@@ -304,7 +304,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E011.png"
     },
     {
         "name": "Entrusted, Shirou",
@@ -332,7 +332,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E012.png"
     },
     {
         "name": "Friendly Teacher, Taiga",
@@ -359,7 +359,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E013.png"
     },
     {
         "name": "Foreign Acquaintance? Saber",
@@ -386,7 +386,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E014.png"
     },
     {
         "name": "Student Council President, Issei",
@@ -412,7 +412,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E015.png"
     },
     {
         "name": "Strong Sense of Justice, Shirou",
@@ -438,7 +438,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E016.png"
     },
     {
         "name": "Archery Club President, Ayako",
@@ -464,7 +464,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E017.png"
     },
     {
         "name": "Golden Benevolence, Gilgamesh",
@@ -492,7 +492,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E018.png"
     },
     {
         "name": "Smile Lit by Sunrise, Saber",
@@ -518,7 +518,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E019.png"
     },
     {
         "name": "A Servant's Power Sealed Within",
@@ -545,7 +545,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E020.png"
     },
     {
         "name": "Strike Air",
@@ -575,7 +575,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E021.png"
     },
     {
         "name": "Solitary Return",
@@ -604,7 +604,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E022.png"
     },
     {
         "name": "\"presage flower\" Sakura",
@@ -631,7 +631,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E023.png"
     },
     {
         "name": "Irreplaceable Existence, Sakura",
@@ -658,7 +658,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E024.png"
     },
     {
         "name": "Brillant Smile, Sakura",
@@ -688,7 +688,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E025.png"
     },
     {
         "name": "Monstrous Glance, Rider",
@@ -719,7 +719,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E026.png"
     },
     {
         "name": "Rider Attacking",
@@ -746,7 +746,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E027.png"
     },
     {
         "name": "Peaceful Morning, Sakura",
@@ -773,7 +773,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E028.png"
     },
     {
         "name": "Distortion of Daily Life, Sakura",
@@ -800,7 +800,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E029.png"
     },
     {
         "name": "Flexible Physique, Rider",
@@ -826,7 +826,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E030.png"
     },
     {
         "name": "FLUFFY, Sakura",
@@ -856,7 +856,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E031.png"
     },
     {
         "name": "\"Protection from Arrows\" Lancer",
@@ -885,7 +885,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E032.png"
     },
     {
         "name": "Enchanting Beauty, Rider",
@@ -914,7 +914,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E033.png"
     },
     {
         "name": "Sakura Waiting to Return Together",
@@ -941,7 +941,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E034.png"
     },
     {
         "name": "Agonizing Decision, Shinji",
@@ -967,7 +967,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E035.png"
     },
     {
         "name": "True Intentions, Rider",
@@ -994,7 +994,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E036.png"
     },
     {
         "name": "Master's Capability, Rider",
@@ -1021,7 +1021,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E037.png"
     },
     {
         "name": "\"Rain\" Sakura",
@@ -1050,7 +1050,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E038.png"
     },
     {
         "name": "Anti-Heroic Knight, Rider",
@@ -1080,7 +1080,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E039.png"
     },
     {
         "name": "Final Command Spell, Sakura",
@@ -1109,7 +1109,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E040.png"
     },
     {
         "name": "Ulster's Hero, Lancer",
@@ -1138,7 +1138,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E041.png"
     },
     {
         "name": "First-Time Substitute Master, Shinji",
@@ -1165,7 +1165,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E042.png"
     },
     {
         "name": "Study Mode, Sakura",
@@ -1192,7 +1192,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E043.png"
     },
     {
         "name": "Helping Out at the Emiya Household, Sakura",
@@ -1220,7 +1220,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E044.png"
     },
     {
         "name": "Battle-Hungry Smile, Lancer",
@@ -1246,7 +1246,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E045.png"
     },
     {
         "name": "\"Servant Chase\" Lancer",
@@ -1273,7 +1273,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E046.png"
     },
     {
         "name": "\"Monstrous Strength\" Rider",
@@ -1300,7 +1300,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E047.png"
     },
     {
         "name": "Warrior with Backbone, Lancer",
@@ -1326,7 +1326,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E048.png"
     },
     {
         "name": "Having a Nightmare, Sakura",
@@ -1353,7 +1353,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E049.png"
     },
     {
         "name": "Mysterious Knight, Rider",
@@ -1379,7 +1379,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E050.png"
     },
     {
         "name": "Spellbook of Fake Authority",
@@ -1405,7 +1405,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E051.png"
     },
     {
         "name": "Storytime",
@@ -1434,7 +1434,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E052.png"
     },
     {
         "name": "Mystic Eyes of Petrification",
@@ -1463,7 +1463,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E053.png"
     },
     {
         "name": "I'm starved!",
@@ -1492,7 +1492,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E054.png"
     },
     {
         "name": "Fate-Changing Blow",
@@ -1521,7 +1521,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E055.png"
     },
     {
         "name": "Ruthless King of Knights, Saber Alter",
@@ -1548,7 +1548,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E056.png"
     },
     {
         "name": "\"In Charge of Fuyuki\" Rin",
@@ -1578,7 +1578,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E057.png"
     },
     {
         "name": "Heroic Spirit With Complex Past, Archer",
@@ -1607,7 +1607,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E058.png"
     },
     {
         "name": "Variety of Fighting Styles, Archer",
@@ -1634,7 +1634,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E059.png"
     },
     {
         "name": "Dreamt of Moment, Rin",
@@ -1661,7 +1661,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E060.png"
     },
     {
         "name": "Black Shadow",
@@ -1690,7 +1690,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E061.png"
     },
     {
         "name": "Awkward Relationship, Rin",
@@ -1718,7 +1718,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E062.png"
     },
     {
         "name": "HEROIC, Rin & Archer",
@@ -1746,7 +1746,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E063.png"
     },
     {
         "name": "Overwhelming Strength, Saber Alter",
@@ -1776,7 +1776,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E064.png"
     },
     {
         "name": "Straightforward Sense of Justice, Rin",
@@ -1805,7 +1805,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E065.png"
     },
     {
         "name": "Shocked Expression, Rin",
@@ -1832,7 +1832,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E066.png"
     },
     {
         "name": "Standing By in the Rain, Archer",
@@ -1860,7 +1860,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E067.png"
     },
     {
         "name": "Decisive Judgement, Archer",
@@ -1886,7 +1886,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E068.png"
     },
     {
         "name": "Stellar Offense and Defense, Saber Alter",
@@ -1915,7 +1915,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E069.png"
     },
     {
         "name": "Beauty Feigning Innocence, Rin",
@@ -1942,7 +1942,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E070.png"
     },
     {
         "name": "Revealed Face, Saber Alter",
@@ -1969,7 +1969,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E071.png"
     },
     {
         "name": "Battle Stance, Archer",
@@ -1995,7 +1995,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E072.png"
     },
     {
         "name": "Knight Clothed in Black, Saber Alter",
@@ -2022,7 +2022,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E073.png"
     },
     {
         "name": "Offering Protection, Rin",
@@ -2049,7 +2049,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E074.png"
     },
     {
         "name": "Pair of Swords, Archer",
@@ -2076,7 +2076,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E075.png"
     },
     {
         "name": "Making Plans, Rin",
@@ -2106,7 +2106,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E076.png"
     },
     {
         "name": "Sakura's Ribbon",
@@ -2133,7 +2133,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E077.png"
     },
     {
         "name": "Shadow that Engulfs Heroic Spirits",
@@ -2160,7 +2160,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E078.png"
     },
     {
         "name": "Distance Separating the Two",
@@ -2189,7 +2189,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E079.png"
     },
     {
         "name": "Ultimate Choice",
@@ -2218,7 +2218,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E080.png"
     },
     {
         "name": "Excalibur Morgan",
@@ -2247,7 +2247,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E081.png"
     },
     {
         "name": "Mysterious Girl, Illyasviel",
@@ -2277,7 +2277,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E082.png"
     },
     {
         "name": "Dirty Tactics, True Assasin",
@@ -2304,7 +2304,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E083.png"
     },
     {
         "name": "One of Many Faces, Illyasviel",
@@ -2331,7 +2331,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E084.png"
     },
     {
         "name": "Mad Warrior's Howl, Berserker",
@@ -2358,7 +2358,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E085.png"
     },
     {
         "name": "Fearless Smile, Illyasviel",
@@ -2386,7 +2386,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E086.png"
     },
     {
         "name": "Valorous Warrior, Berserker",
@@ -2415,7 +2415,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E087.png"
     },
     {
         "name": "Rule Breaker, Caster",
@@ -2441,7 +2441,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E088.png"
     },
     {
         "name": "Spectating the Battle, Illyasviel",
@@ -2468,7 +2468,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E089.png"
     },
     {
         "name": "Tenacious, Berserker",
@@ -2495,7 +2495,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E090.png"
     },
     {
         "name": "One of Three Great Families, Illyasviel",
@@ -2524,7 +2524,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E091.png"
     },
     {
         "name": "Unsettling Warning, Illyasviel",
@@ -2551,7 +2551,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E092.png"
     },
     {
         "name": "Easygoing Swordsman, Assassin",
@@ -2578,7 +2578,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E093.png"
     },
     {
         "name": "\"5th Holy Grail War's Overseer\" Kirei",
@@ -2605,7 +2605,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E094.png"
     },
     {
         "name": "Masked Hitman, True Assassin",
@@ -2632,7 +2632,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E095.png"
     },
     {
         "name": "Fierce Presence, Berserker",
@@ -2659,7 +2659,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E096.png"
     },
     {
         "name": "Kotomine's Meal",
@@ -2685,7 +2685,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E097.png"
     },
     {
         "name": "Cutthroat Battle",
@@ -2715,7 +2715,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E098.png"
     },
     {
         "name": "Winter's Lorelei",
@@ -2744,7 +2744,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E099.png"
     },
     {
         "name": "Zabaniya",
@@ -2773,7 +2773,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E100.png"
     },
     {
         "name": "petit Shirou",
@@ -2799,7 +2799,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E101.png"
     },
     {
         "name": "petit Sakura",
@@ -2826,7 +2826,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E102.png"
     },
     {
         "name": "petit Rin",
@@ -2855,7 +2855,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E103.png"
     },
     {
         "name": "petit Illyasviel",
@@ -2884,7 +2884,7 @@
         "set": "FS",
         "release": "64",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_E104.png"
     },
     {
         "name": "Spring Season, Sakura",
@@ -2910,6 +2910,6 @@
         "set": "FS",
         "release": "64",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/FS_S64_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fs_s64/FS_S64_PE01.png"
     }
 ]

--- a/DB/FT_S02.json
+++ b/DB/FT_S02.json
@@ -27,7 +27,7 @@
         "set": "FT",
         "release": "02",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_001.png"
     },
     {
         "name": "Titania Erza",
@@ -57,7 +57,7 @@
         "set": "FT",
         "release": "02",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_002.png"
     },
     {
         "name": "Fairy Tail Master, Makarov",
@@ -84,7 +84,7 @@
         "set": "FT",
         "release": "02",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_003.png"
     },
     {
         "name": "Magic Swordsman, Erza",
@@ -111,7 +111,7 @@
         "set": "FT",
         "release": "02",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_004.png"
     },
     {
         "name": "\"Black Winged Armor\" Erza",
@@ -138,7 +138,7 @@
         "set": "FT",
         "release": "02",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_005.png"
     },
     {
         "name": "Childhood Erza",
@@ -164,7 +164,7 @@
         "set": "FT",
         "release": "02",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_006.png"
     },
     {
         "name": "\"Infinity Robe\" Erza",
@@ -193,7 +193,7 @@
         "set": "FT",
         "release": "02",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_007.png"
     },
     {
         "name": "Childhood Jellal",
@@ -220,7 +220,7 @@
         "set": "FT",
         "release": "02",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_008.png"
     },
     {
         "name": "Ultra Close Type, Erza",
@@ -248,7 +248,7 @@
         "set": "FT",
         "release": "02",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_009.png"
     },
     {
         "name": "\"Parfum Magic\" Ichiya",
@@ -275,7 +275,7 @@
         "set": "FT",
         "release": "02",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_010.png"
     },
     {
         "name": "\"Flame Empress Armor\" Erza",
@@ -302,7 +302,7 @@
         "set": "FT",
         "release": "02",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_011.png"
     },
     {
         "name": "Little Fairy, Levy",
@@ -328,7 +328,7 @@
         "set": "FT",
         "release": "02",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_012.png"
     },
     {
         "name": "S-class Wizard, Mystogan",
@@ -357,7 +357,7 @@
         "set": "FT",
         "release": "02",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_013.png"
     },
     {
         "name": "Healing Wizard, Porlyusica",
@@ -386,7 +386,7 @@
         "set": "FT",
         "release": "02",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_014.png"
     },
     {
         "name": "Laxus's \"Grandpa\" Makarov",
@@ -415,7 +415,7 @@
         "set": "FT",
         "release": "02",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_015.png"
     },
     {
         "name": "Makarov's Grandson, Laxus",
@@ -443,7 +443,7 @@
         "set": "FT",
         "release": "02",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_016.png"
     },
     {
         "name": "Phantom Lord Master, Jose",
@@ -472,7 +472,7 @@
         "set": "FT",
         "release": "02",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_017.png"
     },
     {
         "name": "\"Seidhr Magic\" Bixlow",
@@ -499,7 +499,7 @@
         "set": "FT",
         "release": "02",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_018.png"
     },
     {
         "name": "\"Stone Eyes\" Evergreen",
@@ -525,7 +525,7 @@
         "set": "FT",
         "release": "02",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_019.png"
     },
     {
         "name": "\"The Reaper\" Erigor",
@@ -551,7 +551,7 @@
         "set": "FT",
         "release": "02",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_020.png"
     },
     {
         "name": "Aria of the Heavens",
@@ -578,7 +578,7 @@
         "set": "FT",
         "release": "02",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_021.png"
     },
     {
         "name": "\"Dark Ecriture\" Fried",
@@ -604,7 +604,7 @@
         "set": "FT",
         "release": "02",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_022.png"
     },
     {
         "name": "Tower of Heaven Ruler, Jellal",
@@ -632,7 +632,7 @@
         "set": "FT",
         "release": "02",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_023.png"
     },
     {
         "name": "Fairy Law",
@@ -658,7 +658,7 @@
         "set": "FT",
         "release": "02",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_024.png"
     },
     {
         "name": "And more importantly, live with an open heart",
@@ -687,7 +687,7 @@
         "set": "FT",
         "release": "02",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_025.png"
     },
     {
         "name": "Heaven's Wheel, Scattered Petals",
@@ -717,7 +717,7 @@
         "set": "FT",
         "release": "02",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_026.png"
     },
     {
         "name": "Circle Sword",
@@ -747,7 +747,7 @@
         "set": "FT",
         "release": "02",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_027.png"
     },
     {
         "name": "Fairy Tail has come calling!!!!!!",
@@ -776,7 +776,7 @@
         "set": "FT",
         "release": "02",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_028.png"
     },
     {
         "name": "Fairy Tail Wizard, Lucy",
@@ -805,7 +805,7 @@
         "set": "FT",
         "release": "02",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_029.png"
     },
     {
         "name": "Celestial Wizard, Lucy",
@@ -835,7 +835,7 @@
         "set": "FT",
         "release": "02",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_030.png"
     },
     {
         "name": "\"Unison Raid\" Lucy",
@@ -861,7 +861,7 @@
         "set": "FT",
         "release": "02",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_031.png"
     },
     {
         "name": "Rookie Wizard, Lucy",
@@ -887,7 +887,7 @@
         "set": "FT",
         "release": "02",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_032.png"
     },
     {
         "name": "My Determination, Lucy",
@@ -913,7 +913,7 @@
         "set": "FT",
         "release": "02",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_033.png"
     },
     {
         "name": "Beautiful Bond, Lucy",
@@ -942,7 +942,7 @@
         "set": "FT",
         "release": "02",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_034.png"
     },
     {
         "name": "Lucy Heartfilia",
@@ -968,7 +968,7 @@
         "set": "FT",
         "release": "02",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_035.png"
     },
     {
         "name": "With Special Friends, Lucy",
@@ -994,7 +994,7 @@
         "set": "FT",
         "release": "02",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_036.png"
     },
     {
         "name": "Aquarius the Water Bearer",
@@ -1020,7 +1020,7 @@
         "set": "FT",
         "release": "02",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_037.png"
     },
     {
         "name": "Former S-class Wizard, Mirajane",
@@ -1046,7 +1046,7 @@
         "set": "FT",
         "release": "02",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_038.png"
     },
     {
         "name": "Still a Rookie, Lucy",
@@ -1072,7 +1072,7 @@
         "set": "FT",
         "release": "02",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_039.png"
     },
     {
         "name": "Holder Wizard, Lucy",
@@ -1101,7 +1101,7 @@
         "set": "FT",
         "release": "02",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_040.png"
     },
     {
         "name": "Daughter of Heartfilia Family, Lucy",
@@ -1130,7 +1130,7 @@
         "set": "FT",
         "release": "02",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_041.png"
     },
     {
         "name": "\"Beast Arm\" Elfman",
@@ -1156,7 +1156,7 @@
         "set": "FT",
         "release": "02",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_042.png"
     },
     {
         "name": "Celestial Wizard, Angel",
@@ -1182,7 +1182,7 @@
         "set": "FT",
         "release": "02",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_043.png"
     },
     {
         "name": "Sol of the Earth",
@@ -1208,7 +1208,7 @@
         "set": "FT",
         "release": "02",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_044.png"
     },
     {
         "name": "Gate Key",
@@ -1234,7 +1234,7 @@
         "set": "FT",
         "release": "02",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_045.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1263,7 +1263,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Ari",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Ari.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Ari.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1292,7 +1292,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Gem",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Gem.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Gem.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1321,7 +1321,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Leo",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Leo.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Leo.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1350,7 +1350,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Sgr",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Sgr.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Sgr.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1379,7 +1379,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Tau",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Tau.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Tau.png"
     },
     {
         "name": "Celestial Spirit of the Zodiac Gates",
@@ -1408,7 +1408,7 @@
         "set": "FT",
         "release": "02",
         "sid": "046Vir",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_046Vir.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_046Vir.png"
     },
     {
         "name": "Changeling",
@@ -1434,7 +1434,7 @@
         "set": "FT",
         "release": "02",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_047.png"
     },
     {
         "name": "LOVE & LUCKY",
@@ -1460,7 +1460,7 @@
         "set": "FT",
         "release": "02",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_048.png"
     },
     {
         "name": "You did nothin' wrong!",
@@ -1489,7 +1489,7 @@
         "set": "FT",
         "release": "02",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_049.png"
     },
     {
         "name": "Power of the Celestial Spirits",
@@ -1518,7 +1518,7 @@
         "set": "FT",
         "release": "02",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_050.png"
     },
     {
         "name": "Forced Gate Closure",
@@ -1547,7 +1547,7 @@
         "set": "FT",
         "release": "02",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_051.png"
     },
     {
         "name": "Dragon Force, Natsu",
@@ -1574,7 +1574,7 @@
         "set": "FT",
         "release": "02",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_052.png"
     },
     {
         "name": "Fairy Tail Wizard, Natsu",
@@ -1603,7 +1603,7 @@
         "set": "FT",
         "release": "02",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_053.png"
     },
     {
         "name": "Natsu & Happy",
@@ -1631,7 +1631,7 @@
         "set": "FT",
         "release": "02",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_054.png"
     },
     {
         "name": "Black Steel Gajeel",
@@ -1658,7 +1658,7 @@
         "set": "FT",
         "release": "02",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_055.png"
     },
     {
         "name": "A Place to Return to, Natsu",
@@ -1686,7 +1686,7 @@
         "set": "FT",
         "release": "02",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_056.png"
     },
     {
         "name": "Power of Allies, Natsu",
@@ -1715,7 +1715,7 @@
         "set": "FT",
         "release": "02",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_057.png"
     },
     {
         "name": "Erza Scarlet",
@@ -1742,7 +1742,7 @@
         "set": "FT",
         "release": "02",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_058.png"
     },
     {
         "name": "Oracion Seis Master, Zero",
@@ -1771,7 +1771,7 @@
         "set": "FT",
         "release": "02",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_059.png"
     },
     {
         "name": "Natsu Living on Instincts",
@@ -1798,7 +1798,7 @@
         "set": "FT",
         "release": "02",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_060.png"
     },
     {
         "name": "Flame Dragon, Igneel",
@@ -1826,7 +1826,7 @@
         "set": "FT",
         "release": "02",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_061.png"
     },
     {
         "name": "Problem Child, Natsu",
@@ -1852,7 +1852,7 @@
         "set": "FT",
         "release": "02",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_062.png"
     },
     {
         "name": "Oracion Seis",
@@ -1879,7 +1879,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Ang",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Ang.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Ang.png"
     },
     {
         "name": "Oracion Seis",
@@ -1906,7 +1906,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Bra",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Bra.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Bra.png"
     },
     {
         "name": "Oracion Seis",
@@ -1933,7 +1933,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Cob",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Cob.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Cob.png"
     },
     {
         "name": "Oracion Seis",
@@ -1960,7 +1960,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Hot",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Hot.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Hot.png"
     },
     {
         "name": "Oracion Seis",
@@ -1987,7 +1987,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Mid",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Mid.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Mid.png"
     },
     {
         "name": "Oracion Seis",
@@ -2014,7 +2014,7 @@
         "set": "FT",
         "release": "02",
         "sid": "063Rac",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_063Rac.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_063Rac.png"
     },
     {
         "name": "Great Fire Totomaru",
@@ -2042,7 +2042,7 @@
         "set": "FT",
         "release": "02",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_064.png"
     },
     {
         "name": "Flame Lotus Phoenix Sword",
@@ -2068,7 +2068,7 @@
         "set": "FT",
         "release": "02",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_065.png"
     },
     {
         "name": "Natsu vs. Zero",
@@ -2097,7 +2097,7 @@
         "set": "FT",
         "release": "02",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_066.png"
     },
     {
         "name": "Iron Dragon Roar",
@@ -2126,7 +2126,7 @@
         "set": "FT",
         "release": "02",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_067.png"
     },
     {
         "name": "Fairy Tail Wizard, Gray",
@@ -2155,7 +2155,7 @@
         "set": "FT",
         "release": "02",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_068.png"
     },
     {
         "name": "Sky Dragon Slayer, Wendy",
@@ -2184,7 +2184,7 @@
         "set": "FT",
         "release": "02",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_069.png"
     },
     {
         "name": "Ur's Student, Gray",
@@ -2211,7 +2211,7 @@
         "set": "FT",
         "release": "02",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_070.png"
     },
     {
         "name": "Juvia Loxar",
@@ -2238,7 +2238,7 @@
         "set": "FT",
         "release": "02",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_071.png"
     },
     {
         "name": "Wendy Marvell",
@@ -2264,7 +2264,7 @@
         "set": "FT",
         "release": "02",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_072.png"
     },
     {
         "name": "Clothes-removing Habit, Gray",
@@ -2293,7 +2293,7 @@
         "set": "FT",
         "release": "02",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_073.png"
     },
     {
         "name": "Fairy Tail Wizard, Juvia",
@@ -2321,7 +2321,7 @@
         "set": "FT",
         "release": "02",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_074.png"
     },
     {
         "name": "Gray Fullbuster",
@@ -2350,7 +2350,7 @@
         "set": "FT",
         "release": "02",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_075.png"
     },
     {
         "name": "\"A New Goal\" Gray",
@@ -2376,7 +2376,7 @@
         "set": "FT",
         "release": "02",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_076.png"
     },
     {
         "name": "Childhood Wendy",
@@ -2402,7 +2402,7 @@
         "set": "FT",
         "release": "02",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_077.png"
     },
     {
         "name": "Castle Wall of Ice, Gray",
@@ -2428,7 +2428,7 @@
         "set": "FT",
         "release": "02",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_078.png"
     },
     {
         "name": "Magic Cards, Cana",
@@ -2455,7 +2455,7 @@
         "set": "FT",
         "release": "02",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_079.png"
     },
     {
         "name": "\"Ur's Teachings\" Gray",
@@ -2482,7 +2482,7 @@
         "set": "FT",
         "release": "02",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_080.png"
     },
     {
         "name": "Gray's Teacher, Ur",
@@ -2509,7 +2509,7 @@
         "set": "FT",
         "release": "02",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_081.png"
     },
     {
         "name": "Maiden in Love, Juvia",
@@ -2537,7 +2537,7 @@
         "set": "FT",
         "release": "02",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_082.png"
     },
     {
         "name": "Gray's Determination",
@@ -2564,7 +2564,7 @@
         "set": "FT",
         "release": "02",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_083.png"
     },
     {
         "name": "\"Ur's Tears\" Ultear",
@@ -2593,7 +2593,7 @@
         "set": "FT",
         "release": "02",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_084.png"
     },
     {
         "name": "Phantom Wizard, Juvia",
@@ -2622,7 +2622,7 @@
         "set": "FT",
         "release": "02",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_085.png"
     },
     {
         "name": "\"Healing Spell\" Wendy",
@@ -2651,7 +2651,7 @@
         "set": "FT",
         "release": "02",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_086.png"
     },
     {
         "name": "Juvia of the Great Sea",
@@ -2679,7 +2679,7 @@
         "set": "FT",
         "release": "02",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_087.png"
     },
     {
         "name": "Cold Emperor, Lyon",
@@ -2705,7 +2705,7 @@
         "set": "FT",
         "release": "02",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_088.png"
     },
     {
         "name": "Cana Alberona",
@@ -2731,7 +2731,7 @@
         "set": "FT",
         "release": "02",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_089.png"
     },
     {
         "name": "Cait Shelter Master, Robaul",
@@ -2757,7 +2757,7 @@
         "set": "FT",
         "release": "02",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_090.png"
     },
     {
         "name": "Honest and Brave, Wendy",
@@ -2783,7 +2783,7 @@
         "set": "FT",
         "release": "02",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_091.png"
     },
     {
         "name": "Wendy's Caretaker, Carla",
@@ -2809,7 +2809,7 @@
         "set": "FT",
         "release": "02",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_092.png"
     },
     {
         "name": "\"Unison Raid\" Juvia",
@@ -2835,7 +2835,7 @@
         "set": "FT",
         "release": "02",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_093.png"
     },
     {
         "name": "Natsu's Friendly Rival, Gray",
@@ -2861,7 +2861,7 @@
         "set": "FT",
         "release": "02",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_094.png"
     },
     {
         "name": "Young Council Member, Siegrain",
@@ -2889,7 +2889,7 @@
         "set": "FT",
         "release": "02",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_095.png"
     },
     {
         "name": "Moon Drip",
@@ -2916,7 +2916,7 @@
         "set": "FT",
         "release": "02",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_096.png"
     },
     {
         "name": "Ice Geyser",
@@ -2945,7 +2945,7 @@
         "set": "FT",
         "release": "02",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_097.png"
     },
     {
         "name": "Sky Dragon Roar",
@@ -2974,7 +2974,7 @@
         "set": "FT",
         "release": "02",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_098.png"
     },
     {
         "name": "Ice Cannon",
@@ -3003,7 +3003,7 @@
         "set": "FT",
         "release": "02",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_099.png"
     },
     {
         "name": "Water Lock",
@@ -3032,7 +3032,7 @@
         "set": "FT",
         "release": "02",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_100.png"
     },
     {
         "name": "Guardian of Fairy Tail, Erza",
@@ -3061,7 +3061,7 @@
         "set": "FT",
         "release": "02",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_101.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_101.png"
     },
     {
         "name": "Girl Who Loves Celestial Spirits, Lucy",
@@ -3090,7 +3090,7 @@
         "set": "FT",
         "release": "02",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_102.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_102.png"
     },
     {
         "name": "Searching for Igneel, Natsu",
@@ -3116,7 +3116,7 @@
         "set": "FT",
         "release": "02",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_103.png"
     },
     {
         "name": "\"Dragon Egg\" Happy",
@@ -3143,7 +3143,7 @@
         "set": "FT",
         "release": "02",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_104.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_104.png"
     },
     {
         "name": "Silent Ice Make, Gray",
@@ -3170,7 +3170,7 @@
         "set": "FT",
         "release": "02",
         "sid": "105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_105.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_105.png"
     },
     {
         "name": "Fire Dragon Slayer, Natsu",
@@ -3199,7 +3199,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T01.png"
     },
     {
         "name": "Draw of Fairy Tail, Mirajane",
@@ -3226,7 +3226,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T02.png"
     },
     {
         "name": "Ice Make Wizard, Gray",
@@ -3252,7 +3252,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T03.png"
     },
     {
         "name": "Lisanna",
@@ -3278,7 +3278,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T04.png"
     },
     {
         "name": "Maid Look, Lucy",
@@ -3304,7 +3304,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T05.png"
     },
     {
         "name": "Literature Girl, Lucy",
@@ -3331,7 +3331,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T06.png"
     },
     {
         "name": "Cute Celestial User? Lucy",
@@ -3360,7 +3360,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T07.png"
     },
     {
         "name": "Ring Magic, Loke",
@@ -3388,7 +3388,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T08.png"
     },
     {
         "name": "DEAR KABY",
@@ -3417,7 +3417,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T09.png"
     },
     {
         "name": "Gajeel Redfoxx",
@@ -3443,7 +3443,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T10.png"
     },
     {
         "name": "Natsu Dragneel",
@@ -3469,7 +3469,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T11.png"
     },
     {
         "name": "Young Dragon, Natsu",
@@ -3495,7 +3495,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T12.png"
     },
     {
         "name": "Natsu's Partner, Happy",
@@ -3522,7 +3522,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T13.png"
     },
     {
         "name": "Childhood Natsu & Happy",
@@ -3549,7 +3549,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T14.png"
     },
     {
         "name": "Fire Wizard, Natsu",
@@ -3575,7 +3575,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T15.png"
     },
     {
         "name": "Dragon Power, Natsu",
@@ -3604,7 +3604,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T16.png"
     },
     {
         "name": "Armor Wizard, Erza",
@@ -3632,7 +3632,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T17.png"
     },
     {
         "name": "S-class Quest",
@@ -3658,7 +3658,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T18.png"
     },
     {
         "name": "Fire Dragon Roar",
@@ -3687,7 +3687,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T19.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T19.png"
     },
     {
         "name": "Fire Dragon Brilliant Flame",
@@ -3716,7 +3716,7 @@
         "set": "FT",
         "release": "02",
         "sid": "T20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FTEN_S02_T20.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/ft_en_s02/FT_EN_S02_T20.png"
     },
     {
         "name": "Flame of Emotions, Natsu",
@@ -3770,7 +3770,7 @@
         "set": "FT",
         "release": "09",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FT_S09_E110.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/WS_FT_S09_E110.jpg"
     },
     {
         "name": "\"Maiden of the Sky\" Wendy",
@@ -3798,6 +3798,6 @@
         "set": "FT",
         "release": "E10",
         "sid": "E46",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FT_SE10_E46.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/WS_FT_SE10_E46.jpg"
     }
 ]

--- a/DB/FZ_S17.json
+++ b/DB/FZ_S17.json
@@ -23,7 +23,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E001.png"
     },
     {
         "name": "King of Ideals, Saber",
@@ -53,7 +53,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E002.png"
     },
     {
         "name": "Kiritsugu - Belief in Justice",
@@ -82,7 +82,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E003.png"
     },
     {
         "name": "Kiritsugu - Style of Heresy",
@@ -109,7 +109,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E004.png"
     },
     {
         "name": "Silent Assistant, Maiya",
@@ -136,7 +136,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E005.png"
     },
     {
         "name": "Beautiful King of Knights, Saber",
@@ -162,7 +162,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E006.png"
     },
     {
         "name": "Saber - \"Magic Power Unleashed\"",
@@ -188,7 +188,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E007.png"
     },
     {
         "name": "Irisviel - Vessel of the Holy Grail",
@@ -217,7 +217,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E008.png"
     },
     {
         "name": "Saber - End of Reign",
@@ -245,7 +245,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E009.png"
     },
     {
         "name": "Irisviel - Living as a Human",
@@ -272,7 +272,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E010.png"
     },
     {
         "name": "Future Hope, Shiro",
@@ -299,7 +299,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E011.png"
     },
     {
         "name": "Kiritsugu - Pursuit of the Ideal",
@@ -325,7 +325,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E012.png"
     },
     {
         "name": "Parts of Kiritsugu, Maiya",
@@ -351,7 +351,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E013.png"
     },
     {
         "name": "Mother and Child, Irisviel & Ilya",
@@ -380,7 +380,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E014.png"
     },
     {
         "name": "Saber - Noble Phantasm Unleashed",
@@ -408,7 +408,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E015.png"
     },
     {
         "name": "Innocent Girl, Ilya",
@@ -434,7 +434,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E016.png"
     },
     {
         "name": "Irisviel von Einzbern",
@@ -460,7 +460,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E017.png"
     },
     {
         "name": "\"Riding\" Skill, Saber",
@@ -486,7 +486,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E018.png"
     },
     {
         "name": "Maiya Hisau",
@@ -512,7 +512,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E019.png"
     },
     {
         "name": "\"Invisible Air\" Saber",
@@ -538,7 +538,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E020.png"
     },
     {
         "name": "Kiritsugu - Time to Hunt",
@@ -564,7 +564,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E021.png"
     },
     {
         "name": "\"Mage-Killer\" Kiritsugu",
@@ -592,7 +592,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E022.png"
     },
     {
         "name": "Assistant Machine, Maiya",
@@ -621,7 +621,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E023.png"
     },
     {
         "name": "\"First Time Out\" Irisviel von Einzbern",
@@ -649,7 +649,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E024.png"
     },
     {
         "name": "Search for Chestnut Bud",
@@ -676,7 +676,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E025.png"
     },
     {
         "name": "Demolition",
@@ -702,7 +702,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E026.png"
     },
     {
         "name": "Einzbern Castle",
@@ -729,7 +729,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E027.png"
     },
     {
         "name": "Sign of Determination",
@@ -758,7 +758,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E028.png"
     },
     {
         "name": "Origin Shot",
@@ -788,7 +788,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E029.png"
     },
     {
         "name": "Excalibur",
@@ -817,7 +817,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E030.png"
     },
     {
         "name": "Waver Velvet",
@@ -846,7 +846,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E031.png"
     },
     {
         "name": "King of Military Rule, Rider",
@@ -876,7 +876,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E032.png"
     },
     {
         "name": "Kayneth El-Melloi Archibald",
@@ -903,7 +903,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E033.png"
     },
     {
         "name": "Unshakable Pride, Rider",
@@ -929,7 +929,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E034.png"
     },
     {
         "name": "\"Saber's left hand\", Lancer",
@@ -958,7 +958,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E035.png"
     },
     {
         "name": "Ruler of Macedonia, Rider",
@@ -987,7 +987,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E036.png"
     },
     {
         "name": "Lancer - Red Spear Which Cancels Magic",
@@ -1015,7 +1015,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E037.png"
     },
     {
         "name": "Apprentice Mage, Waver",
@@ -1042,7 +1042,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E038.png"
     },
     {
         "name": "Way of the Knight, Lancer",
@@ -1068,7 +1068,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E039.png"
     },
     {
         "name": "King of Grandeur, Rider",
@@ -1094,7 +1094,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E040.png"
     },
     {
         "name": "Charming Magical Look, Lancer",
@@ -1121,7 +1121,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E041.png"
     },
     {
         "name": "Imposing and Majestic, Rider",
@@ -1147,7 +1147,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E042.png"
     },
     {
         "name": "Sola-Ui Nuada-Re Sophia-Ri",
@@ -1173,7 +1173,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E043.png"
     },
     {
         "name": "Proof of Entry, Waver",
@@ -1200,7 +1200,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E044.png"
     },
     {
         "name": "Bold Nature, Rider",
@@ -1226,7 +1226,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E045.png"
     },
     {
         "name": "Loyal and Brave, Lancer",
@@ -1252,7 +1252,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E046.png"
     },
     {
         "name": "Genius Mage, Kayneth",
@@ -1278,7 +1278,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E047.png"
     },
     {
         "name": "Waver \"MacKenzie\"",
@@ -1306,7 +1306,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E048.png"
     },
     {
         "name": "Clock Tower Elite, Kayneth",
@@ -1334,7 +1334,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E049.png"
     },
     {
         "name": "Command Seal",
@@ -1360,7 +1360,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E050.png"
     },
     {
         "name": "Treasured Sword and Magic Spear",
@@ -1387,7 +1387,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E051.png"
     },
     {
         "name": "Ionian Hetairoi",
@@ -1416,7 +1416,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E052CR.png"
     },
     {
         "name": "Bond Between a King and His Retainer",
@@ -1445,7 +1445,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E053.png"
     },
     {
         "name": "Gordius Wheel",
@@ -1474,7 +1474,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E054.png"
     },
     {
         "name": "Gae Dearg",
@@ -1503,7 +1503,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E055.png"
     },
     {
         "name": "Knight of Madness, Berserker",
@@ -1531,7 +1531,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E056.png"
     },
     {
         "name": "King of All Creation, Archer",
@@ -1560,7 +1560,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E057.png"
     },
     {
         "name": "Noble Stance, Archer",
@@ -1587,7 +1587,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E058.png"
     },
     {
         "name": "Bloodthirsty Beast, Berserker",
@@ -1614,7 +1614,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E059.png"
     },
     {
         "name": "Supreme Wine, Archer",
@@ -1641,7 +1641,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E060.png"
     },
     {
         "name": "Golden Monarch, Archer",
@@ -1668,7 +1668,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E061.png"
     },
     {
         "name": "Curse Incarnate, Berserker",
@@ -1694,7 +1694,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E062.png"
     },
     {
         "name": "Head of Tohsaka Family, Tokiomi",
@@ -1722,7 +1722,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E063.png"
     },
     {
         "name": "Venerable Mage, Tokiomi",
@@ -1749,7 +1749,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E064.png"
     },
     {
         "name": "King of Kings, Archer",
@@ -1775,7 +1775,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E065.png"
     },
     {
         "name": "Matou's Obsession, Zouken",
@@ -1801,7 +1801,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E066.png"
     },
     {
         "name": "Sakura - Corrupted Heart",
@@ -1828,7 +1828,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E067.png"
     },
     {
         "name": "Kariya - Cost of Life",
@@ -1856,7 +1856,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E068.png"
     },
     {
         "name": "Young Successor, Rin",
@@ -1884,7 +1884,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E069.png"
     },
     {
         "name": "Berserker - Black Murderous Intent",
@@ -1912,7 +1912,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E070.png"
     },
     {
         "name": "Ancient King, Archer",
@@ -1939,7 +1939,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E071.png"
     },
     {
         "name": "Kariya Matou",
@@ -1965,7 +1965,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E072.png"
     },
     {
         "name": "Memories of Distant Past, Sakura & Aoi & Rin",
@@ -1992,7 +1992,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E073.png"
     },
     {
         "name": "Full of Conceit, Archer",
@@ -2018,7 +2018,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E074.png"
     },
     {
         "name": "\"The Noble One\", Archer",
@@ -2044,7 +2044,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E075.png"
     },
     {
         "name": "Tokiomi - Artifice to Sure Victory",
@@ -2070,7 +2070,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E076.png"
     },
     {
         "name": "Tokiomi - Jewel Magic",
@@ -2096,7 +2096,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E077.png"
     },
     {
         "name": "Man Who Ran from Fate, Kariya",
@@ -2124,7 +2124,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E078.png"
     },
     {
         "name": "Archer - Proud Royal Path",
@@ -2152,7 +2152,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E079.png"
     },
     {
         "name": "Azoth Dagger",
@@ -2179,7 +2179,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E080.png"
     },
     {
         "name": "Vimana",
@@ -2206,7 +2206,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E081.png"
     },
     {
         "name": "Arondight",
@@ -2232,7 +2232,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E082.png"
     },
     {
         "name": "Identity of the Fallen Knight",
@@ -2261,7 +2261,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E083.png"
     },
     {
         "name": "Parting with Rin",
@@ -2290,7 +2290,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E084.png"
     },
     {
         "name": "Sword of Rupture, Ea",
@@ -2319,7 +2319,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E085.png"
     },
     {
         "name": "Kirei - The Emptiness Within",
@@ -2346,7 +2346,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E086.png"
     },
     {
         "name": "Throbbing Soul, Kirei",
@@ -2372,7 +2372,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E087.png"
     },
     {
         "name": "Sadistic Artist, Caster",
@@ -2400,7 +2400,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E088.png"
     },
     {
         "name": "Kirei Kotomine",
@@ -2429,7 +2429,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E089.png"
     },
     {
         "name": "Aesthetics of Death, Caster",
@@ -2455,7 +2455,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E090.png"
     },
     {
         "name": "Receiving New Flesh, Archer",
@@ -2484,7 +2484,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E091.png"
     },
     {
         "name": "Regulator, Risei",
@@ -2510,7 +2510,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E092.png"
     },
     {
         "name": "Many, but One, Assassin",
@@ -2536,7 +2536,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E093.png"
     },
     {
         "name": "Mage Apprentice, Kirei",
@@ -2562,7 +2562,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E094.png"
     },
     {
         "name": "Psycho Killer, Ryunosuke",
@@ -2588,7 +2588,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E095.png"
     },
     {
         "name": "Protector of the Faith, Kirei",
@@ -2617,7 +2617,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E096.png"
     },
     {
         "name": "Flames of Purgatory",
@@ -2643,7 +2643,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E097.png"
     },
     {
         "name": "Sea Monster",
@@ -2669,7 +2669,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E098.png"
     },
     {
         "name": "The Eighth Contract",
@@ -2698,7 +2698,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E099.png"
     },
     {
         "name": "Prank of Fate",
@@ -2727,7 +2727,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_fz_s17_e100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E100.png"
     },
     {
         "name": "Proxy Master, Irisviel",
@@ -2753,7 +2753,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E101.png"
     },
     {
         "name": "Saber in a Dark Suit",
@@ -2781,7 +2781,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_e102.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E102.png"
     },
     {
         "name": "Top Class, Saber",
@@ -2810,7 +2810,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E103.png"
     },
     {
         "name": "Hill of Camlann",
@@ -2838,7 +2838,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_e104.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E104.png"
     },
     {
         "name": "\"Shallow Blooded\" Magus, Waver",
@@ -2864,7 +2864,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_e105.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_E105.png"
     },
     {
         "name": "Mini Saber",
@@ -3024,7 +3024,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FZ_S17_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_PE03.png"
     },
     {
         "name": "Moment of Peace, Saber",
@@ -3050,7 +3050,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_pe04.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_PE04.png"
     },
     {
         "name": "Illya & Irisviel",
@@ -3076,7 +3076,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_pe05.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_PE05.png"
     },
     {
         "name": "Saber & Irisviel & Ilya",
@@ -3102,7 +3102,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "PE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FZ_S17_PE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_PE06.png"
     },
     {
         "name": "Style of a King, Saber",
@@ -3128,7 +3128,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "PE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_FZ_S17_PE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_PE10.png"
     },
     {
         "name": "Summoned Heroine, Saber",
@@ -3154,7 +3154,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te01.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE01.png"
     },
     {
         "name": "Irisviel von Einzbern",
@@ -3180,7 +3180,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te02.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE02.png"
     },
     {
         "name": "Maiya Hisau",
@@ -3205,7 +3205,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te03.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE03.png"
     },
     {
         "name": "\"Riding\" Skill, Saber",
@@ -3231,7 +3231,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te04.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE04.png"
     },
     {
         "name": "\"Invisible Air\" Saber",
@@ -3257,7 +3257,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te05.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE05.png"
     },
     {
         "name": "\"Mage-Killer\" Kiritsugu",
@@ -3285,7 +3285,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te06.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE06.png"
     },
     {
         "name": "Assistant Machine, Maiya",
@@ -3313,7 +3313,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te07.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE07.png"
     },
     {
         "name": "“First Time Out” Irisviel von Einzbern",
@@ -3341,7 +3341,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te08.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE08.png"
     },
     {
         "name": "Einzbern Castle",
@@ -3367,7 +3367,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te09.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE09.png"
     },
     {
         "name": "Proof of Entry, Waver",
@@ -3394,7 +3394,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te10.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE10.png"
     },
     {
         "name": "Loyal and Brave, Lancer",
@@ -3420,7 +3420,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te11.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE11.png"
     },
     {
         "name": "Imposing and Majestic, Rider",
@@ -3446,7 +3446,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te12.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE12.png"
     },
     {
         "name": "Clock Tower Elite, Kayneth",
@@ -3474,7 +3474,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te13.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE13.png"
     },
     {
         "name": "Gordius Wheel",
@@ -3502,7 +3502,7 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te14.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE14.png"
     },
     {
         "name": "Gae Dearg",
@@ -3530,6 +3530,6 @@
         "set": "FZ",
         "release": "17",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/fz_s17_te15.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/f/fz_s17/FZ_S17_TE15.png"
     }
 ]

--- a/DB/GGO_S59.json
+++ b/DB/GGO_S59.json
@@ -21,7 +21,7 @@
         ],
         "flavor_text": "Sure! I'm up for anything! Tell me the plan!",
         "set": "GGO",
-        "release": "SF2019",
+        "release": "BSF2019",
         "sid": "03",
         "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_BSF2019-03.png"
     },

--- a/DB/GGO_S59.json
+++ b/DB/GGO_S59.json
@@ -23,7 +23,7 @@
         "set": "GGO",
         "release": "BSF2019",
         "sid": "03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_BSF2019-03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_BSF2019_03.png"
     },
     {
         "name": "\"Pink Devil\" LLENN",
@@ -50,7 +50,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E001.png"
     },
     {
         "name": "Promise to Be Kept, LLENN",
@@ -80,7 +80,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E002.png"
     },
     {
         "name": "Brimming with Fighting Spirit, LLENN",
@@ -110,7 +110,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E003.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club, Shiori",
@@ -137,7 +137,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E004.png"
     },
     {
         "name": "Interested in VR, Karen",
@@ -164,7 +164,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E005.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club Leader, Saki",
@@ -191,7 +191,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E006.png"
     },
     {
         "name": "Question About Chances of Winning, LLENN",
@@ -218,7 +218,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E007.png"
     },
     {
         "name": "Craving for Sweets Too! Saki & Milana",
@@ -244,7 +244,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E008.png"
     },
     {
         "name": "Taking Every Last Ounce of Courage, LLENN",
@@ -273,7 +273,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E009.png"
     },
     {
         "name": "Boss of 《SHINC》, Eva",
@@ -302,7 +302,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E010.png"
     },
     {
         "name": "《SHINC》, Sophie",
@@ -329,7 +329,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E011.png"
     },
     {
         "name": "Narrow Escape from Death, LLENN",
@@ -356,7 +356,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E012.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club, Milana",
@@ -382,7 +382,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E013.png"
     },
     {
         "name": "Thoroughness of Small, LLENN",
@@ -409,7 +409,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E014.png"
     },
     {
         "name": "Hunch of a Reunion, Karen",
@@ -435,7 +435,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E015.png"
     },
     {
         "name": "《SHINC》, Roza",
@@ -461,7 +461,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E016.png"
     },
     {
         "name": "《SHINC》, Toma",
@@ -490,7 +490,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E017.png"
     },
     {
         "name": "Lurking in a Suitcase LLENN",
@@ -519,7 +519,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E018.png"
     },
     {
         "name": "Poncho Style, LLENN",
@@ -546,7 +546,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E019.png"
     },
     {
         "name": "《SHINC》, Tanya",
@@ -573,7 +573,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E020.png"
     },
     {
         "name": "\"Last Battle\", LLENN",
@@ -599,7 +599,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E021.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club, Moe",
@@ -625,7 +625,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E022.png"
     },
     {
         "name": "All Set! LLENN",
@@ -652,7 +652,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E023.png"
     },
     {
         "name": "《SHINC》, Anna",
@@ -679,7 +679,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E024.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club, Risa",
@@ -705,7 +705,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E025.png"
     },
     {
         "name": "\"Operation Sweets\", Eva",
@@ -734,7 +734,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E026.png"
     },
     {
         "name": "Affiliated Girls' High School\nRhythmic Gymnastics Club, Kana",
@@ -763,7 +763,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E027.png"
     },
     {
         "name": "Slip into Pink, LLENN",
@@ -792,7 +792,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E028.png"
     },
     {
         "name": "Plasma Grenade",
@@ -817,7 +817,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E029.png"
     },
     {
         "name": "Degtyaryov Anti-Tank Rifle",
@@ -844,7 +844,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E030.png"
     },
     {
         "name": "Word of Honor",
@@ -872,7 +872,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E031.png"
     },
     {
         "name": "Course of the Last Battle",
@@ -900,7 +900,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E032.png"
     },
     {
         "name": "\"Operation Sweets\" A Major Success!",
@@ -928,7 +928,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E033.png"
     },
     {
         "name": "Serious Battle",
@@ -956,7 +956,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E034.png"
     },
     {
         "name": "Insightful Shooter, LLENN",
@@ -983,7 +983,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E035.png"
     },
     {
         "name": "Rampaging in \"GGO\"! Fukaziroh",
@@ -1010,7 +1010,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E036.png"
     },
     {
         "name": "Insane LLENN",
@@ -1039,7 +1039,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E037.png"
     },
     {
         "name": "Cleansing with Grenades! Fukaziroh",
@@ -1068,7 +1068,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E038.png"
     },
     {
         "name": "Beautiful Beloved Weapon, Fukaziroh",
@@ -1095,7 +1095,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E039.png"
     },
     {
         "name": "\"Beloved Weapons Don't Betray\" LLENN",
@@ -1122,7 +1122,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E040.png"
     },
     {
         "name": "Bold Tactic, Fukaziroh",
@@ -1148,7 +1148,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E041.png"
     },
     {
         "name": "\"Super Haphazard\", LLENN",
@@ -1175,7 +1175,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E042.png"
     },
     {
         "name": "Tough Partner, Fukaziroh",
@@ -1202,7 +1202,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E043.png"
     },
     {
         "name": "Feeling of Uneasiness, LLENN",
@@ -1228,7 +1228,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E044.png"
     },
     {
         "name": "Best Tactic Up Their Sleeves, Fukaziroh",
@@ -1258,7 +1258,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E045.png"
     },
     {
         "name": "Lively Assault, LLENN",
@@ -1287,7 +1287,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E046.png"
     },
     {
         "name": "Altruist, Clarence",
@@ -1314,7 +1314,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E047.png"
     },
     {
         "name": "Bond with P-chan, LLENN",
@@ -1340,7 +1340,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E048.png"
     },
     {
         "name": "Keeping In Check At Gunpoint, Fukaziroh",
@@ -1367,7 +1367,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E049.png"
     },
     {
         "name": "Supporting Fire, Fukaziroh",
@@ -1396,7 +1396,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E050.png"
     },
     {
         "name": "Ability of a Champion, LLENN",
@@ -1425,7 +1425,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E051.png"
     },
     {
         "name": "\"Magazines & A Kiss\" LLENN",
@@ -1453,7 +1453,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E052.png"
     },
     {
         "name": "LLENN Piling Up Experience",
@@ -1480,7 +1480,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E053.png"
     },
     {
         "name": "Way To Fight With a Petite Figure, LLENN",
@@ -1507,7 +1507,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E054.png"
     },
     {
         "name": "Hidden Blade, Fukaziroh",
@@ -1534,7 +1534,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E055.png"
     },
     {
         "name": "Ice Cream Before Battle, Miyu",
@@ -1561,7 +1561,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E056.png"
     },
     {
         "name": "Searching for Comrades, Karen",
@@ -1587,7 +1587,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E057.png"
     },
     {
         "name": "With My Beloved Weapons, Fukaziroh",
@@ -1614,7 +1614,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E058.png"
     },
     {
         "name": "Pinpoint Induction, LLENN",
@@ -1641,7 +1641,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E059.png"
     },
     {
         "name": "Helper from \"ALO\", Fukaziroh",
@@ -1669,7 +1669,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E060.png"
     },
     {
         "name": "Real Life Close Friends, Karen & Miyu",
@@ -1698,7 +1698,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E061.png"
     },
     {
         "name": "Chatting P-chan",
@@ -1723,7 +1723,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E062.png"
     },
     {
         "name": "Multiple Grenade Launcher",
@@ -1749,7 +1749,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E063.png"
     },
     {
         "name": "Emergency Med Kit",
@@ -1774,7 +1774,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E064.png"
     },
     {
         "name": "Don't Underestimate A Fairy!",
@@ -1802,7 +1802,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E065.png"
     },
     {
         "name": "Even By Gnawing Through The Throat",
@@ -1830,7 +1830,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E066.png"
     },
     {
         "name": "How Adorable…",
@@ -1858,7 +1858,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E067.png"
     },
     {
         "name": "Cut! Kick!",
@@ -1887,7 +1887,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E068.png"
     },
     {
         "name": "True Identity of the Devil, Elza",
@@ -1914,7 +1914,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E069.png"
     },
     {
         "name": "Obstinate Death Wish, Pitohui",
@@ -1941,7 +1941,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E070.png"
     },
     {
         "name": "Devil, Pitohui",
@@ -1970,7 +1970,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E071.png"
     },
     {
         "name": "Excellent Combat Skill, M",
@@ -1997,7 +1997,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E072.png"
     },
     {
         "name": "In Coma, Pitohui",
@@ -2024,7 +2024,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E073.png"
     },
     {
         "name": "Superb Geographical Sense, M",
@@ -2050,7 +2050,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E074.png"
     },
     {
         "name": "Look of a Sadist, Pitohui",
@@ -2077,7 +2077,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E075.png"
     },
     {
         "name": "Setting the Stage, M",
@@ -2106,7 +2106,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E076.png"
     },
     {
         "name": "Gun Enthusiast, Pitohui",
@@ -2136,7 +2136,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E077.png"
     },
     {
         "name": "Origin of Name, M",
@@ -2165,7 +2165,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E078.png"
     },
     {
         "name": "Boring Tactic, Pitohui",
@@ -2192,7 +2192,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E079.png"
     },
     {
         "name": "Declaration of War, Pitohui",
@@ -2219,7 +2219,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E080.png"
     },
     {
         "name": "Dissatisfied Pitohui",
@@ -2245,7 +2245,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E081.png"
     },
     {
         "name": "Leader of \"MMTM\", David",
@@ -2271,7 +2271,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E082.png"
     },
     {
         "name": "Being Outnumbered? Pitohui",
@@ -2300,7 +2300,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E083.png"
     },
     {
         "name": "Marksmanship, M",
@@ -2330,7 +2330,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E084.png"
     },
     {
         "name": "Imminent \"Death\", M",
@@ -2357,7 +2357,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E085.png"
     },
     {
         "name": "Real World Circumstances, Goushi",
@@ -2384,7 +2384,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E086.png"
     },
     {
         "name": "Purging the Traitor, Pitohui",
@@ -2410,7 +2410,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E087.png"
     },
     {
         "name": "Machine Guns are FUN! ZEMAL",
@@ -2438,7 +2438,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E088.png"
     },
     {
         "name": "\"KKHC\" Bright Flower, Shirley",
@@ -2464,7 +2464,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E089.png"
     },
     {
         "name": "Fathomed Act, Elza",
@@ -2490,7 +2490,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E090.png"
     },
     {
         "name": "Fright & Betrayal, M",
@@ -2519,7 +2519,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E091.png"
     },
     {
         "name": "Excessive Excitement, Pitohui",
@@ -2548,7 +2548,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E092.png"
     },
     {
         "name": "Incensed Pitohui",
@@ -2577,7 +2577,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E093.png"
     },
     {
         "name": "Satellite Scan",
@@ -2603,7 +2603,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E094.png"
     },
     {
         "name": "Muramasa F10",
@@ -2628,7 +2628,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E095.png"
     },
     {
         "name": "Shield of M",
@@ -2653,7 +2653,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E096.png"
     },
     {
         "name": "Resurrection of the Devil",
@@ -2682,7 +2682,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E097.png"
     },
     {
         "name": "Pleasure in Massacre",
@@ -2710,7 +2710,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E098.png"
     },
     {
         "name": "Strategy of the Cautious Type",
@@ -2738,7 +2738,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E099.png"
     },
     {
         "name": "A Love at the Risk of One's Life",
@@ -2767,7 +2767,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E100.png"
     },
     {
         "name": "Look of Admiration, Saki",
@@ -2796,7 +2796,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E101.png"
     },
     {
         "name": "VR Teatime, LLENN",
@@ -2823,7 +2823,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E102.png"
     },
     {
         "name": "VR Teatime, Fukaziroh",
@@ -2850,7 +2850,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E103.png"
     },
     {
         "name": "Leisure with Dignity, Pitohui",
@@ -2877,7 +2877,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_E104.png"
     },
     {
         "name": "Confident in Her Dexterity! LLENN",
@@ -2904,7 +2904,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_PE02.png"
     },
     {
         "name": "Overwhelming World View, LLENN",
@@ -2931,7 +2931,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE01.png"
     },
     {
         "name": "Karen Hoping For A Change",
@@ -2958,7 +2958,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE02.png"
     },
     {
         "name": "\"Partner\" LLENN & Fukaziroh",
@@ -2984,7 +2984,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE03.png"
     },
     {
         "name": "Senior Gamer, Miyu",
@@ -3010,7 +3010,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE04.png"
     },
     {
         "name": "I'll Do It!! LLENN",
@@ -3037,7 +3037,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE05.png"
     },
     {
         "name": "Sharp Look, LLENN",
@@ -3063,7 +3063,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE06.png"
     },
     {
         "name": "Bashful Karen",
@@ -3092,7 +3092,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE07.png"
     },
     {
         "name": "Squad Leader, LLENN",
@@ -3121,7 +3121,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE08.png"
     },
     {
         "name": "Rampaging With Determination! LLENN",
@@ -3150,7 +3150,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE09.png"
     },
     {
         "name": "Tutorial",
@@ -3177,7 +3177,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE10.png"
     },
     {
         "name": "Pink's Ambush",
@@ -3206,7 +3206,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE11.png"
     },
     {
         "name": "Aiming The Instant, M",
@@ -3233,7 +3233,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE12.png"
     },
     {
         "name": "Get Rid Of Nuisances, Pitohui",
@@ -3259,7 +3259,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE13.png"
     },
     {
         "name": "Veteran Player, Pitohui",
@@ -3286,7 +3286,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE14.png"
     },
     {
         "name": "Brain Role, M",
@@ -3312,7 +3312,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE15.png"
     },
     {
         "name": "Encounter With LLENN, Pitohui",
@@ -3338,7 +3338,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE16.png"
     },
     {
         "name": "First Meeting, M",
@@ -3366,7 +3366,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE17.png"
     },
     {
         "name": "Squad Jam Invitation, Pitohui",
@@ -3395,7 +3395,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE18.png"
     },
     {
         "name": "Hobby Talk, Pitohui",
@@ -3424,7 +3424,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE19.png"
     },
     {
         "name": "Sadistic Smile",
@@ -3453,7 +3453,7 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE20.png"
     },
     {
         "name": "Snipers' Confrontation",
@@ -3482,6 +3482,6 @@
         "set": "GGO",
         "release": "59",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/GGO_S59_TE21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/ggo_s59/GGO_S59_TE21.png"
     }
 ]

--- a/DB/GL_S52.json
+++ b/DB/GL_S52.json
@@ -24,7 +24,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E001.png"
     },
     {
         "name": "Kamina",
@@ -51,7 +51,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E002.png"
     },
     {
         "name": "Yoko",
@@ -81,7 +81,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E003.png"
     },
     {
         "name": "I'll Be Seeing Ya Soon, You Bozos! Kittan",
@@ -110,7 +110,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E004.png"
     },
     {
         "name": "Team Super Galaxy DAI-GURREN, Yoko",
@@ -137,7 +137,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E005.png"
     },
     {
         "name": "Kid & Iraak",
@@ -164,7 +164,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E006.png"
     },
     {
         "name": "King Kittan",
@@ -190,7 +190,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E007.png"
     },
     {
         "name": "Warrior Brimming With Life Experience, Makken",
@@ -216,7 +216,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E008.png"
     },
     {
         "name": "Sniper Yoko",
@@ -242,7 +242,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E009.png"
     },
     {
         "name": "Zorthy",
@@ -268,7 +268,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E010.png"
     },
     {
         "name": "Science Bureau Chief, Leeron",
@@ -297,7 +297,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E011.png"
     },
     {
         "name": "Chief Advisor's Secretary, Kinon",
@@ -324,7 +324,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E012.png"
     },
     {
         "name": "Aretenborough",
@@ -351,7 +351,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E013.png"
     },
     {
         "name": "Setting Off from Adai Village, Rossiu",
@@ -377,7 +377,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E014.png"
     },
     {
         "name": "If You Doubt Yourself, Kamina",
@@ -404,7 +404,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E015.png"
     },
     {
         "name": "Jorgun & Balinbow",
@@ -431,7 +431,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E016.png"
     },
     {
         "name": "Dreadnaught Captain, Dayakka",
@@ -460,7 +460,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E017.png"
     },
     {
         "name": "Make the Impossible Possible! Kamina",
@@ -488,7 +488,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E018.png"
     },
     {
         "name": "Special Lesson, Yomako",
@@ -516,7 +516,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E019.png"
     },
     {
         "name": "The Black Siblings, Kinon & Kiyoh & Kiyal",
@@ -543,7 +543,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E020.png"
     },
     {
         "name": "I Have to Know～! Kiyal & Kiyoh",
@@ -570,7 +570,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E021.png"
     },
     {
         "name": "Yomako's Students, Maosha & Nakim",
@@ -597,7 +597,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E022.png"
     },
     {
         "name": "Girls' Feelings, Leeron",
@@ -623,7 +623,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E023.png"
     },
     {
         "name": "New Supreme Commander of the New Government, Rossiu",
@@ -650,7 +650,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E024.png"
     },
     {
         "name": "Reliable Mechanic, Leyte",
@@ -677,7 +677,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E025.png"
     },
     {
         "name": "Masculinity Is About Fighting Spirit! Kamina",
@@ -703,7 +703,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E026.png"
     },
     {
         "name": "The Black Siblings, Kittan",
@@ -729,7 +729,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E027.png"
     },
     {
         "name": "New Teacher, Yomako",
@@ -757,7 +757,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E028.png"
     },
     {
         "name": "Team DAI-GURREN Flag",
@@ -783,7 +783,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E029.png"
     },
     {
         "name": "Later, Buddy",
@@ -813,7 +813,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E030.png"
     },
     {
         "name": "For the Sake of Precious Children",
@@ -842,7 +842,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E031.png"
     },
     {
         "name": "So This Is the Power of the Spiral, Huh...?",
@@ -872,7 +872,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E032.png"
     },
     {
         "name": "Nia",
@@ -898,7 +898,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E033.png"
     },
     {
         "name": "Beastman, Viral",
@@ -925,7 +925,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E034.png"
     },
     {
         "name": "Human Eradication Forces Far East Theater Commander, Viral",
@@ -952,7 +952,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E035.png"
     },
     {
         "name": "Team DAI-GURREN's Head Cook, Nia",
@@ -982,7 +982,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E036.png"
     },
     {
         "name": "Spiral King's Supreme General, Cytomander the Swift",
@@ -1011,7 +1011,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E037.png"
     },
     {
         "name": "Believing Heart, Nia",
@@ -1041,7 +1041,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E038.png"
     },
     {
         "name": "Lazengann",
@@ -1071,7 +1071,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E039.png"
     },
     {
         "name": "The Spiral King, Lordgenome",
@@ -1100,7 +1100,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E040.png"
     },
     {
         "name": "Elusive Old Coco",
@@ -1127,7 +1127,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E041.png"
     },
     {
         "name": "My Feelings, Nia",
@@ -1154,7 +1154,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E042.png"
     },
     {
         "name": "Tyrant of Teppelin, Lordgenome",
@@ -1181,7 +1181,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E043.png"
     },
     {
         "name": "Destined Duel, Enkidu",
@@ -1209,7 +1209,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E044.png"
     },
     {
         "name": "Mobile Fortress Gunmen, Dai-Gunzan",
@@ -1236,7 +1236,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E045.png"
     },
     {
         "name": "Special Seat of an Ex-Rival, Viral",
@@ -1264,7 +1264,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E046.png"
     },
     {
         "name": "First Swimsuit, Nia",
@@ -1291,7 +1291,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E047.png"
     },
     {
         "name": "Spiral King's Supreme General, Thymilph the Raging Wave",
@@ -1317,7 +1317,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E048.png"
     },
     {
         "name": "Two Faces, Enki",
@@ -1344,7 +1344,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E049.png"
     },
     {
         "name": "Bio-Computer Lordgenome Head",
@@ -1372,7 +1372,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E050.png"
     },
     {
         "name": "Mystery Monstrous Mecha, Gunmen",
@@ -1398,7 +1398,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E051.png"
     },
     {
         "name": "Spiral King's Supreme General, Adiane the Elegant",
@@ -1425,7 +1425,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E052.png"
     },
     {
         "name": "Obstructive Viral",
@@ -1454,7 +1454,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E053.png"
     },
     {
         "name": "Spiral King's Supreme General, Guame the Immovable",
@@ -1484,7 +1484,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E054.png"
     },
     {
         "name": "Spiral Energy",
@@ -1510,7 +1510,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E055.png"
     },
     {
         "name": "That's What... I Was Waiting For!!",
@@ -1539,7 +1539,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E056.png"
     },
     {
         "name": "Destiny Combining, GURREN LAGANN",
@@ -1568,7 +1568,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E057.png"
     },
     {
         "name": "This Time, It Really Is Over…",
@@ -1597,7 +1597,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E058.png"
     },
     {
         "name": "Lord of the Beastmen",
@@ -1626,7 +1626,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E059.png"
     },
     {
         "name": "To Save The Woman I Love, Simon",
@@ -1653,7 +1653,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E060.png"
     },
     {
         "name": "GURREN LAGANN, Double Boomerang Spiral",
@@ -1680,7 +1680,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E061.png"
     },
     {
         "name": "Team DAI-GURREN's Leader, Simon",
@@ -1710,7 +1710,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E062.png"
     },
     {
         "name": "TENGEN TOPPA GURREN LAGANN",
@@ -1739,7 +1739,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E063.png"
     },
     {
         "name": "A Proper Member of Team DAI-GURREN, Boota",
@@ -1766,7 +1766,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E064.png"
     },
     {
         "name": "Drill Power, LAGANN",
@@ -1793,7 +1793,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E065.png"
     },
     {
         "name": "Strong Will, Simon",
@@ -1819,7 +1819,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E066.png"
     },
     {
         "name": "Team Super Galaxy DAI-GURREN's Leader, Simon",
@@ -1845,7 +1845,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E067.png"
     },
     {
         "name": "GURREN LAGANN",
@@ -1873,7 +1873,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E068.png"
     },
     {
         "name": "Super Galaxy DAI-GURREN",
@@ -1903,7 +1903,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E069.png"
     },
     {
         "name": "Super Galaxy GURREN LAGANN",
@@ -1934,7 +1934,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E070.png"
     },
     {
         "name": "Supreme Commander of the New Government, Simon",
@@ -1961,7 +1961,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E071.png"
     },
     {
         "name": "DAI-GURREN",
@@ -1987,7 +1987,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E072.png"
     },
     {
         "name": "Evolution By Spiral Power, Boota",
@@ -2016,7 +2016,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E073.png"
     },
     {
         "name": "Piercing Sentiments, Simon & Nia",
@@ -2046,7 +2046,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E074.png"
     },
     {
         "name": "Kamina's Partner, Simon",
@@ -2075,7 +2075,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E075.png"
     },
     {
         "name": "ARCH-GURREN LAGANN",
@@ -2105,7 +2105,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E076.png"
     },
     {
         "name": "Grapearl (For Gimmy's & Darry's Dedicated Use)",
@@ -2132,7 +2132,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E077.png"
     },
     {
         "name": "LAGANN IMPACT!",
@@ -2160,7 +2160,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E078.png"
     },
     {
         "name": "Mass-Production Model, Grapearl",
@@ -2186,7 +2186,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E079.png"
     },
     {
         "name": "Berserk Simon",
@@ -2213,7 +2213,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E080.png"
     },
     {
         "name": "Ace of the New Government Defense Squadron, Gimmy",
@@ -2240,7 +2240,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E081.png"
     },
     {
         "name": "First Rate Marksman, Darry",
@@ -2267,7 +2267,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E082.png"
     },
     {
         "name": "ARC-GURREN",
@@ -2296,7 +2296,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E083.png"
     },
     {
         "name": "Core Drill",
@@ -2322,7 +2322,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E084.png"
     },
     {
         "name": "GIGA DRILL BREAK",
@@ -2348,7 +2348,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E085.png"
     },
     {
         "name": "On My Back, In My Heart,",
@@ -2377,7 +2377,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E086.png"
     },
     {
         "name": "Dueling with the Moon",
@@ -2406,7 +2406,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E087.png"
     },
     {
         "name": "My Drill Is the Drill That Creates the Heavens!!!!",
@@ -2435,7 +2435,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E088.png"
     },
     {
         "name": "That's the Team DAI-GURREN Way!!",
@@ -2464,7 +2464,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E089.png"
     },
     {
         "name": "Messenger Nia",
@@ -2491,7 +2491,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E090.png"
     },
     {
         "name": "Ultimate Universal Diablo, Granzeboma",
@@ -2520,7 +2520,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E091.png"
     },
     {
         "name": "Anti-Spiral Race",
@@ -2547,7 +2547,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E092.png"
     },
     {
         "name": "Ashtanga Class",
@@ -2576,7 +2576,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E093.png"
     },
     {
         "name": "Mugann",
@@ -2603,7 +2603,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E094.png"
     },
     {
         "name": "Advanced Class Mugann",
@@ -2630,7 +2630,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E095.png"
     },
     {
         "name": "Ku-Mugann",
@@ -2659,7 +2659,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E096.png"
     },
     {
         "name": "Kyo-Mugann",
@@ -2688,7 +2688,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E097.png"
     },
     {
         "name": "Death Spiral Machine",
@@ -2714,7 +2714,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E098.png"
     },
     {
         "name": "The Conclusion of Evolution is Universal Destruction－－",
@@ -2744,7 +2744,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E099.png"
     },
     {
         "name": "Humanity Extermination System",
@@ -2773,7 +2773,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E100.png"
     },
     {
         "name": "One Shot to Finish Them All, Yoko",
@@ -2799,7 +2799,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E101.png"
     },
     {
         "name": "Perennial Pledge, Nia",
@@ -2825,7 +2825,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E102.png"
     },
     {
         "name": "Helmet Bond, Viral",
@@ -2851,7 +2851,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E103.png"
     },
     {
         "name": "Charge Into the Wilderness! Team GURREN",
@@ -2877,7 +2877,7 @@
         "set": "GL",
         "release": "52",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_E104.png"
     },
     {
         "name": "We Are Team GURREN!",
@@ -2989,7 +2989,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE01.png"
     },
     {
         "name": "The Girl From the Surface, Yoko",
@@ -3015,7 +3015,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE02.png"
     },
     {
         "name": "\"Bro\" Kamina",
@@ -3041,7 +3041,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE03.png"
     },
     {
         "name": "Massive Rifle, Yoko",
@@ -3067,7 +3067,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE04.png"
     },
     {
         "name": "Badass Indomitable Leader, Kamina",
@@ -3094,7 +3094,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE05.png"
     },
     {
         "name": "The Brutal Surface, Yoko",
@@ -3123,7 +3123,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE06.png"
     },
     {
         "name": "Team GURREN's Leader, Kamina",
@@ -3152,7 +3152,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE07.png"
     },
     {
         "name": "Who The Hell Do You Think I Am??!!",
@@ -3182,7 +3182,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE08.png"
     },
     {
         "name": "Chibi Pig-Mole, Boota",
@@ -3209,7 +3209,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE09.png"
     },
     {
         "name": "Simon the Digger",
@@ -3236,7 +3236,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE10.png"
     },
     {
         "name": "LAGANN",
@@ -3262,7 +3262,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE11.png"
     },
     {
         "name": "Heaven-Piercing Drill, LAGANN",
@@ -3289,7 +3289,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE12.png"
     },
     {
         "name": "Giha Village Youth, Simon",
@@ -3315,7 +3315,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE13.png"
     },
     {
         "name": "Its Name Is GURREN",
@@ -3342,7 +3342,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE14.png"
     },
     {
         "name": "GURREN",
@@ -3371,7 +3371,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE15.png"
     },
     {
         "name": "Save My Bro! Simon",
@@ -3399,7 +3399,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE16.png"
     },
     {
         "name": "Combine! GURREN LAGANN",
@@ -3428,7 +3428,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE17.png"
     },
     {
         "name": "Cross Counter",
@@ -3454,7 +3454,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE18.png"
     },
     {
         "name": "Bust Through the Heavens with Your Drill!!",
@@ -3483,7 +3483,7 @@
         "set": "GL",
         "release": "52",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE19.png"
     },
     {
         "name": "There's A Surface, All Right!",
@@ -3512,6 +3512,6 @@
         "set": "GL",
         "release": "52",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_GL_S52_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/g/gl_s52/GL_S52_TE20.png"
     }
 ]

--- a/DB/IMC_W41.json
+++ b/DB/IMC_W41.json
@@ -24,7 +24,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E001_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E001.png"
     },
     {
         "name": "Miria Akagi",
@@ -51,7 +51,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E002_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E002.png"
     },
     {
         "name": "Rika Jougasaki",
@@ -77,7 +77,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E003_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E003.png"
     },
     {
         "name": "Kirari Moroboshi",
@@ -107,7 +107,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E004_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E004.png"
     },
     {
         "name": "Mika Jougasaki",
@@ -137,7 +137,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E005_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E005.png"
     },
     {
         "name": "Team KBYD, Yuki",
@@ -164,7 +164,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E006_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E006.png"
     },
     {
         "name": "Airi Totoki",
@@ -191,7 +191,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E007_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E007.png"
     },
     {
         "name": "new generations, Mio",
@@ -218,7 +218,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E008_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E008.png"
     },
     {
         "name": "Reliable Senior, Mika",
@@ -244,7 +244,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E009_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E009.png"
     },
     {
         "name": "Happy Happy ☆ Kirari",
@@ -272,7 +272,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E010_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E010.png"
     },
     {
         "name": "Dekoration, Miria",
@@ -301,7 +301,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E011_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E011.png"
     },
     {
         "name": "Dekoration, Rika",
@@ -331,7 +331,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E012_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E012.png"
     },
     {
         "name": "Syoko Hoshi",
@@ -358,7 +358,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E013_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E013.png"
     },
     {
         "name": "Taking a Step Once More, Mio",
@@ -385,7 +385,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E014_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E014.png"
     },
     {
         "name": "Flying Kiss, Mika",
@@ -411,7 +411,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E015_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E015.png"
     },
     {
         "name": "Aiko Takamori",
@@ -437,7 +437,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E016_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E016.png"
     },
     {
         "name": "Nana Abe",
@@ -464,7 +464,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E017_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E017.png"
     },
     {
         "name": "Loves Big Sis, Rika",
@@ -491,7 +491,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E018_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E018.png"
     },
     {
         "name": "Camp with Everyone, Miria",
@@ -517,7 +517,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E019_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E019.png"
     },
     {
         "name": "Feeling Worried, Kirari",
@@ -544,7 +544,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E020_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E020.png"
     },
     {
         "name": "Popular in Class, Mio",
@@ -572,7 +572,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E021_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E021.png"
     },
     {
         "name": "Dekoration, Kirari",
@@ -600,7 +600,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E022_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E022.png"
     },
     {
         "name": "Bad at Smiling? Producer",
@@ -626,7 +626,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E023_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E023.png"
     },
     {
         "name": "My First Star, Miria",
@@ -653,7 +653,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E024_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E024.png"
     },
     {
         "name": "Sanae Katagiri",
@@ -679,7 +679,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E025_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E025.png"
     },
     {
         "name": "Yuki Himekawa",
@@ -705,7 +705,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E026_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E026.png"
     },
     {
         "name": "Akane Hino",
@@ -732,7 +732,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E027_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E027.png"
     },
     {
         "name": "Yui Ohtsuki",
@@ -760,7 +760,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E028_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E028.png"
     },
     {
         "name": "Mio in Summer Clothes",
@@ -786,7 +786,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E029_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E029.png"
     },
     {
         "name": "Yuko Hori",
@@ -815,7 +815,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E030_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E030.png"
     },
     {
         "name": "Gentle Big Sis, Mika",
@@ -843,7 +843,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E031_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E031.png"
     },
     {
         "name": "Matching Live T-shirts, Mika",
@@ -871,7 +871,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E032_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E032.png"
     },
     {
         "name": "Shizuku Oikawa",
@@ -899,7 +899,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E033_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E033.png"
     },
     {
         "name": "Unspoken Pressure",
@@ -925,7 +925,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E034_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E034.png"
     },
     {
         "name": "Energy Drink",
@@ -951,7 +951,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E035_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E035.png"
     },
     {
         "name": "LET’S GO HAPPY!!",
@@ -981,7 +981,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E036_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E036.png"
     },
     {
         "name": "Brand New Evo! Revo! Generation!",
@@ -1011,7 +1011,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E037_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E037.png"
     },
     {
         "name": "TOKIMEKI Escalate",
@@ -1041,7 +1041,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E038_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E038.png"
     },
     {
         "name": "Fan Letter",
@@ -1070,7 +1070,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E039_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E039.png"
     },
     {
         "name": "Chihiro Senkawa",
@@ -1097,7 +1097,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E040_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E040.png"
     },
     {
         "name": "Kanako Mimura",
@@ -1124,7 +1124,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E041_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E041.png"
     },
     {
         "name": "Uzuki Shimamura",
@@ -1151,7 +1151,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E042_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E042.png"
     },
     {
         "name": "Anzu Futaba",
@@ -1181,7 +1181,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E043_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E043.png"
     },
     {
         "name": "Miku Maekawa",
@@ -1210,7 +1210,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E044_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E044.png"
     },
     {
         "name": "Chieri Ogata",
@@ -1240,7 +1240,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E045_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E045.png"
     },
     {
         "name": "Sae Kobayakawa",
@@ -1267,7 +1267,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E046_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E046.png"
     },
     {
         "name": "Marketing Mode, Anzu",
@@ -1293,7 +1293,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E047_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E047.png"
     },
     {
         "name": "CANDY ISLAND, Chieri",
@@ -1320,7 +1320,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E048_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E048.png"
     },
     {
         "name": "Sachiko Koshimizu",
@@ -1346,7 +1346,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E049_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E049.png"
     },
     {
         "name": "CANDY ISLAND, Kanako",
@@ -1375,7 +1375,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E050_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E050.png"
     },
     {
         "name": "Our Lyrics, Miku",
@@ -1404,7 +1404,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E051_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E051.png"
     },
     {
         "name": "new generations, Uzuki",
@@ -1433,7 +1433,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E052_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E052.png"
     },
     {
         "name": "Miho Kohinata",
@@ -1459,7 +1459,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E053_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E053.png"
     },
     {
         "name": "My First Star, Kanako",
@@ -1485,7 +1485,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E054_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E054.png"
     },
     {
         "name": "Full of Smiles, Uzuki",
@@ -1511,7 +1511,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E055_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E055.png"
     },
     {
         "name": "Strike! Miku",
@@ -1537,7 +1537,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E056_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E056.png"
     },
     {
         "name": "My First Star, Chieri",
@@ -1563,7 +1563,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E057_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E057.png"
     },
     {
         "name": "Mayu Sakuma",
@@ -1592,7 +1592,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E058_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E058.png"
     },
     {
         "name": "My First Star, Uzuki",
@@ -1621,7 +1621,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E059_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E059.png"
     },
     {
         "name": "CANDY ISLAND, Anzu",
@@ -1650,7 +1650,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E060_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E060.png"
     },
     {
         "name": "Relaxation Time, Anzu",
@@ -1677,7 +1677,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E061_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E061.png"
     },
     {
         "name": "At Work, Producer",
@@ -1703,7 +1703,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E062_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E062.png"
     },
     {
         "name": "Marshmallow Catch, Kanako",
@@ -1729,7 +1729,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E063_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E063.png"
     },
     {
         "name": "＊(Asterisk), Miku",
@@ -1755,7 +1755,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E064_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E064.png"
     },
     {
         "name": "Rina Fujimoto",
@@ -1781,7 +1781,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E065_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E065.png"
     },
     {
         "name": "Team KBYD, Sachiko",
@@ -1810,7 +1810,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E066_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E066.png"
     },
     {
         "name": "Uzuki in Pajamas",
@@ -1836,7 +1836,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E067_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E067.png"
     },
     {
         "name": "Team KBYD, Sae",
@@ -1864,7 +1864,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E068_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E068.png"
     },
     {
         "name": "Camp with Everyone, Chieri",
@@ -1892,7 +1892,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E069_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E069.png"
     },
     {
         "name": "Stamina Drink",
@@ -1921,7 +1921,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E070_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E070.png"
     },
     {
         "name": "Bond of new generations",
@@ -1947,7 +1947,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E071_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E071.png"
     },
     {
         "name": "Happy×2 Days",
@@ -1976,7 +1976,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E072_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E072.png"
     },
     {
         "name": "ΦωΦver!!",
@@ -2005,7 +2005,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E073_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E073.png"
     },
     {
         "name": "Star!!",
@@ -2034,7 +2034,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E074_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E074.png"
     },
     {
         "name": "Aspired Stage",
@@ -2063,7 +2063,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E075_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E075.png"
     },
     {
         "name": "Result of Going All Out",
@@ -2092,7 +2092,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E076_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E076.png"
     },
     {
         "name": "Riina Tada",
@@ -2119,7 +2119,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E077_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E077.png"
     },
     {
         "name": "Rin Shibuya",
@@ -2145,7 +2145,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E078_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E078.png"
     },
     {
         "name": "Minami Nitta",
@@ -2172,7 +2172,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E079_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E079.png"
     },
     {
         "name": "Ranko Kanzaki",
@@ -2201,7 +2201,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E080_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E080.png"
     },
     {
         "name": "Anastasia",
@@ -2230,7 +2230,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E081_RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E081.png"
     },
     {
         "name": "My First Star, Anastasia",
@@ -2257,7 +2257,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E082_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E082.png"
     },
     {
         "name": "＊(Asterisk), Riina",
@@ -2284,7 +2284,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E083_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E083.png"
     },
     {
         "name": "My First Star, Rin",
@@ -2310,7 +2310,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E084_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E084.png"
     },
     {
         "name": "Black Fallen Angel, Ranko",
@@ -2337,7 +2337,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E085_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E085.png"
     },
     {
         "name": "White Angel, Ranko",
@@ -2363,7 +2363,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E086_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E086.png"
     },
     {
         "name": "My First Star, Minami",
@@ -2389,7 +2389,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E087_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E087.png"
     },
     {
         "name": "Mizuki Kawashima",
@@ -2418,7 +2418,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E088_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E088.png"
     },
     {
         "name": "Kaede Takagaki",
@@ -2447,7 +2447,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E089_R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E089.png"
     },
     {
         "name": "Cool High School Girl, Rin",
@@ -2473,7 +2473,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E090_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E090.png"
     },
     {
         "name": "Koume Shirasaka",
@@ -2499,7 +2499,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E091_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E091.png"
     },
     {
         "name": "Camp with Everyone, Anastasia",
@@ -2526,7 +2526,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E092_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E092.png"
     },
     {
         "name": "Karen Hojo",
@@ -2555,7 +2555,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E093_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E093.png"
     },
     {
         "name": "new generations, Rin",
@@ -2584,7 +2584,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E094_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E094.png"
     },
     {
         "name": "Our Lyrics, Riina",
@@ -2612,7 +2612,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E095_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E095.png"
     },
     {
         "name": "LOVE LAIKA, Minami",
@@ -2640,7 +2640,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E096_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E096.png"
     },
     {
         "name": "Nao Kamiya",
@@ -2669,7 +2669,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E097_U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E097.png"
     },
     {
         "name": "LOVE LAIKA, Anastasia",
@@ -2696,7 +2696,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E098_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E098.png"
     },
     {
         "name": "Chie Sasaki",
@@ -2722,7 +2722,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E099_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E099.png"
     },
     {
         "name": "Haruna Kamijo",
@@ -2748,7 +2748,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E100_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E100.png"
     },
     {
         "name": "Aki Yamato",
@@ -2774,7 +2774,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E101_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E101.png"
     },
     {
         "name": "Encounter with Rin, Producer",
@@ -2800,7 +2800,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E102_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E102.png"
     },
     {
         "name": "Time of Awakening, Ranko",
@@ -2826,7 +2826,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E103_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E103.png"
     },
     {
         "name": "Rock Idol, Riina",
@@ -2852,7 +2852,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E104_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E104.png"
     },
     {
         "name": "Strict Stare, Rin",
@@ -2878,7 +2878,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E105_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E105.png"
     },
     {
         "name": "As a Leader, Minami",
@@ -2907,7 +2907,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E106_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E106.png"
     },
     {
         "name": "Sealed Grimoire",
@@ -2934,7 +2934,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E107_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E107.png"
     },
     {
         "name": "Mismatched Pair",
@@ -2960,7 +2960,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E108_C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E108.png"
     },
     {
         "name": "Memories",
@@ -2989,7 +2989,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E109_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E109.png"
     },
     {
         "name": "-LEGNE- Opposing Blade, Melody of Light",
@@ -3018,7 +3018,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E110_CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E110.png"
     },
     {
         "name": "Taking a Step Forward",
@@ -3047,7 +3047,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E111_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E111.png"
     },
     {
         "name": "Everyone's Leader",
@@ -3077,7 +3077,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_E112_CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_E112.png"
     },
     {
         "name": "Sunset Glow Present, Rin",
@@ -3102,7 +3102,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_PE01_PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_PE01.png"
     },
     {
         "name": "Sunset Glow Present, Anzu",
@@ -3129,7 +3129,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_PE02_PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_PE02.png"
     },
     {
         "name": "Start with 14 Members, Rika",
@@ -3156,7 +3156,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE01_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE01.png"
     },
     {
         "name": "Veteran Trainer",
@@ -3183,7 +3183,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE02_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE02.png"
     },
     {
         "name": "In Lesson, Kirari",
@@ -3210,7 +3210,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE03_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE03.png"
     },
     {
         "name": "Taking a Step Once More, Producer",
@@ -3236,7 +3236,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE04_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE04.png"
     },
     {
         "name": "Start with 14 Members, Miria",
@@ -3262,7 +3262,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE05_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE05.png"
     },
     {
         "name": "In Audition, Mio",
@@ -3288,7 +3288,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE06_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE06.png"
     },
     {
         "name": "First Job, Miria",
@@ -3314,7 +3314,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE07_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE07.png"
     },
     {
         "name": "My First Star, Miria",
@@ -3340,7 +3340,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE08_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE08.png"
     },
     {
         "name": "Charisma JK, Mika",
@@ -3366,7 +3366,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE09_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE09.png"
     },
     {
         "name": "First Job, Rika",
@@ -3392,7 +3392,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE10_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE10.png"
     },
     {
         "name": "My First Star, Rika",
@@ -3418,7 +3418,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE11_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE11.png"
     },
     {
         "name": "The First Step, Mio",
@@ -3447,7 +3447,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE12_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE12.png"
     },
     {
         "name": "Together with Anzu, Kirari",
@@ -3476,7 +3476,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE13a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE13a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE13a.png"
     },
     {
         "name": "Together with Anzu, Kirari",
@@ -3505,7 +3505,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE13b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE13b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE13b.png"
     },
     {
         "name": "Together with Anzu, Kirari",
@@ -3534,7 +3534,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE13c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE13c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE13c.png"
     },
     {
         "name": "Together with Anzu, Kirari",
@@ -3563,7 +3563,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE13d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE13d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE13d.png"
     },
     {
         "name": "Encounter with the Trio, Mika",
@@ -3592,7 +3592,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE14_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE14.png"
     },
     {
         "name": "First Job, Kirari",
@@ -3620,7 +3620,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE15_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE15.png"
     },
     {
         "name": "WONDERFUL M@GIC!! Mio",
@@ -3650,7 +3650,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE16_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE16.png"
     },
     {
         "name": "Super Happy-Happy☆ Candy Shower",
@@ -3676,7 +3676,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE17_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE17.png"
     },
     {
         "name": "Please! Cinderella",
@@ -3705,7 +3705,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE18a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE18a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE18a.png"
     },
     {
         "name": "Please! Cinderella",
@@ -3734,7 +3734,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE18b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE18b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE18b.png"
     },
     {
         "name": "Please! Cinderella",
@@ -3763,7 +3763,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE18c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE18c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE18c.png"
     },
     {
         "name": "Please! Cinderella",
@@ -3792,7 +3792,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE18d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE18d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE18d.png"
     },
     {
         "name": "Highest Stage",
@@ -3822,7 +3822,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE19a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE19a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE19a.png"
     },
     {
         "name": "Highest Stage",
@@ -3852,7 +3852,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE19b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE19b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE19b.png"
     },
     {
         "name": "Gentle Smile, Chieri",
@@ -3879,7 +3879,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE20_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE20.png"
     },
     {
         "name": "Producer Holding Out Name Card",
@@ -3905,7 +3905,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE21_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE21.png"
     },
     {
         "name": "Miku Proposes a Showdown",
@@ -3932,7 +3932,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE22_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE22.png"
     },
     {
         "name": "Taking Hold of Victory!? Miku",
@@ -3958,7 +3958,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE23_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE23.png"
     },
     {
         "name": "The First Step, Uzuki",
@@ -3984,7 +3984,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE24_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE24.png"
     },
     {
         "name": "Smiling Double Peace, Uzuki",
@@ -4010,7 +4010,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE25_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE25.png"
     },
     {
         "name": "Plotting Anzu",
@@ -4036,7 +4036,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE26_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE26.png"
     },
     {
         "name": "In Training!? Kanako",
@@ -4062,7 +4062,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE27_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE27.png"
     },
     {
         "name": "Start with 14 Members, Kanako",
@@ -4090,7 +4090,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE28_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE28.png"
     },
     {
         "name": "Does Not Wish to Work, Anzu",
@@ -4116,7 +4116,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE29a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE29a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE29a.png"
     },
     {
         "name": "Does Not Wish to Work, Anzu",
@@ -4142,7 +4142,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE29b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE29b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE29b.png"
     },
     {
         "name": "Does Not Wish to Work, Anzu",
@@ -4168,7 +4168,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE29c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE29c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE29c.png"
     },
     {
         "name": "Does Not Wish to Work, Anzu",
@@ -4194,7 +4194,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE29d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE29d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE29d.png"
     },
     {
         "name": "First Job, Miku",
@@ -4220,7 +4220,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE30_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE30.png"
     },
     {
         "name": "Start with 14 Members, Chieri",
@@ -4246,7 +4246,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE31_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE31.png"
     },
     {
         "name": "Determination to Not Do Work, Anzu",
@@ -4275,7 +4275,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE32_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE32.png"
     },
     {
         "name": "First Job, Chieri",
@@ -4303,7 +4303,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE33_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE33.png"
     },
     {
         "name": "First Job, Kanako",
@@ -4331,7 +4331,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE34_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE34.png"
     },
     {
         "name": "WONDERFUL M@GIC!! Uzuki",
@@ -4361,7 +4361,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE35_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE35.png"
     },
     {
         "name": "Failure!?",
@@ -4387,7 +4387,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE36_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE36.png"
     },
     {
         "name": "Please! Cinderella",
@@ -4416,7 +4416,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE37a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE37a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE37a.png"
     },
     {
         "name": "Please! Cinderella",
@@ -4445,7 +4445,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE37b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE37b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE37b.png"
     },
     {
         "name": "Please! Cinderella",
@@ -4474,7 +4474,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE37c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE37c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE37c.png"
     },
     {
         "name": "Please! Cinderella",
@@ -4503,7 +4503,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE37d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE37d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE37d.png"
     },
     {
         "name": "Highest Stage",
@@ -4532,7 +4532,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE38a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE38a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE38a.png"
     },
     {
         "name": "Highest Stage",
@@ -4561,7 +4561,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE38b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE38b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE38b.png"
     },
     {
         "name": "Anastasia Cheering On",
@@ -4588,7 +4588,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE39",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE39_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE39.png"
     },
     {
         "name": "Under the Same Umbrella, Producer",
@@ -4614,7 +4614,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE40",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE40_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE40.png"
     },
     {
         "name": "The First Step, Rin",
@@ -4641,7 +4641,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE41",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE41_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE41.png"
     },
     {
         "name": "My First Star, Minami",
@@ -4667,7 +4667,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE42",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE42_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE42.png"
     },
     {
         "name": "Encounter with Producer, Rin",
@@ -4693,7 +4693,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE43",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE43_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE43.png"
     },
     {
         "name": "Ranko Cannot be Honest with Herself",
@@ -4719,7 +4719,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE44a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE44a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE44a.png"
     },
     {
         "name": "Ranko Cannot be Honest with Herself",
@@ -4745,7 +4745,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE44b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE44b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE44b.png"
     },
     {
         "name": "Ranko Cannot be Honest with Herself",
@@ -4771,7 +4771,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE44c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE44c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE44c.png"
     },
     {
         "name": "Ranko Cannot be Honest with Herself",
@@ -4797,7 +4797,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE44d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE44d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE44d.png"
     },
     {
         "name": "Before the Stage, Riina",
@@ -4823,7 +4823,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE45",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE45_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE45.png"
     },
     {
         "name": "First Job, Ranko",
@@ -4849,7 +4849,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE46",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE46_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE46.png"
     },
     {
         "name": "Start with 14 Members, Riina",
@@ -4875,7 +4875,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE47",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE47_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE47.png"
     },
     {
         "name": "First Job, Anastasia",
@@ -4901,7 +4901,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE48",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE48_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE48.png"
     },
     {
         "name": "Facing the Debut, Minami",
@@ -4927,7 +4927,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE49",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE49_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE49.png"
     },
     {
         "name": "First Job, Minami",
@@ -4955,7 +4955,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE50",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE50_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE50.png"
     },
     {
         "name": "My First Star, Ranko",
@@ -4984,7 +4984,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE51",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE51_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE51.png"
     },
     {
         "name": "Confirmed Debut, Anastasia",
@@ -5012,7 +5012,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE52",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE52_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE52.png"
     },
     {
         "name": "First Job, Riina",
@@ -5040,7 +5040,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE53",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE53_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE53.png"
     },
     {
         "name": "WONDERFUL M@GIC!! Rin",
@@ -5070,7 +5070,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE54",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE54_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE54.png"
     },
     {
         "name": "Hanako",
@@ -5097,7 +5097,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE55",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE55_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE55.png"
     },
     {
         "name": "Please! Cinderella",
@@ -5126,7 +5126,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE56a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE56a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE56a.png"
     },
     {
         "name": "Please! Cinderella",
@@ -5155,7 +5155,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE56b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE56b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE56b.png"
     },
     {
         "name": "Please! Cinderella",
@@ -5184,7 +5184,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE56c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE56c_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE56c.png"
     },
     {
         "name": "Please! Cinderella",
@@ -5213,7 +5213,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE56d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE56d_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE56d.png"
     },
     {
         "name": "Highest Stage",
@@ -5242,7 +5242,7 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE57a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE57a_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE57a.png"
     },
     {
         "name": "Highest Stage",
@@ -5271,6 +5271,6 @@
         "set": "IMC",
         "release": "41",
         "sid": "TE57b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_IMC_W41_TE57b_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/i/imc_w41/IMC_W41_TE57b.png"
     }
 ]

--- a/DB/JJ_S66.json
+++ b/DB/JJ_S66.json
@@ -24,7 +24,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E001.png"
     },
     {
         "name": "Path Within the Darkness, Mista",
@@ -51,7 +51,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E002.png"
     },
     {
         "name": "The Path Ahead, Giorno",
@@ -80,7 +80,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E003.png"
     },
     {
         "name": "Final Form, G.W.R",
@@ -110,7 +110,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E004.png"
     },
     {
         "name": "Embodiment of Justice, Giorno",
@@ -137,7 +137,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E005.png"
     },
     {
         "name": "Simmering Fury, Fugo",
@@ -164,7 +164,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E006.png"
     },
     {
         "name": "The One Chosen by Fate, Giorno",
@@ -194,7 +194,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E007.png"
     },
     {
         "name": "Heavy Gunshots, Mista",
@@ -224,7 +224,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E008.png"
     },
     {
         "name": "Angry Lunatic Tendencies, Fugo",
@@ -252,7 +252,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E009.png"
     },
     {
         "name": "Closing in on Death, Mista",
@@ -280,7 +280,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E010.png"
     },
     {
         "name": "Harbinger of Hope, Polnareff",
@@ -307,7 +307,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E011.png"
     },
     {
         "name": "Bizarre Investigation Request, Koichi & Reverb Act 3",
@@ -334,7 +334,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E012.png"
     },
     {
         "name": "Abundance of Life, G.W",
@@ -360,7 +360,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E013.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -387,7 +387,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014a.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -414,7 +414,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014b.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -441,7 +441,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014c.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -468,7 +468,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014d.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -495,7 +495,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014e.png"
     },
     {
         "name": "6 Together as 1, S.B",
@@ -522,7 +522,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E014f",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E014f.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E014f.png"
     },
     {
         "name": "Savage Smoke, P.S",
@@ -548,7 +548,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E015.png"
     },
     {
         "name": "Smoke of Death, Fugo",
@@ -577,7 +577,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E016.png"
     },
     {
         "name": "Silent Dance, C.R",
@@ -603,7 +603,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E017.png"
     },
     {
         "name": "A New Power, G.W",
@@ -629,7 +629,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E018.png"
     },
     {
         "name": "Determination of Life, Giorno",
@@ -658,7 +658,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E019.png"
     },
     {
         "name": "A New Power, Giorno",
@@ -687,7 +687,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E020.png"
     },
     {
         "name": "Unexpected Clean Freak, P.S",
@@ -715,7 +715,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E021.png"
     },
     {
         "name": "Determined Stand, S.B",
@@ -744,7 +744,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E022.png"
     },
     {
         "name": "Ladybug Brooch",
@@ -770,7 +770,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E023.png"
     },
     {
         "name": "The \"Arrow\" of Hope",
@@ -796,7 +796,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E024.png"
     },
     {
         "name": "The World's \"Truth\"",
@@ -826,7 +826,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E025.png"
     },
     {
         "name": "\"The Path\" to Resolution",
@@ -856,7 +856,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E026.png"
     },
     {
         "name": "Rampant Death",
@@ -886,7 +886,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E027.png"
     },
     {
         "name": "Fear of Shrinking, Formaggio & T.F",
@@ -913,7 +913,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E028.png"
     },
     {
         "name": "Crucial Compability Check, Melone & Bh",
@@ -940,7 +940,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E029.png"
     },
     {
         "name": "Grand Teachings, Prosciutto",
@@ -967,7 +967,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E030.png"
     },
     {
         "name": "Grand Teachings, Pesci & F.M",
@@ -995,7 +995,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E031.png"
     },
     {
         "name": "Freezing World, Ghiaccio & W.I",
@@ -1022,7 +1022,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E032.png"
     },
     {
         "name": "Flipped World, Illuso & M.M",
@@ -1050,7 +1050,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E033.png"
     },
     {
         "name": "Unavoidable Assassination, Risotto",
@@ -1080,7 +1080,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E034.png"
     },
     {
         "name": "Man in the Mirror, Illuso",
@@ -1106,7 +1106,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E035.png"
     },
     {
         "name": "Conception of the Two, Bh",
@@ -1133,7 +1133,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E036.png"
     },
     {
         "name": "A Traitor's Dignity, Risotto & Mt",
@@ -1162,7 +1162,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E037.png"
     },
     {
         "name": "Resourceful Assassin, Formaggio",
@@ -1191,7 +1191,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E038.png"
     },
     {
         "name": "Significance of Resolution, Prosciutto & T.D",
@@ -1220,7 +1220,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E039.png"
     },
     {
         "name": "Mammoni, Pesci & F.M",
@@ -1247,7 +1247,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E040.png"
     },
     {
         "name": "Targeting the Hidden Treasure, Zucchero & T.M",
@@ -1274,7 +1274,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E041.png"
     },
     {
         "name": "Targeting the Hidden Treasure, Sale & A&C",
@@ -1300,7 +1300,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E042.png"
     },
     {
         "name": "Gently Weeps, Ghiaccio & W.I.G.W",
@@ -1328,7 +1328,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E043.png"
     },
     {
         "name": "The Disappearance of Sorbet and Gelato",
@@ -1354,7 +1354,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E044.png"
     },
     {
         "name": "Controller of Magnetism",
@@ -1383,7 +1383,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E045.png"
     },
     {
         "name": "Grand Death",
@@ -1412,7 +1412,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E046.png"
     },
     {
         "name": "Remnant of the Past, Diavolo",
@@ -1441,7 +1441,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E047.png"
     },
     {
         "name": "Erased World, E.C",
@@ -1470,7 +1470,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E048.png"
     },
     {
         "name": "Predator of the Waters, Cr",
@@ -1497,7 +1497,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E049.png"
     },
     {
         "name": "\"Movements\" in the Future, Doppio & Eu",
@@ -1523,7 +1523,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E050.png"
     },
     {
         "name": "Spinner of Lies, T.M",
@@ -1549,7 +1549,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E051.png"
     },
     {
         "name": "Sowing Seeds of Despair, Cioccolata & G.T",
@@ -1576,7 +1576,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E052.png"
     },
     {
         "name": "Pride of a King, Diavolo",
@@ -1604,7 +1604,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E053.png"
     },
     {
         "name": "He Who Sinks Into the Ground, Secco & Sa",
@@ -1633,7 +1633,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E054.png"
     },
     {
         "name": "Tyrant Residing in Jail, Polpo",
@@ -1660,7 +1660,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E055.png"
     },
     {
         "name": "10 Hours Ago, Pericolo",
@@ -1687,7 +1687,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E056.png"
     },
     {
         "name": "Harmonized Teamwork, Tiziano",
@@ -1714,7 +1714,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E057.png"
     },
     {
         "name": "Harmonized Teamwork, Squalo",
@@ -1740,7 +1740,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E058.png"
     },
     {
         "name": "Restless Pursuer, N.C",
@@ -1770,7 +1770,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E059.png"
     },
     {
         "name": "Leaky Eye Luca",
@@ -1797,7 +1797,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E060.png"
     },
     {
         "name": "Eternal Ruler, E.C",
@@ -1823,7 +1823,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E061.png"
     },
     {
         "name": "Treat Time, Cioccolata",
@@ -1850,7 +1850,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E062.png"
     },
     {
         "name": "Split Personality, Diavolo",
@@ -1877,7 +1877,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E063.png"
     },
     {
         "name": "Split Personality, Doppio",
@@ -1904,7 +1904,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E064.png"
     },
     {
         "name": "Revenge of the Dead, Carne",
@@ -1931,7 +1931,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E065.png"
     },
     {
         "name": "Treat Time, Secco & Sa",
@@ -1957,7 +1957,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E066.png"
     },
     {
         "name": "Observer From the Shadows, S.S",
@@ -1986,7 +1986,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E067.png"
     },
     {
         "name": "Miraculous Public Telephone",
@@ -2012,7 +2012,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E068.png"
     },
     {
         "name": "Polpo's Entry Test",
@@ -2040,7 +2040,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E069.png"
     },
     {
         "name": "Eternal Ruler",
@@ -2070,7 +2070,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E070.png"
     },
     {
         "name": "10 Seconds Into the Future",
@@ -2099,7 +2099,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E071.png"
     },
     {
         "name": "Cioccolata and Secco",
@@ -2129,7 +2129,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E072.png"
     },
     {
         "name": "Guiding Fate, Trish",
@@ -2156,7 +2156,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E073.png"
     },
     {
         "name": "Noble Resolutions, Bucciarati",
@@ -2183,7 +2183,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E074.png"
     },
     {
         "name": "Soul's Will, Bucciarati",
@@ -2211,7 +2211,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E075.png"
     },
     {
         "name": "Replaying the Past, Abbacchio",
@@ -2239,7 +2239,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E076.png"
     },
     {
         "name": "Beacon Dispelling the Darkness, Bucciarati",
@@ -2267,7 +2267,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E077.png"
     },
     {
         "name": "Choosing His Own Path, Narancia",
@@ -2294,7 +2294,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E078.png"
     },
     {
         "name": "Awakened Power, Trish",
@@ -2324,7 +2324,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E079.png"
     },
     {
         "name": "Pursuer of Information, Abbacchio",
@@ -2354,7 +2354,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E080.png"
     },
     {
         "name": "Aerial Hunter, Narancia",
@@ -2383,7 +2383,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E081.png"
     },
     {
         "name": "Determination to Uncover Truth, M.J",
@@ -2411,7 +2411,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E082.png"
     },
     {
         "name": "Awakened Power, S.L",
@@ -2437,7 +2437,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E083.png"
     },
     {
         "name": "The One Who Opens, Z.M",
@@ -2463,7 +2463,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E084.png"
     },
     {
         "name": "Indestructible Flexibility, S.L",
@@ -2490,7 +2490,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E085.png"
     },
     {
         "name": "Rebelling Against Fate, Bucciarati",
@@ -2519,7 +2519,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E086.png"
     },
     {
         "name": "Rebelling, Trish",
@@ -2548,7 +2548,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E087.png"
     },
     {
         "name": "Agile Aeroplane, L.B",
@@ -2575,7 +2575,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E088.png"
     },
     {
         "name": "The Right Path, Bucciarati",
@@ -2602,7 +2602,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E089.png"
     },
     {
         "name": "Transforming Path, Z.M",
@@ -2628,7 +2628,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E090.png"
     },
     {
         "name": "Overwhelming Mental Strength, Narancia",
@@ -2656,7 +2656,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E091.png"
     },
     {
         "name": "Heart of Justice, Abbacchio",
@@ -2683,7 +2683,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E092.png"
     },
     {
         "name": "Destructive Tempest, L.B",
@@ -2711,7 +2711,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E093.png"
     },
     {
         "name": "Playback Investigation, M.J",
@@ -2740,7 +2740,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E094.png"
     },
     {
         "name": "\"Key\" to the Safe \"Vehicle\"",
@@ -2766,7 +2766,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E095.png"
     },
     {
         "name": "Room in the Turtle",
@@ -2792,7 +2792,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E096.png"
     },
     {
         "name": "The Sound of Farewell",
@@ -2821,7 +2821,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E097.png"
     },
     {
         "name": "Determination to Awaken",
@@ -2851,7 +2851,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E098.png"
     },
     {
         "name": "Under the Falling Sky",
@@ -2880,7 +2880,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E099.png"
     },
     {
         "name": "Unflinching Spirit",
@@ -2910,7 +2910,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E100.png"
     },
     {
         "name": "Pioneer of Fate, Mista",
@@ -2936,7 +2936,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E101.png"
     },
     {
         "name": "Pioneer of Fate, Giorno",
@@ -2963,7 +2963,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E102.png"
     },
     {
         "name": "Pioneer of Fate, Fugo",
@@ -2990,7 +2990,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E103.png"
     },
     {
         "name": "Pioneer of Fate, Narancia",
@@ -3016,7 +3016,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E104.png"
     },
     {
         "name": "Pioneer of Fate, Bucciarati",
@@ -3043,7 +3043,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E105.png"
     },
     {
         "name": "Pioneer of Fate, Abbacchio",
@@ -3070,7 +3070,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E106.png"
     },
     {
         "name": "Pioneer of Fate, Trish",
@@ -3097,7 +3097,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_E107.png"
     },
     {
         "name": "Carrying on the Bloodline, Giorno",
@@ -3124,7 +3124,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_PE01.png"
     },
     {
         "name": "Beginning of Fate, Bucciarati",
@@ -3151,7 +3151,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_PE02.png"
     },
     {
         "name": "Golden Dream, Giorno & Bucciarati",
@@ -3180,7 +3180,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_PE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_PE04.png"
     },
     {
         "name": "Bad at Studying, Narancia",
@@ -3207,7 +3207,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE01.png"
     },
     {
         "name": "Kind Teacher, Fugo",
@@ -3234,7 +3234,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE02.png"
     },
     {
         "name": "Gang Newcomer, Giorno",
@@ -3261,7 +3261,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE03.png"
     },
     {
         "name": "Hazing the Newcomer, Abbacchio",
@@ -3288,7 +3288,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE04.png"
     },
     {
         "name": "Accurate Shot, Mista",
@@ -3317,7 +3317,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE05.png"
     },
     {
         "name": "Golden Experience, G.W",
@@ -3347,7 +3347,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE06.png"
     },
     {
         "name": "Golden Intentions, Giorno",
@@ -3376,7 +3376,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE07.png"
     },
     {
         "name": "Overflowing Life Force",
@@ -3402,7 +3402,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE08.png"
     },
     {
         "name": "Golden Experience",
@@ -3432,7 +3432,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE09.png"
     },
     {
         "name": "Last Bullet",
@@ -3461,7 +3461,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE10.png"
     },
     {
         "name": "Readiness to Die, Bucciarati",
@@ -3488,7 +3488,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE11.png"
     },
     {
         "name": "Interest in the Newcomer, Abbacchio",
@@ -3514,7 +3514,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE12.png"
     },
     {
         "name": "Icebreaker, Mista",
@@ -3540,7 +3540,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE13.png"
     },
     {
         "name": "Sudden Fury, Fugo",
@@ -3566,7 +3566,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE14.png"
     },
     {
         "name": "Z.M",
@@ -3592,7 +3592,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE15.png"
     },
     {
         "name": "Pure and Innocent, Narancia",
@@ -3618,7 +3618,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE16.png"
     },
     {
         "name": "Unseen Attack, Bucciarati",
@@ -3646,7 +3646,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE17.png"
     },
     {
         "name": "Sudden Attack, Bucciarati",
@@ -3675,7 +3675,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE18.png"
     },
     {
         "name": "Future Comrade, Giorno",
@@ -3703,7 +3703,7 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE19.png"
     },
     {
         "name": "Permitted to Join",
@@ -3733,6 +3733,6 @@
         "set": "JJ",
         "release": "66",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/JJ_S66_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/j/jj_s66/JJ_S66_TE20.png"
     }
 ]

--- a/DB/KC2_S31.json
+++ b/DB/KC2_S31.json
@@ -23,9 +23,7 @@
         ],
         "flavor_text": "Enemy ship locked, fire all main guns!",
         "set": "KC",
-        "release": "31",
-        "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E001RRo.png"
+        "release": "31"        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E001.png"
     },
     {
         "name": "2nd Yamato-class Battleship, Musashi-Kai",
@@ -53,7 +51,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E002RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E002.png"
     },
     {
         "name": "10th Kagero-class Destroyer, Tokitsukaze",
@@ -79,7 +77,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E003Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E003.png"
     },
     {
         "name": "12th Kagero-class Destroyer, Isokaze-Kai",
@@ -105,7 +103,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E004Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E004.png"
     },
     {
         "name": "9th Kagero-class Destroyer, Amatsukaze-Kai",
@@ -131,7 +129,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E005Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E005.png"
     },
     {
         "name": "Japan's Largest Light Cruiser, Oyodo-Kai",
@@ -157,7 +155,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E006Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E006.png"
     },
     {
         "name": "1st Tone-class Aviation Cruiser, Tone-Kai-Ni",
@@ -185,7 +183,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E007Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E007.png"
     },
     {
         "name": "2nd Tone-class Aviation Cruiser, Chikuma-Kai-Ni",
@@ -213,7 +211,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E008Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E008.png"
     },
     {
         "name": "2nd Hiyo-class Light Aircraft Carrier, Junyo-Kai-Ni",
@@ -241,7 +239,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E009Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E009.png"
     },
     {
         "name": "1st Unryu-class Aircraft Carrier, Unryu-Kai",
@@ -271,7 +269,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E010R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E010.png"
     },
     {
         "name": "12th Kagero-class Destroyer, Isokaze",
@@ -297,7 +295,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E011Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E011.png"
     },
     {
         "name": "17th Yugumo-class Destroyer, Hayashimo",
@@ -323,7 +321,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E012Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E012.png"
     },
     {
         "name": "19th Yugumo-class Destroyer, Kiyoshimo",
@@ -350,7 +348,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E013Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E013.png"
     },
     {
         "name": "1st Oyodo-class Light Cruiser, Oyodo",
@@ -376,7 +374,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E014Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E014.png"
     },
     {
         "name": "Shimakaze-class Destroyer, Shimakaze-Kai",
@@ -402,7 +400,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E015Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E015.png"
     },
     {
         "name": "9th Kagero-class Destroyer, Amatsukaze",
@@ -428,7 +426,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E016Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E016.png"
     },
     {
         "name": "1st Oyodo-class Light Cruiser, Oyodo-Kai",
@@ -454,7 +452,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E017Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E017.png"
     },
     {
         "name": "2nd Shokaku-class Aircraft Carrier, Zuikaku-Kai",
@@ -482,7 +480,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E018Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E018.png"
     },
     {
         "name": "1st Unryu-class Aircraft Carrier, Unryu",
@@ -510,35 +508,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E019Uo.png"
-    },
-    {
-        "name": "1st Unryu-class Aircraft Carrier, Unryu",
-        "code": "KC/S31-E019P",
-        "rarity": "PR",
-        "expansion": "Kancolle, 2nd Fleet",
-        "side": "S",
-        "type": "Character",
-        "color": "YELLOW",
-        "level": "2",
-        "cost": "1",
-        "power": "8000",
-        "soul": 1,
-        "trigger": [
-            "SOUL"
-        ],
-        "attributes": [
-            "Fleet Girl",
-            "Aircraft Carrier"
-        ],
-        "ability": [
-            "【ACT】 [(1)] Choose one of your 《Fleet Girl》 characters, and that character gets the following ability until end of turn. \"【AUTO】 When this card becomes 【REVERSE】, if the level of this card's battle opponent is lower than or equal to the level of this card, you may put that character into your opponent's stock\""
-        ],
-        "flavor_text": "I've been done in……I need to recover from listing…… I don't…….want to sink again!",
-        "set": "KC",
-        "release": "31",
-        "sid": "E019P",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E019.png"
     },
     {
         "name": "Type 3 Submergence Transport Vehicle, Maruyu-Kai",
@@ -564,7 +534,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E020Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E020.png"
     },
     {
         "name": "11th Kagero-class Destroyer, Urakaze",
@@ -590,7 +560,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E021Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E021.png"
     },
     {
         "name": "13th Kagero-class Destroyer, Hamakaze",
@@ -616,7 +586,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E022Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E022.png"
     },
     {
         "name": "14th Kagero-class Destroyer, Tanikaze",
@@ -642,7 +612,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E023Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E023.png"
     },
     {
         "name": "Hei-class Landing Craft Carrier, Akitsumaru-Kai",
@@ -668,7 +638,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E024Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E024.png"
     },
     {
         "name": "4th Agano-class Light Cruiser, Sakawa",
@@ -694,7 +664,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E025Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E025.png"
     },
     {
         "name": "1st Hiyo-class Light Aircraft Carrier, Hiyo-Kai",
@@ -722,7 +692,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E026Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E026.png"
     },
     {
         "name": "2nd I-400-class Submarine, I-401-Kai",
@@ -750,7 +720,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E027Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E027.png"
     },
     {
         "name": "Medal",
@@ -776,7 +746,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E028Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E028.png"
     },
     {
         "name": "Remodeling Blueprint",
@@ -802,7 +772,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E029Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E029.png"
     },
     {
         "name": "Large Ship Construction",
@@ -828,7 +798,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E030Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E030.png"
     },
     {
         "name": "This is a good wind…commence the attack!",
@@ -858,7 +828,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E031CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E031.png"
     },
     {
         "name": "The main guns of Musashi, are not just for show.",
@@ -887,7 +857,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E032CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E032.png"
     },
     {
         "name": "Aviation Cruisers, Head Out!",
@@ -916,7 +886,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E033CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E033.png"
     },
     {
         "name": "Glorious First Carrier Division, Kaga",
@@ -944,7 +914,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E034RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E034.png"
     },
     {
         "name": "1st Ayanami-class Destroyer, Ayanami-Kai-Ni",
@@ -970,7 +940,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E035Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E035.png"
     },
     {
         "name": "Ryujo-class Light Aircraft Carrier, Ryujo-Kai-Ni",
@@ -998,7 +968,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E036Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E036.png"
     },
     {
         "name": "1st Sendai-class Light Cruiser, Sendai-Kai-Ni",
@@ -1026,7 +996,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E037Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E037.png"
     },
     {
         "name": "2nd Sendai-class Light Cruiser, Jintsu-Kai-Ni",
@@ -1054,7 +1024,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E038Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E038.png"
     },
     {
         "name": "3rd Sendai-class Light Cruiser, Naka-Kai-Ni",
@@ -1082,7 +1052,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E039Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E039.png"
     },
     {
         "name": "A Winter Moment, Akatsuki",
@@ -1108,7 +1078,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E040Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E040.png"
     },
     {
         "name": "To a Special Someone, Sendai",
@@ -1134,7 +1104,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E041Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E041.png"
     },
     {
         "name": "1st Hatsuharu-class destroyer, Hatsuharu-Kai-Ni",
@@ -1160,33 +1130,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E042Uo.png"
-    },
-    {
-        "name": "1st Hatsuharu-class destroyer, Hatsuharu-Kai-Ni",
-        "code": "KC/S31-E042P",
-        "rarity": "PR",
-        "expansion": "Kancolle, 2nd Fleet",
-        "side": "S",
-        "type": "Character",
-        "color": "GREEN",
-        "level": "1",
-        "cost": "0",
-        "power": "5000",
-        "soul": 1,
-        "trigger": [],
-        "attributes": [
-            "Fleet Girl",
-            "Destroyer"
-        ],
-        "ability": [
-            "【AUTO】 When this card's battle opponent becomes 【REVERSE】, choose one of your opponent's characters in the center stage, and that character gets -1000 power until end of turn."
-        ],
-        "flavor_text": "You are going to face the wrath of Hatsuharu!",
-        "set": "KC",
-        "release": "31",
-        "sid": "E042P",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E042.png"
     },
     {
         "name": "Ryujo-class Light Aircraft Carrier, Ryujo-Kai",
@@ -1214,7 +1158,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E043Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E043.png"
     },
     {
         "name": "10th Ayanami-class Destroyer, Ushio-Kai",
@@ -1240,7 +1184,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E044Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E044.png"
     },
     {
         "name": "A Winter Moment, Hibiki",
@@ -1266,7 +1210,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E045Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E045.png"
     },
     {
         "name": "A Winter Moment, Ikaduchi",
@@ -1292,7 +1236,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E046Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E046.png"
     },
     {
         "name": "A Winter Moment, Inaduma",
@@ -1318,7 +1262,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E047Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E047.png"
     },
     {
         "name": "Flagship of the 2nd Torpedo Squadron, Jintsu-Kai-Ni",
@@ -1344,7 +1288,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E048Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E048.png"
     },
     {
         "name": "1st Chitose-class Seaplane Carrier, Chitose-Kou",
@@ -1370,7 +1314,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E049Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E049.png"
     },
     {
         "name": "2nd Chitose-class Seaplane Carrier, Chiyoda-Kou",
@@ -1396,7 +1340,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E050Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E050.png"
     },
     {
         "name": "1st Aoba-class Heavy Cruiser, Aoba-Kai",
@@ -1422,7 +1366,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E051Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E051.png"
     },
     {
         "name": "1st Chitose-class Light Aircraft Carrier, Chitose-Ko",
@@ -1450,7 +1394,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E052Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E052.png"
     },
     {
         "name": "2nd Chitose-class Light Aircraft Carrier, Chiyoda-Ko",
@@ -1478,7 +1422,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E053Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E053.png"
     },
     {
         "name": "Flares",
@@ -1505,7 +1449,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E054Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E054.png"
     },
     {
         "name": "Wedding (Tentative)",
@@ -1531,7 +1475,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E055Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E055.png"
     },
     {
         "name": "Naka is the center, the number one highlight!",
@@ -1560,7 +1504,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E056CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E056.png"
     },
     {
         "name": "Light Aircraft Carrier Ryujo, heading out!",
@@ -1589,7 +1533,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E057CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E057.png"
     },
     {
         "name": "Ayanami will protect you!",
@@ -1618,7 +1562,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E058CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E058.png"
     },
     {
         "name": "Jintsu, sallying forth!",
@@ -1647,7 +1591,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E059CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E059.png"
     },
     {
         "name": "Seaplane bomber force, go-!",
@@ -1676,7 +1620,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E060CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E060.png"
     },
     {
         "name": "“Tea Time” Kongo",
@@ -1704,7 +1648,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E061RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E061.png"
     },
     {
         "name": "3rd Kongo-class Battleship, Haruna-Kai-Ni",
@@ -1732,7 +1676,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E062RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E062.png"
     },
     {
         "name": "4th Kongo-class Battleship, Kirishima-Kai-Ni",
@@ -1760,7 +1704,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E063RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E063.png"
     },
     {
         "name": "4th Mutsuki-class Destroyer, Uduki",
@@ -1786,7 +1730,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E064Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E064.png"
     },
     {
         "name": "Light Cruiser Who Takes Care of Sister Ships, Tatsuta",
@@ -1812,7 +1756,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E065Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E065.png"
     },
     {
         "name": "4th Mutsuki-class Destroyer, Uduki-Kai",
@@ -1838,7 +1782,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E066Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E066.png"
     },
     {
         "name": "1st Nagara-class Light Cruiser, Nagara-Kai",
@@ -1866,7 +1810,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E067Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E067.png"
     },
     {
         "name": "3rd Mutsuki-class Destroyer, Yayoi",
@@ -1893,34 +1837,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E068Co.png"
-    },
-    {
-        "name": "3rd Mutsuki-class Destroyer, Yayoi",
-        "code": "KC/S31-E068P",
-        "rarity": "PR",
-        "expansion": "Kancolle, 2nd Fleet",
-        "side": "S",
-        "type": "Character",
-        "color": "RED",
-        "level": "0",
-        "cost": "0",
-        "power": "1000",
-        "soul": 1,
-        "trigger": [],
-        "attributes": [
-            "Fleet Girl",
-            "Destroyer"
-        ],
-        "ability": [
-            "【CONT】 If the number of markers underneath this card is two or more, this card gets, \"【CONT】 Assist All of your characters in front of this card get +1000 power.\".",
-            "【ACT】 [【REST】 this card] If the number of markers underneath this card is one or less, choose a card named \"1st Mutsuki-class Destroyer, Mutsuki\" or \"2nd Mutsuki-class Destroyer, Kisaragi\" in your waiting room, and put it face down underneath this card as a marker."
-        ],
-        "flavor_text": "Now you've done it…I'm not mad… not mad at al-…",
-        "set": "KC",
-        "release": "31",
-        "sid": "E068P",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E068.png"
     },
     {
         "name": "Present of Appreciation, Uduki",
@@ -1946,7 +1863,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E069Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E069.png"
     },
     {
         "name": "3rd Nagara-class Light Cruiser, Natori-Kai",
@@ -1972,7 +1889,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E070Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E070.png"
     },
     {
         "name": "3rd Kuma-class Torpedo Cruiser, Kitakami-Kai",
@@ -2000,7 +1917,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E071Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E071.png"
     },
     {
         "name": "4th Kuma-class Torpedo Cruiser, Oi-Kai",
@@ -2028,7 +1945,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E072Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E072.png"
     },
     {
         "name": "2nd Nagara-class Light Cruiser, Isuzu-Kai-Ni",
@@ -2056,7 +1973,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E073Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E073.png"
     },
     {
         "name": "Hi-Speed Repair Agent",
@@ -2082,7 +1999,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E074Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E074.png"
     },
     {
         "name": "If you are fine with Haruna, I'll take you on any time!",
@@ -2110,7 +2027,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E075CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E075.png"
     },
     {
         "name": "Pu-pukupuu!",
@@ -2139,7 +2056,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E076CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E076.png"
     },
     {
         "name": "Soryu-class Aircraft Carrier, Soryu-Kai-Ni",
@@ -2167,7 +2084,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E077RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E077.png"
     },
     {
         "name": "Hiryu-class Aircraft Carrier, Hiryu-Kai-Ni",
@@ -2195,7 +2112,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E078RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E078R.png"
     },
     {
         "name": "Obstinate Class Leader, Shiratsuyu-Kai",
@@ -2222,7 +2139,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E079Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E079.png"
     },
     {
         "name": "Command Ship of the 2nd Destroyer Squadron, Murasame-Kai",
@@ -2248,7 +2165,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E080Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E080.png"
     },
     {
         "name": "Newly Constructed Repair Ship, Akashi-Kai",
@@ -2277,7 +2194,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E081Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E081.png"
     },
     {
         "name": "Resupply Vessel, Taigei",
@@ -2303,7 +2220,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E082Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E082.png"
     },
     {
         "name": "1st Myoko-class Heavy Cruiser, Myoko-Kai-Ni",
@@ -2331,7 +2248,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E083Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E083.png"
     },
     {
         "name": "Newly Constructed Repair Ship, Akashi",
@@ -2358,7 +2275,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E084Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E084.png"
     },
     {
         "name": "Ryuho-class Light Aircraft Carrier, Ryuho-Kai",
@@ -2386,7 +2303,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E085Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E085.png"
     },
     {
         "name": "4th Myoko-class Heavy Cruiser, Haguro-Kai-Ni",
@@ -2414,7 +2331,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E086Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E086.png"
     },
     {
         "name": "1st Nagato-class Battleship, Nagato-Kai",
@@ -2442,7 +2359,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E087Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E087.png"
     },
     {
         "name": "2nd Nagato-class Battleship, Mutsu-Kai",
@@ -2470,7 +2387,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E088Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E088.png"
     },
     {
         "name": "5th Shiratsuyu-class Destroyer, Harusame",
@@ -2496,33 +2413,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E089Co.png"
-    },
-    {
-        "name": "5th Shiratsuyu-class Destroyer, Harusame",
-        "code": "KC/S31-E089P",
-        "rarity": "PR",
-        "expansion": "Kancolle, 2nd Fleet",
-        "side": "S",
-        "type": "Character",
-        "color": "BLUE",
-        "level": "0",
-        "cost": "0",
-        "power": "500",
-        "soul": 1,
-        "trigger": [],
-        "attributes": [
-            "Fleet Girl",
-            "Destroyer"
-        ],
-        "ability": [
-            "【CONT】 Assist All of your characters in front of this card get +500 power. 【AUTO】 [Put a card from your hand into your waiting room] When this card is placed on the stage from your hand, you may pay the cost. If you do, choose a card named \"Drum Can(Transport Use)\" in your waiting room, and return it to your hand."
-        ],
-        "flavor_text": "Th-they got me…But I can still continue on my escort duties!",
-        "set": "KC",
-        "release": "31",
-        "sid": "E089P",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E089.png"
     },
     {
         "name": "Taigei-class Submarine Tender, Taigei",
@@ -2549,7 +2440,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E090Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E090.png"
     },
     {
         "name": "3rd Myoko-class Heavy Cruiser, Ashigara-Kai",
@@ -2575,7 +2466,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E091Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E091.png"
     },
     {
         "name": "4th Shiratsuyu-class Destroyer, Yudachi-Kai-Ni",
@@ -2601,7 +2492,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E092Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E092.png"
     },
     {
         "name": "2nd Shoho-class Light Aircraft Carrier, Zuiho-Kai",
@@ -2629,7 +2520,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E093Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E093.png"
     },
     {
         "name": "Ryuho-class Light Aircraft Carrier, Ryuho-Kai",
@@ -2657,7 +2548,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E094Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E094.png"
     },
     {
         "name": "Drum Can(Transport Use)",
@@ -2683,7 +2574,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E095Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E095.png"
     },
     {
         "name": "Food Supply Ship, Irako",
@@ -2709,7 +2600,7 @@
         "set": "KC",
         "release": "31",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E096Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E096.png"
     },
     {
         "name": "Haguro of The Fifth Squadron, heading out!",
@@ -2739,7 +2630,95 @@
         "set": "KC",
         "release": "31",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S31_E097CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E097.png"
+    },
+    {
+        "name": "Attack force, head out now-!",
+        "code": "KC/S31-E098",
+        "rarity": "CC",
+        "expansion": "Kancolle, 2nd Fleet",
+        "side": "S",
+        "type": "Climax",
+        "color": "BLUE",
+        "level": "",
+        "cost": "",
+        "power": "",
+        "soul": 0,
+        "trigger": [
+            "DRAW"
+        ],
+        "attributes": [
+            "-",
+            "-"
+        ],
+        "ability": [
+            "【CONT】 All of your characters get +1000 power and +1 soul. (DRAW@: When this card triggers, you may draw a card.)",
+            "(【DRAW】: When this card triggers, you may draw 1 card)"
+        ],
+        "flavor_text": "It's time for a counterattack… All planes on deck, sortie!",
+        "set": "KC",
+        "release": "31",
+        "sid": "E098",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E098.png"
+    },
+    {
+        "name": "From which ship do I start to repair?",
+        "code": "KC/S31-E099",
+        "rarity": "CC",
+        "expansion": "Kancolle, 2nd Fleet",
+        "side": "S",
+        "type": "Climax",
+        "color": "BLUE",
+        "level": "",
+        "cost": "",
+        "power": "",
+        "soul": 0,
+        "trigger": [
+            "SOUL",
+            "SOUL"
+        ],
+        "attributes": [
+            "-",
+            "-"
+        ],
+        "ability": [
+            "【CONT】 All of your characters get +2 soul."
+        ],
+        "flavor_text": "I can repair even more now! Thank you very much!",
+        "set": "KC",
+        "release": "31",
+        "sid": "E099",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E099.png"
+    },
+    {
+        "name": "Don't look down on us remodeled Aircraft Carriers!",
+        "code": "KC/S31-E100",
+        "rarity": "CC",
+        "expansion": "Kancolle, 2nd Fleet",
+        "side": "S",
+        "type": "Climax",
+        "color": "BLUE",
+        "level": "",
+        "cost": "",
+        "power": "",
+        "soul": 0,
+        "trigger": [
+            "SOUL",
+            "SOUL"
+        ],
+        "attributes": [
+            "-",
+            "-"
+        ],
+        "ability": [
+            "【AUTO】 When this card is placed on your climax area from your hand, choose up to one blue card in your waiting room, put it into your stock, and all of your characters get +1 soul until end of turn."
+        ],
+        "flavor_text": "Continue the assault! Ryuho, Attack Squadron, launching!",
+        "set": "KC",
+        "release": "31",
+        "sid": "E100",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s31/KC_S31_E100.png"
+ng"
     },
     {
         "name": "Attack force, head out now-!",

--- a/DB/KC3_S42.json
+++ b/DB/KC3_S42.json
@@ -24,7 +24,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E001.png"
     },
     {
         "name": "Taiho-class Armored Aircraft Carrier, Taiho Kai",
@@ -54,7 +54,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E002.png"
     },
     {
         "name": "During the Festival, Urakaze",
@@ -81,7 +81,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E003.png"
     },
     {
         "name": "Taiho-class Armored Aircraft Carrier, Taiho",
@@ -107,7 +107,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E004.png"
     },
     {
         "name": "1st Shokaku-class Aircraft Carrier, Shokaku Kai-II",
@@ -137,7 +137,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E005.png"
     },
     {
         "name": "2nd Shokaku-class Aircraft Carrier, Zuikaku Kai-II",
@@ -166,7 +166,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E006.png"
     },
     {
         "name": "1st Shokaku-class Armored Aircraft Carrier, Shokaku Kai-II Type.Kou",
@@ -196,7 +196,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E007.png"
     },
     {
         "name": "2nd Shokaku-class Armored Aircraft Carrier, Zuikaku Kai-II Type.Kou",
@@ -226,7 +226,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E008.png"
     },
     {
         "name": "3rd Yugumo-class Destroyer, Kazagumo",
@@ -253,7 +253,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E009.png"
     },
     {
         "name": "16th Kagero-class Destroyer, Arashi",
@@ -281,7 +281,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E010.png"
     },
     {
         "name": "17th Kagero-class Destroyer, Hagikaze",
@@ -309,7 +309,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E011.png"
     },
     {
         "name": "14th Yugumo-class Destroyer, Okinami",
@@ -336,7 +336,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E012.png"
     },
     {
         "name": "3rd Unryu-class Aircraft Carrier, Katsuragi",
@@ -363,7 +363,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E013.png"
     },
     {
         "name": "2nd Akizuki-class Destroyer, Teruzuki",
@@ -390,7 +390,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E014.png"
     },
     {
         "name": "15th Kagero-class Destroyer, Nowaki",
@@ -416,7 +416,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E015.png"
     },
     {
         "name": "Delicious Season, Isokaze",
@@ -445,7 +445,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E016.png"
     },
     {
         "name": "6th Yugumo-class Destroyer, Takanami",
@@ -472,7 +472,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E017.png"
     },
     {
         "name": "16th Yugumo-class Destroyer, Asashimo",
@@ -498,7 +498,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E018.png"
     },
     {
         "name": "2nd Unryu-class Aircraft Carrier, Amagi Kai",
@@ -524,7 +524,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E019.png"
     },
     {
         "name": "6th Yugumo-class Destroyer, Takanami Kai",
@@ -550,7 +550,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E020.png"
     },
     {
         "name": "During the Festival, Hamakaze",
@@ -576,7 +576,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E021.png"
     },
     {
         "name": "16th Yugumo-class Destroyer, Asashimo Kai",
@@ -605,7 +605,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E022.png"
     },
     {
         "name": "3rd Unryu-class Aircraft Carrier, Katsuragi Kai",
@@ -634,7 +634,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E023.png"
     },
     {
         "name": "4th Akizuki-class Destroyer, Hatsuzuki",
@@ -662,7 +662,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E024.png"
     },
     {
         "name": "Hishi Mochi",
@@ -688,7 +688,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E025.png"
     },
     {
         "name": "1st Task Force, heading out!",
@@ -718,7 +718,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E026.png"
     },
     {
         "name": "Let me show you the true power of a re-modelled Hiryu-class!!",
@@ -747,7 +747,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E027.png"
     },
     {
         "name": "Main guns, get ready for aerial combat!",
@@ -777,7 +777,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E028.png"
     },
     {
         "name": "Sis, leave this to me",
@@ -806,7 +806,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E029.png"
     },
     {
         "name": "3rd Admiral Hipper-class Heavy Cruiser, Prinz Eugen",
@@ -832,7 +832,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E030.png"
     },
     {
         "name": "1st Bismarck-class Battleship, Bismarck drei",
@@ -862,7 +862,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E031.png"
     },
     {
         "name": "1st Bismarck-class Battleship, Bismarck",
@@ -888,7 +888,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E032.png"
     },
     {
         "name": "U-boat IXC-class Submarine, U-511",
@@ -915,7 +915,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E033.png"
     },
     {
         "name": "1st Graf Zeppelin-class Aircraft Carrier, Graf Zeppelin Kai",
@@ -944,7 +944,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E034.png"
     },
     {
         "name": "Ro-number Submarine, Ro-500",
@@ -973,7 +973,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E035.png"
     },
     {
         "name": "3rd Admiral Hipper-class Heavy Cruiser, Prinz Eugen Kai",
@@ -1003,7 +1003,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E036.png"
     },
     {
         "name": "3rd Z1-class Destroyer, Z3",
@@ -1030,7 +1030,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E037.png"
     },
     {
         "name": "During the Festival, Jintsu Kai-II",
@@ -1056,7 +1056,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E038.png"
     },
     {
         "name": "3rd Takao-class Heavy Cruiser, Maya Kai-II",
@@ -1082,7 +1082,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E039.png"
     },
     {
         "name": "1st Bismarck-class Battleship, Bismarck zwei",
@@ -1111,7 +1111,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E040.png"
     },
     {
         "name": "1st Akatsuki-class Destroyer, Akatsuki Kai-II",
@@ -1140,7 +1140,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E041.png"
     },
     {
         "name": "1st Z1-class Destroyer, Z1 zwei",
@@ -1169,7 +1169,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E042.png"
     },
     {
         "name": "1st Z1-class Destroyer, Z1",
@@ -1197,7 +1197,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E043.png"
     },
     {
         "name": "1st Furutaka-class Heavy Cruiser, Furutaka Kai-II",
@@ -1223,7 +1223,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E044.png"
     },
     {
         "name": "4th Takao-class Heavy Cruiser, Chokai Kai-II",
@@ -1250,7 +1250,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E045.png"
     },
     {
         "name": "7th Ayanami-class Destroyer, Oboro Kai",
@@ -1277,7 +1277,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E046.png"
     },
     {
         "name": "10th Ayanami-class Destroyer, Ushio Kai-II",
@@ -1303,7 +1303,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E047.png"
     },
     {
         "name": "A Midsummer Moment, Akebono",
@@ -1329,7 +1329,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E048.png"
     },
     {
         "name": "3rd Z1-class Destroyer, Z3 zwei",
@@ -1356,7 +1356,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E049.png"
     },
     {
         "name": "4th Hatsuharu-class Destroyer, Hatsushimo Kai-II",
@@ -1382,7 +1382,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E050.png"
     },
     {
         "name": "1st Bismarck-class Battleship, Bismarck Kai",
@@ -1409,7 +1409,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E051.png"
     },
     {
         "name": "2nd Furutaka-class Heavy Cruiser, Kako Kai-II",
@@ -1435,7 +1435,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E052.png"
     },
     {
         "name": "1st Graf Zeppelin-class Aircraft Carrier, Graf Zeppelin",
@@ -1461,7 +1461,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E053.png"
     },
     {
         "name": "Class S Type.Kou Medal",
@@ -1487,7 +1487,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E054.png"
     },
     {
         "name": "Fleet warfare… I can hardly wait!",
@@ -1516,7 +1516,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E055.png"
     },
     {
         "name": "Aim carefully…… Feuer!",
@@ -1545,7 +1545,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E056.png"
     },
     {
         "name": "Ro-number Submarine, heading out!",
@@ -1574,7 +1574,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E057.png"
     },
     {
         "name": "Akitsushima-class Seaplane Tender, Akitsushima Kai",
@@ -1601,7 +1601,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E058.png"
     },
     {
         "name": "2nd Katori-class Training Cruiser, Kashima",
@@ -1631,7 +1631,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E059.png"
     },
     {
         "name": "1st Fubuki-class Destroyer, Fubuki Kai-II",
@@ -1660,7 +1660,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E060.png"
     },
     {
         "name": "2nd Kazahaya-class Transport Ship, Hayasui",
@@ -1687,7 +1687,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E061.png"
     },
     {
         "name": "Akitsushima-class Seaplane Tender, Akitsushima",
@@ -1713,7 +1713,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E062.png"
     },
     {
         "name": "6th Nagara-class Light Cruiser, Abukuma Kai-II",
@@ -1742,7 +1742,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E063.png"
     },
     {
         "name": "1st Fuso-class Aircraft Battleship, Fuso Kai-II",
@@ -1771,7 +1771,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E064.png"
     },
     {
         "name": "2nd Fuso-class Aircraft Battleship, Yamashiro Kai-II",
@@ -1800,7 +1800,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E065.png"
     },
     {
         "name": "1st Katori-class Training Cruiser, Katori",
@@ -1827,7 +1827,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E066.png"
     },
     {
         "name": "2nd Kazahaya-class Transport Ship, Hayasui Kai",
@@ -1856,7 +1856,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E067.png"
     },
     {
         "name": "1st Mutsuki-class Destroyer, Mutsuki Kai-II",
@@ -1882,7 +1882,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E068.png"
     },
     {
         "name": "2nd Mutsuki-class Destroyer, Kisaragi Kai-II",
@@ -1908,7 +1908,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E069.png"
     },
     {
         "name": "5th Fubuki-class Destroyer, Murakumo Kai-II",
@@ -1934,7 +1934,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E070.png"
     },
     {
         "name": "Mizuho-class Seaplane Tender, Mizuho",
@@ -1963,7 +1963,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E071.png"
     },
     {
         "name": "Offshore Supply",
@@ -1989,7 +1989,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E072.png"
     },
     {
         "name": "Marine Escort Corp Flagship Kashima, anchors aweigh",
@@ -2018,7 +2018,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E073.png"
     },
     {
         "name": "I think I've found it!",
@@ -2047,7 +2047,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E074.png"
     },
     {
         "name": "2nd Vittorio Veneto-class Battleship, Italia",
@@ -2077,7 +2077,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E075.png"
     },
     {
         "name": "9th Shiratsuyu-class Destroyer, Kawakaze",
@@ -2103,7 +2103,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E076.png"
     },
     {
         "name": "A Midsummer Moment, Littorio",
@@ -2130,7 +2130,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E077.png"
     },
     {
         "name": "3rd Maestrale-class Destroyer, Libeccio",
@@ -2157,7 +2157,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E078.png"
     },
     {
         "name": "Interlude of the Rain, Murasame Kai",
@@ -2186,7 +2186,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E079.png"
     },
     {
         "name": "6th Asashio-class Destroyer, Yamagumo",
@@ -2212,7 +2212,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E080.png"
     },
     {
         "name": "1st Zara-class Heavy Cruiser, Zara",
@@ -2239,7 +2239,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E081.png"
     },
     {
         "name": "3rd Myoko-class Heavy Cruiser, Ashigara Kai-II",
@@ -2265,7 +2265,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E082.png"
     },
     {
         "name": "10th Asashio-class Destroyer, Kasumi Kai-II",
@@ -2292,7 +2292,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E083.png"
     },
     {
         "name": "10th Asashio-class Destroyer, Kasumi Kai-II-Otsu",
@@ -2319,7 +2319,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E084.png"
     },
     {
         "name": "2nd Myoko-class Heavy Cruiser, Nachi Kai-II",
@@ -2346,7 +2346,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E085.png"
     },
     {
         "name": "2nd Vittorio Veneto-class Battleship, Littorio",
@@ -2376,7 +2376,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E086.png"
     },
     {
         "name": "4th Vittorio Veneto-class Battleship, Roma Kai",
@@ -2405,7 +2405,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E087.png"
     },
     {
         "name": "1st Shoho-class Light Aircraft Carrier, Shoho Kai",
@@ -2432,7 +2432,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E088.png"
     },
     {
         "name": "Happy Halloween Roma",
@@ -2459,7 +2459,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E089.png"
     },
     {
         "name": "Happy Halloween Libeccio",
@@ -2485,7 +2485,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E090.png"
     },
     {
         "name": "5th Asashio-class Destroyer, Asagumo Kai",
@@ -2511,7 +2511,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E091.png"
     },
     {
         "name": "6th Asashio-class Destroyer, Yamagumo Kai",
@@ -2537,7 +2537,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E092.png"
     },
     {
         "name": "5th Shiratsuyu-class Destroyer, Harusame Kai",
@@ -2565,7 +2565,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E093.png"
     },
     {
         "name": "7th Shiratsuyu-class Destroyer, Umikaze",
@@ -2594,7 +2594,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E094.png"
     },
     {
         "name": "4th Vittorio Veneto-class Battleship, Roma",
@@ -2623,7 +2623,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E095.png"
     },
     {
         "name": "A Midsummer Moment, Yudachi Kai-II",
@@ -2652,7 +2652,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E096.png"
     },
     {
         "name": "Combat Rations",
@@ -2679,7 +2679,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E097.png"
     },
     {
         "name": "Let me show you Italia's true power!",
@@ -2709,7 +2709,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E098.png"
     },
     {
         "name": "Kasumi, anchors aweigh! Please follow me!",
@@ -2738,7 +2738,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E099.png"
     },
     {
         "name": "I'm going all out, follow me!",
@@ -2767,7 +2767,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E100.png"
     },
     {
         "name": "3rd Kagero-class Destroyer, Kuroshio Kai",
@@ -2793,7 +2793,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E101.png"
     },
     {
         "name": "8th Mutsuki-class Destroyer, Nagatsuki Kai",
@@ -2819,7 +2819,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E102.png"
     },
     {
         "name": "2nd Kongo-class Battleship, Hiei Kai",
@@ -2845,7 +2845,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E103.png"
     },
     {
         "name": "10th Shiratsuyu-class Destroyer, Suzukaze Kai",
@@ -2871,7 +2871,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E104.png"
     },
     {
         "name": "7th Kagero-class Destroyer, Hatsukaze",
@@ -2898,7 +2898,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E105.png"
     },
     {
         "name": "1st Akatsuki-class Destroyer, Akatsuki Kai",
@@ -2925,7 +2925,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E106.png"
     },
     {
         "name": "Newly Constructed Repair Ship, Akashi",
@@ -2952,7 +2952,7 @@
         "set": "KC",
         "release": "42",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC-S42-E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s42/KC_S42_E107.png"
     },
     {
         "name": "5th Mutsuki-class Destroyer, Satsuki Kai-II",

--- a/DB/KCE1_SE28.json
+++ b/DB/KCE1_SE28.json
@@ -24,7 +24,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E01.png"
     },
     {
         "name": "Northern Princess in the Deep Sea",
@@ -50,7 +50,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E02.png"
     },
     {
         "name": "Final Mode, Northern Princess in the Deep Sea",
@@ -79,7 +79,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E03.png"
     },
     {
         "name": "Ne-class Heavy Cruiser",
@@ -106,7 +106,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E04.png"
     },
     {
         "name": "Midway Princess in the Deep Sea",
@@ -136,7 +136,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E05.png"
     },
     {
         "name": "Aircraft Carrier Ogre in the Deep Sea",
@@ -162,7 +162,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E06.png"
     },
     {
         "name": "Armored Aircraft Carrier Ogre in the Deep Sea",
@@ -188,7 +188,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E07.png"
     },
     {
         "name": "Armored Aircraft Carrier Princess in the Deep Sea",
@@ -215,7 +215,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E08.png"
     },
     {
         "name": "Airfield Princess in the Deep Sea",
@@ -244,7 +244,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E09.png"
     },
     {
         "name": "Tsu-class Light Cruiser",
@@ -271,7 +271,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E10_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E10.png"
     },
     {
         "name": "Ni-Class Destroyer",
@@ -298,7 +298,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E11.png"
     },
     {
         "name": "Port Hydro Ogre in the Deep Sea",
@@ -327,7 +327,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E12.png"
     },
     {
         "name": "Airｃraｆｔ Carrier Hydro Ogre in the Deep Sea",
@@ -356,7 +356,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E13.png"
     },
     {
         "name": "Aircraft Carrier Princess in the Deep Sea",
@@ -385,7 +385,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E14.png"
     },
     {
         "name": "Berserker Mode, Port Princess in the Deep Sea",
@@ -414,7 +414,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E15.png"
     },
     {
         "name": "Floating Fortress",
@@ -441,7 +441,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E16.png"
     },
     {
         "name": "I-class Destroyer",
@@ -468,7 +468,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E17.png"
     },
     {
         "name": "So-class Submarine",
@@ -494,7 +494,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E18.png"
     },
     {
         "name": "Chi-class Torpedo Cruiser",
@@ -520,7 +520,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E19.png"
     },
     {
         "name": "Ru-class Battleship",
@@ -546,7 +546,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E20.png"
     },
     {
         "name": "Port Princess in the Deep Sea",
@@ -572,7 +572,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E21.png"
     },
     {
         "name": "Final Mode, Midway Princess in the Deep Sea",
@@ -601,7 +601,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E22.png"
     },
     {
         "name": "Sink!",
@@ -630,7 +630,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E23.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E23.png"
     },
     {
         "name": "Nothing… you don't understand anything at all…",
@@ -659,7 +659,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E24.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E24.png"
     },
     {
         "name": "I told you… it's hopeless…",
@@ -688,7 +688,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E25.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E25.png"
     },
     {
         "name": "Anchorage Ogre in the Deep Sea",
@@ -715,7 +715,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E26.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E26_.png"
     },
     {
         "name": "Final Mode, Light Cruiser Ogre in the Deep Sea",
@@ -742,7 +742,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E27.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E27_.png"
     },
     {
         "name": "Battleship Hydro Ogre in the Deep Seaa",
@@ -772,7 +772,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E28.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E28_.png"
     },
     {
         "name": "Southern Battle Princess in the Deep Sea",
@@ -799,7 +799,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E29.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E29.png"
     },
     {
         "name": "Southern Ogre in the Deep Sea",
@@ -826,7 +826,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E30.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E30.png"
     },
     {
         "name": "Anchorage Princess in the Deep Sea",
@@ -852,7 +852,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E31.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E31.png"
     },
     {
         "name": "Seaplane Carrier Princess in the Deep Sea",
@@ -881,7 +881,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E32.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E32.png"
     },
     {
         "name": "Isolated Island Ogre in the Deep Sea",
@@ -910,7 +910,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E33.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E33.png"
     },
     {
         "name": "Air Defense Princess in the Deep Sea",
@@ -941,7 +941,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E34.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E34.png"
     },
     {
         "name": "Wa-class Supply Ship",
@@ -968,7 +968,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E35.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E35.png"
     },
     {
         "name": "Ka-class Submarine",
@@ -994,7 +994,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E36.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E36.png"
     },
     {
         "name": "Light Cruiser Ogre in the Deep Sea",
@@ -1021,7 +1021,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E37",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E37.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E37.png"
     },
     {
         "name": "Nu-class Light Aircraft Carrier",
@@ -1048,7 +1048,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E38",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E38.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E38.png"
     },
     {
         "name": "Re-class Battleship",
@@ -1078,7 +1078,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E39",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E39.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E39.png"
     },
     {
         "name": "Battleship Princess in the Deep Sea",
@@ -1107,7 +1107,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E40",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E40.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E40.png"
     },
     {
         "name": "Destroyer Princess in the Deep Sea",
@@ -1134,7 +1134,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E41",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E41.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E41.png"
     },
     {
         "name": "Ri-class Heavy Cruiser",
@@ -1160,7 +1160,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E42",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E42.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E42.png"
     },
     {
         "name": "Ha-class Destroyer",
@@ -1186,7 +1186,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E43",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E43.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E43.png"
     },
     {
         "name": "Ho-class Light Cruiser",
@@ -1212,7 +1212,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E44",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E44.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E44.png"
     },
     {
         "name": "Ta-class Battleship",
@@ -1239,7 +1239,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E45",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E45.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E45.png"
     },
     {
         "name": "Southern Battle Ogre in the Deep Sea",
@@ -1265,7 +1265,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E46",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E46.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E46.png"
     },
     {
         "name": "Anchorage Hydro Ogre in the Deep Sea",
@@ -1294,7 +1294,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E47",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E47.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E47.png"
     },
     {
         "name": "Fall!",
@@ -1323,7 +1323,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E48",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E48.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E48.png"
     },
     {
         "name": "Please sink!",
@@ -1352,7 +1352,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E49",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E49.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E49.png"
     },
     {
         "name": "Hehehe… Does it hurt?",
@@ -1382,7 +1382,7 @@
         "set": "KC",
         "release": "E28",
         "sid": "E50",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_KC_SE28_E50.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_se28/KC_SE28_E50.png"
     },
     {
         "name": "Christmas, Northern Princess in the Deep Sea",

--- a/DB/KC_S25.json
+++ b/DB/KC_S25.json
@@ -2,7 +2,7 @@
     {
         "name": "1st Yamato-class Battleship, Yamato",
         "code": "KC/S25-E001",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",
@@ -31,7 +31,7 @@
     {
         "name": "2nd Yamato-class Battleship, Musashi",
         "code": "KC/S25-E002",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",
@@ -941,7 +941,7 @@
     {
         "name": "Akagi-class Aircraft Carrier, Akagi-Kai",
         "code": "KC/S25-E035",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",
@@ -2184,7 +2184,7 @@
     {
         "name": "1st Kongo-class Battleship, Kongo-Kai-Ni",
         "code": "KC/S25-E080",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",
@@ -2214,7 +2214,7 @@
     {
         "name": "2nd Kongo-class Battleship, Hiei-Kai-Ni",
         "code": "KC/S25-E081",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",
@@ -3507,7 +3507,7 @@
     {
         "name": "1st Nagato-class Battleship, Nagato",
         "code": "KC/S25-E128",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Kancolle",
         "side": "S",
         "type": "Character",

--- a/DB/KC_S25.json
+++ b/DB/KC_S25.json
@@ -26,7 +26,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E001RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E001.png"
     },
     {
         "name": "2nd Yamato-class Battleship, Musashi",
@@ -55,7 +55,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E002RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E002.png"
     },
     {
         "name": "Shimakaze-class Destroyer, Shimakaze",
@@ -81,7 +81,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E003RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E003.png"
     },
     {
         "name": "2nd Shokaku-class Aircraft Carrier, Zuikaku",
@@ -110,7 +110,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E004RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E004.png"
     },
     {
         "name": "1st Shokaku-class Aircraft Carrier, Shokaku",
@@ -139,7 +139,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E005RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E005.png"
     },
     {
         "name": "7th Kagero-class Destroyer, Hatsukaze",
@@ -166,7 +166,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E006R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E006.png"
     },
     {
         "name": "18th Kagero-class Destroyer, Maikaze",
@@ -192,7 +192,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E007R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E007.png"
     },
     {
         "name": "Miracle Destroyer, Yukikaze",
@@ -219,7 +219,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E008R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E008.png"
     },
     {
         "name": "2nd Junsen-class Type Ⅲ Submarine, I-8",
@@ -246,7 +246,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E009R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E009.png"
     },
     {
         "name": "3rd Agano-class Light Cruiser, Yahagi",
@@ -273,7 +273,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E010R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E010.png"
     },
     {
         "name": "1st Kagero-class Destroyer, Kagero",
@@ -300,7 +300,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E011U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E011.png"
     },
     {
         "name": "4th Yugumo-class Destroyer, Naganami",
@@ -327,7 +327,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E012U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E012.png"
     },
     {
         "name": "19th Kagero-class Destroyer, Akigumo",
@@ -353,7 +353,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E013U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E013.png"
     },
     {
         "name": "1st Yugumo-class Destroyer, Yugumo",
@@ -379,7 +379,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E014U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E014.png"
     },
     {
         "name": "2nd Yugumo-class Destroyer, Makigumo",
@@ -405,7 +405,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E015U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E015.png"
     },
     {
         "name": "3rd Junsen Otsu-class Type Kai Ⅱ Submarine, I-58",
@@ -432,7 +432,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E016U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E016.png"
     },
     {
         "name": "1st Agano-class Light Cruiser, Agano",
@@ -458,7 +458,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E017U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E017.png"
     },
     {
         "name": "1st Hiyo-class Light Aircraft Carrier, Hiyo",
@@ -487,7 +487,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E018U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E018.png"
     },
     {
         "name": "2nd Junsen-class Type Ⅲ Submarine, I-8-Kai",
@@ -516,7 +516,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E019U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E019.png"
     },
     {
         "name": "1st Tone-class Heavy Cruiser, Tone",
@@ -545,7 +545,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E020U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E020.png"
     },
     {
         "name": "3rd Junsen Otsu-class Submarine, I-19-Kai",
@@ -574,7 +574,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E021U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E021.png"
     },
     {
         "name": "2nd Kagero-class Destroyer, Shiranui",
@@ -600,7 +600,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E022C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E022.png"
     },
     {
         "name": "3rd Kagero-class Destroyer, Kuroshio",
@@ -626,7 +626,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E023C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E023.png"
     },
     {
         "name": "1st Kaidai Ⅵ-class Type a Submarine, I-168",
@@ -652,7 +652,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E024C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E024.png"
     },
     {
         "name": "2nd Agano-class Light Cruiser, Noshiro",
@@ -681,7 +681,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E025C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E025.png"
     },
     {
         "name": "3rd Junsen Otsu-class Submarine, I-19",
@@ -708,7 +708,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E026C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E026.png"
     },
     {
         "name": "2nd Tone-class Heavy Cruiser, Chikuma",
@@ -736,7 +736,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E027C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E027.png"
     },
     {
         "name": "2nd Hiyo-class Light Aircraft Carrier, Junyo-Kai",
@@ -765,7 +765,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E028C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E028.png"
     },
     {
         "name": "3rd Junsen Otsu-class Type Kai Ⅱ Submarine, I-58-Kai",
@@ -793,7 +793,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E029C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E029.png"
     },
     {
         "name": "2nd I-400-class Submarine, I-401",
@@ -821,7 +821,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E030C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E030.png"
     },
     {
         "name": "Compass",
@@ -847,7 +847,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E031C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E031.png"
     },
     {
         "name": "Gunfire assault, ready!",
@@ -877,7 +877,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E032CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E032.png"
     },
     {
         "name": "All planes, take off!",
@@ -907,7 +907,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E033CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E033.png"
     },
     {
         "name": "Fast like Shimakaze",
@@ -936,7 +936,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E034CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E034.png"
     },
     {
         "name": "Akagi-class Aircraft Carrier, Akagi-Kai",
@@ -966,7 +966,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E035RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E035.png"
     },
     {
         "name": "Kaga-class Aircraft Carrier, Kaga",
@@ -997,7 +997,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E036RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E036.png"
     },
     {
         "name": "Yubari-class Light Cruiser, Yubari",
@@ -1026,7 +1026,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E037RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E037.png"
     },
     {
         "name": "\"Faithful\" Destroyer, Верный",
@@ -1052,7 +1052,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E038R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E038.png"
     },
     {
         "name": "2nd Aoba-class Heavy Cruiser, Kinugasa-Kai-Ni",
@@ -1080,7 +1080,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E039R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E039.png"
     },
     {
         "name": "1st Chitose-class Light Aircraft Carrier, Chitose-Ko-Kai-Ni",
@@ -1109,7 +1109,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E040R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E040.png"
     },
     {
         "name": "2nd Chitose-class Light Aircraft Carrier, Chiyoda-Ko-Kai-Ni",
@@ -1138,7 +1138,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E041R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E041.png"
     },
     {
         "name": "1st Ise-class Aviation Battleship, Ise-Kai",
@@ -1167,7 +1167,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E042R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E042.png"
     },
     {
         "name": "2nd Ise-class Aviation Battleship, Hyuga-Kai",
@@ -1197,7 +1197,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E043R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E043.png"
     },
     {
         "name": "1st Ayanami-class Destroyer, Ayanami",
@@ -1224,7 +1224,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E044U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E044.png"
     },
     {
         "name": "1st Hatsuharu-class Destroyer, Hatsuharu",
@@ -1251,7 +1251,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E045U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E045.png"
     },
     {
         "name": "1st Akatsuki-class Destroyer, Akatsuki",
@@ -1277,7 +1277,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E046U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E046.png"
     },
     {
         "name": "1st Furutaka-class Heavy Cruiser, Furutaka",
@@ -1304,7 +1304,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E047U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E047.png"
     },
     {
         "name": "3rd Sendai-class Light Cruiser, Naka",
@@ -1331,7 +1331,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E048U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E048.png"
     },
     {
         "name": "1st Sendai-class Light Cruiser, Sendai",
@@ -1357,7 +1357,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E049U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E049.png"
     },
     {
         "name": "1st Aoba-class Heavy Cruiser, Aoba",
@@ -1383,7 +1383,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E050U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E050.png"
     },
     {
         "name": "1st Ise-class Battleship, Ise",
@@ -1412,7 +1412,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E051U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E051.png"
     },
     {
         "name": "2nd Ise-class Battleship, Hyuga",
@@ -1441,7 +1441,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E052U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E052.png"
     },
     {
         "name": "Ryujo-class Light Aircraft Carrier, Ryujo",
@@ -1469,7 +1469,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E053U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E053.png"
     },
     {
         "name": "2nd Takao-class Heavy Cruiser, Atago",
@@ -1498,7 +1498,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E054U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E054.png"
     },
     {
         "name": "8th Ayanami-class Destroyer, Akebono",
@@ -1525,7 +1525,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E055C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E055.png"
     },
     {
         "name": "2nd Akatsuki-class Destroyer, Hibiki",
@@ -1552,7 +1552,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E056C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E056.png"
     },
     {
         "name": "Hardworking, Ikaduchi",
@@ -1578,7 +1578,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E057C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E057.png"
     },
     {
         "name": "2nd Hatsuharu-class Destroyer, Nenohi",
@@ -1605,7 +1605,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E058C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E058.png"
     },
     {
         "name": "2nd Ayanami-class Destroyer, Shikinami",
@@ -1631,7 +1631,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E059C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E059.png"
     },
     {
         "name": "9th Ayanami-class Destroyer, Sazanami",
@@ -1657,7 +1657,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E060C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E060.png"
     },
     {
         "name": "Clumsy Girl, Inaduma",
@@ -1684,7 +1684,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E061C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E061.png"
     },
     {
         "name": "4th Hatsuharu-class Destroyer, Hatsushimo",
@@ -1710,7 +1710,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E062C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E062.png"
     },
     {
         "name": "7th Ayanami-class Destroyer, Oboro",
@@ -1736,7 +1736,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E063C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E063.png"
     },
     {
         "name": "10th Ayanami-class Destroyer, Ushio",
@@ -1762,7 +1762,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E064C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E064.png"
     },
     {
         "name": "3rd Hatsuharu-class Destroyer, Wakaba",
@@ -1788,7 +1788,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E065C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E065.png"
     },
     {
         "name": "2nd Sendai-class Light Cruiser, Jintsu",
@@ -1815,7 +1815,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E066C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E066.png"
     },
     {
         "name": "2nd Aoba-class Heavy Cruiser, Kinugasa",
@@ -1841,7 +1841,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E067C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E067.png"
     },
     {
         "name": "2nd Furutaka-class Heavy Cruiser, Kako",
@@ -1867,7 +1867,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E068C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E068.png"
     },
     {
         "name": "1st Chitose-class Seaplane Carrier, Chitose",
@@ -1894,7 +1894,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E069C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E069.png"
     },
     {
         "name": "2nd Chitose-class Seaplane Carrier, Chiyoda",
@@ -1923,7 +1923,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E070C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E070.png"
     },
     {
         "name": "4th Takao-class Heavy Cruiser, Chokai",
@@ -1951,7 +1951,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E071C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E071.png"
     },
     {
         "name": "3rd Takao-class Heavy Cruiser, Maya",
@@ -1979,7 +1979,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E072C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E072.png"
     },
     {
         "name": "1st Takao-class Heavy Cruiser, Takao",
@@ -2008,7 +2008,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E073C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E073.png"
     },
     {
         "name": "Mission Girl",
@@ -2034,7 +2034,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E074C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E074.png"
     },
     {
         "name": "Akagi of the First Carrier Division is up next!",
@@ -2063,7 +2063,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E075CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E075.png"
     },
     {
         "name": "Pan Pakka Pa-n!",
@@ -2092,7 +2092,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E076CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E076.png"
     },
     {
         "name": "Aviation battleship, heading out!",
@@ -2121,7 +2121,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E077CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E077.png"
     },
     {
         "name": "We must go into night combat!",
@@ -2150,7 +2150,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E078CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E078.png"
     },
     {
         "name": "It's Akatsuki's turn, pay close attention!",
@@ -2179,7 +2179,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E079CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E079.png"
     },
     {
         "name": "1st Kongo-class Battleship, Kongo-Kai-Ni",
@@ -2209,7 +2209,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E080RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E080.png"
     },
     {
         "name": "2nd Kongo-class Battleship, Hiei-Kai-Ni",
@@ -2238,7 +2238,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E081RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E081.png"
     },
     {
         "name": "1st Kongo-class Battleship, Kongo",
@@ -2268,7 +2268,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E082RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E082.png"
     },
     {
         "name": "2nd Kongo-class Battleship, Hiei",
@@ -2297,7 +2297,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E083RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E083.png"
     },
     {
         "name": "3rd Kongo-class Battleship, Haruna",
@@ -2327,7 +2327,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E084RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E084RR.png"
     },
     {
         "name": "4th Kongo-class Battleship, Kirishima",
@@ -2356,7 +2356,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E085RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E085.png"
     },
     {
         "name": "1st Tenryu-class Light Cruiser, Tenryu-Kai",
@@ -2383,7 +2383,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E086R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E086.png"
     },
     {
         "name": "3rd Kuma-class Torpedo Cruiser, Kitakami-Kai-Ni",
@@ -2411,7 +2411,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E087R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E087.png"
     },
     {
         "name": "4th Kuma-class Torpedo Cruiser, Oi-Kai-Ni",
@@ -2439,7 +2439,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E088R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E088.png"
     },
     {
         "name": "5th Kuma-class Torpedo Cruiser, Kiso-Kai-Ni",
@@ -2469,7 +2469,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E089R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E089.png"
     },
     {
         "name": "I'll be the flagship! Isuzu-Kai-Ni",
@@ -2498,7 +2498,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E090R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E090.png"
     },
     {
         "name": "1st Fubuki-class Destroyer, Fubuki",
@@ -2525,7 +2525,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E091U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E091.png"
     },
     {
         "name": "1st Mutsuki-class Destroyer, Mutsuki",
@@ -2551,7 +2551,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E092U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E092.png"
     },
     {
         "name": "2nd Tenryu-class Light Cruiser, Tatsuta",
@@ -2579,7 +2579,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E093U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E093.png"
     },
     {
         "name": "3rd Kuma-class Light Cruiser, Kitakami",
@@ -2605,7 +2605,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E094U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E094.png"
     },
     {
         "name": "4th Kuma-class Light Cruiser, Oi",
@@ -2631,7 +2631,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E095U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E095.png"
     },
     {
         "name": "1st Kuma-class Light Cruiser, Kuma",
@@ -2660,7 +2660,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E096U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E096.png"
     },
     {
         "name": "1st Nagara-class Light Cruiser, Nagara",
@@ -2686,7 +2686,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E097U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E097.png"
     },
     {
         "name": "1st Fuso-class Battleship, Fuso",
@@ -2715,7 +2715,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E098U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E098.png"
     },
     {
         "name": "Hosho-class Light Aircraft Carrier, Hosho",
@@ -2744,7 +2744,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E099U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E099.png"
     },
     {
         "name": "2nd Fuso-class Aviation Battleship, Yamashiro-Kai",
@@ -2773,7 +2773,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E100U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E100.png"
     },
     {
         "name": "5th Fubuki-class Destroyer, Murakumo",
@@ -2800,7 +2800,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E101C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E101.png"
     },
     {
         "name": "7th Mutsuki-class Destroyer, Fumiduki",
@@ -2826,7 +2826,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E102C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E102.png"
     },
     {
         "name": "9th Mutsuki-class Destroyer, Kikuduki",
@@ -2853,7 +2853,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E103C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E103.png"
     },
     {
         "name": "5th Mutsuki-class Destroyer, Satsuki",
@@ -2880,7 +2880,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E104C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E104.png"
     },
     {
         "name": "2nd Fubuki-class Destroyer, Shirayuki",
@@ -2907,7 +2907,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E105C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E105.png"
     },
     {
         "name": "9th Fubuki-class Destroyer, Isonami",
@@ -2934,7 +2934,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E106C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E106.png"
     },
     {
         "name": "10th Mutsuki-class Destroyer, Mikaduki",
@@ -2960,7 +2960,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E107C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E107.png"
     },
     {
         "name": "11th Mutsuki-class Destroyer, Mochiduki",
@@ -2986,7 +2986,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E108C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E108.png"
     },
     {
         "name": "8th Mutsuki-class Destroyer, Nagatsuki",
@@ -3012,7 +3012,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E109C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E109.png"
     },
     {
         "name": "3rd Fubuki-class Destroyer, Hatsuyuki",
@@ -3038,7 +3038,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E110C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E110.png"
     },
     {
         "name": "2nd Mutsuki-class Destroyer, Kisaragi",
@@ -3064,7 +3064,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E111C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E111.png"
     },
     {
         "name": "4th Fubuki-class Destroyer, Miyuki",
@@ -3090,7 +3090,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E112C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E112.png"
     },
     {
         "name": "5th Nagara-class Light Cruiser, Kinu",
@@ -3116,7 +3116,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E113C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E113.png"
     },
     {
         "name": "2nd Nagara-class Light Cruiser, Isuzu",
@@ -3143,7 +3143,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E114C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E114.png"
     },
     {
         "name": "6th Nagara-class Light Cruiser, Abukuma",
@@ -3169,7 +3169,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E115C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E115.png"
     },
     {
         "name": "4th Nagara-class Light Cruiser, Yura",
@@ -3195,7 +3195,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E116C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E116.png"
     },
     {
         "name": "5th Kuma-class Light Cruiser, Kiso",
@@ -3221,7 +3221,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E117C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E117.png"
     },
     {
         "name": "3rd Nagara-class Light Cruiser, Natori",
@@ -3248,7 +3248,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E118C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E118.png"
     },
     {
         "name": "2nd Kuma-class Light Cruiser, Tama",
@@ -3274,7 +3274,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E119C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E119.png"
     },
     {
         "name": "2nd Fuso-class Battleship, Yamashiro",
@@ -3302,7 +3302,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E120",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E120C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E120.png"
     },
     {
         "name": "1st Fuso-class Aviation Battleship, Fuso-Kai",
@@ -3330,7 +3330,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E121C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E121.png"
     },
     {
         "name": "Item Shop Girl",
@@ -3357,7 +3357,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E122C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E122.png"
     },
     {
         "name": "Standby! Fire!",
@@ -3386,7 +3386,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E123CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E123.png"
     },
     {
         "name": "That's the way to do it, anchors aweigh!",
@@ -3415,7 +3415,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E124",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E124CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E124.png"
     },
     {
         "name": "Let me take care of it!",
@@ -3444,7 +3444,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E125",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E125CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E125.png"
     },
     {
         "name": "Torpedo ships, heading out!",
@@ -3473,7 +3473,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E126",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E126CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E126.png"
     },
     {
         "name": "Torpedo Squadron, Charge!",
@@ -3502,7 +3502,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E127",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E127CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E127.png"
     },
     {
         "name": "1st Nagato-class Battleship, Nagato",
@@ -3531,7 +3531,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E128",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E128RRPlus.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E128.png"
     },
     {
         "name": "3rd Mogami-class Heavy Cruiser, Suzuya",
@@ -3558,7 +3558,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E129",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E129RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E129.png"
     },
     {
         "name": "4th Mogami-class Heavy Cruiser, Kumano",
@@ -3585,7 +3585,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E130",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E130RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E130.png"
     },
     {
         "name": "2nd Nagato-class Battleship, Mutsu",
@@ -3615,7 +3615,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E131",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E131RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E131.png"
     },
     {
         "name": "4th Shiratsuyu-class Destroyer, Yudachi-Kai-Ni",
@@ -3641,7 +3641,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E132",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E132R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E132.png"
     },
     {
         "name": "Lucky Destroyer, Shigure-Kai-Ni",
@@ -3667,7 +3667,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E133",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E133R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E133.png"
     },
     {
         "name": "2nd Shoho-class Light Aircraft Carrier, Zuiho",
@@ -3696,7 +3696,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E134",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E134R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E134.png"
     },
     {
         "name": "Soryu-class Aircraft Carrier, Soryu",
@@ -3724,7 +3724,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E135",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E135R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E135.png"
     },
     {
         "name": "2nd Mogami-class Aviation Heavy Cruiser, Mikuma-Kai",
@@ -3753,7 +3753,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E136",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E136R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E136.png"
     },
     {
         "name": "3rd Mogami-class Aviation Heavy Cruiser, Suzuya-Kai",
@@ -3781,7 +3781,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E137",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E137R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E137.png"
     },
     {
         "name": "Hiryu-class Aircraft Carrier, Hiryu",
@@ -3810,7 +3810,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E138",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E138R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E138.png"
     },
     {
         "name": "4th Mogami-class Aviation Heavy Cruiser, Kumano-Kai",
@@ -3838,7 +3838,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E139",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E139R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E139.png"
     },
     {
         "name": "4th Shiratsuyu-class Destroyer, Yudachi",
@@ -3865,7 +3865,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E140",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E140U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E140.png"
     },
     {
         "name": "1st Asashio-class Destroyer, Asashio",
@@ -3891,7 +3891,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E141",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E141U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E141.png"
     },
     {
         "name": "1st Shiratsuyu-class Destroyer, Shiratsuyu",
@@ -3917,7 +3917,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E142",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E142U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E142.png"
     },
     {
         "name": "1st Mogami-class Heavy Cruiser, Mogami",
@@ -3944,7 +3944,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E143",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E143U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E143.png"
     },
     {
         "name": "2nd Mogami-class Heavy Cruiser, Mikuma",
@@ -3970,7 +3970,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E144",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E144U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E144.png"
     },
     {
         "name": "1st Myoko-class Heavy Cruiser, Myoko",
@@ -3996,7 +3996,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E145",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E145U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E145.png"
     },
     {
         "name": "1st Shoho-class Light Aircraft Carrier, Shoho",
@@ -4024,7 +4024,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E146",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E146U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E146.png"
     },
     {
         "name": "1st Mogami-class Aviation Heavy Cruiser, Mogami-Kai",
@@ -4052,7 +4052,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E147",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E147U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E147.png"
     },
     {
         "name": "9th Asashio-class Destroyer, Arare",
@@ -4079,7 +4079,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E148",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E148C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E148.png"
     },
     {
         "name": "3rd Shiratsuyu-class Destroyer, Murasame",
@@ -4106,7 +4106,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E149",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E149C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E149.png"
     },
     {
         "name": "3rd Asashio-class Destroyer, Michishio",
@@ -4132,7 +4132,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E150",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E150C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E150.png"
     },
     {
         "name": "2nd Shiratsuyu-class Destroyer, Shigure",
@@ -4159,7 +4159,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E151",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E151C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E151.png"
     },
     {
         "name": "4th Asashio-class Destroyer, Arashio",
@@ -4186,7 +4186,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E152",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E152C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E152.png"
     },
     {
         "name": "6th Shiratsuyu-class Destroyer, Samidare",
@@ -4212,7 +4212,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E153",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E153C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E153.png"
     },
     {
         "name": "2nd Asashio-class Destroyer, Oshio",
@@ -4238,7 +4238,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E154",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E154C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E154.png"
     },
     {
         "name": "10th Asashio-class Destroyer, Kasumi",
@@ -4265,7 +4265,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E155",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E155C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E155.png"
     },
     {
         "name": "10th Shiratsuyu-class Destroyer, Suzukaze",
@@ -4291,7 +4291,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E156",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E156C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E156.png"
     },
     {
         "name": "4th Myoko-class Heavy Cruiser, Haguro",
@@ -4317,7 +4317,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E157",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E157C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E157.png"
     },
     {
         "name": "3rd Myoko-class Heavy Cruiser, Ashigara",
@@ -4346,7 +4346,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E158",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E158C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E158.png"
     },
     {
         "name": "2nd Myoko-class Heavy Cruiser, Nachi",
@@ -4375,7 +4375,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E159",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E159C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E159.png"
     },
     {
         "name": "Food Supply Ship, Mamiya",
@@ -4402,7 +4402,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E160",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E160C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E160.png"
     },
     {
         "name": "Do not look down on the power of the Big 7",
@@ -4431,7 +4431,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E161",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E161CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E161.png"
     },
     {
         "name": "Leave it to Suzuya-!",
@@ -4461,7 +4461,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E162",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E162CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E162.png"
     },
     {
         "name": "Second Carrier Division is heading out!",
@@ -4490,7 +4490,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E163",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E163CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E163.png"
     },
     {
         "name": "Well then, let's have a great party!",
@@ -4519,7 +4519,7 @@
         "set": "KC",
         "release": "25",
         "sid": "E164",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_E164CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_E164.png"
     },
     {
         "name": "Hei-class Landing Craft Carrier, Akitsumaru",
@@ -4598,7 +4598,7 @@
         "set": "KC",
         "release": "25",
         "sid": "PE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_PE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_PE07.png"
     },
     {
         "name": "8th Kagero-class Destroyer, Yukikaze",
@@ -4624,7 +4624,7 @@
         "set": "KC",
         "release": "25",
         "sid": "PE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KC_S25_PE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_PE08.png"
     },
     {
         "name": "Clumsy Girl, Inaduma",
@@ -4651,7 +4651,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE01_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE01.png"
     },
     {
         "name": "4th Hatsuharu-class Destroyer, Hatsushimo",
@@ -4677,7 +4677,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE02_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE02.png"
     },
     {
         "name": "7th Ayanami-class Destroyer, Oboro",
@@ -4703,7 +4703,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE03_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE03.png"
     },
     {
         "name": "3rd Sendai-class Light Cruiser, Naka",
@@ -4730,7 +4730,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE04_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE04.png"
     },
     {
         "name": "2nd Furutaka-class Heavy Cruiser, Kako",
@@ -4756,7 +4756,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE05_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE05.png"
     },
     {
         "name": "Ryujo-class Light Aircraft Carrier, Ryujo",
@@ -4784,7 +4784,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE06_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE06.png"
     },
     {
         "name": "Akagi of the First Carrier Division is up next!",
@@ -4813,7 +4813,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE07_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE07.png"
     },
     {
         "name": "We must go into night combat!",
@@ -4842,7 +4842,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE08_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE08.png"
     },
     {
         "name": "9th Mutsuki-class Destroyer, Kikuduki",
@@ -4869,7 +4869,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE09_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE09.png"
     },
     {
         "name": "8th Mutsuki-class Destroyer, Nagatsuki",
@@ -4895,7 +4895,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE10_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE10.png"
     },
     {
         "name": "1st Mutsuki-class Destroyer, Mutsuki",
@@ -4921,7 +4921,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE11_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE11.png"
     },
     {
         "name": "2nd Nagara-class Light Cruiser, Isuzu",
@@ -4948,7 +4948,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE12_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE12.png"
     },
     {
         "name": "2nd Kuma-class Light Cruiser, Tama",
@@ -4974,7 +4974,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE13_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE13.png"
     },
     {
         "name": "1st Fuso-class Battleship, Fuso",
@@ -5003,7 +5003,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE14_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE14.png"
     },
     {
         "name": "Hosho-class Light Aircraft Carrier, Hosho",
@@ -5032,7 +5032,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE15_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE15.png"
     },
     {
         "name": "I'll be the flagship! Isuzu-Kai-Ni",
@@ -5061,7 +5061,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE16_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE16.png"
     },
     {
         "name": "1st Fuso-class Aviation Battleship, Fuso-Kai",
@@ -5089,7 +5089,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE17_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE17.png"
     },
     {
         "name": "Torpedo Squadron, Charge!",
@@ -5118,7 +5118,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE18_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE18.png"
     },
     {
         "name": "Confident Maya",
@@ -5146,7 +5146,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE19_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE19.png"
     },
     {
         "name": "All-knowing Chokai",
@@ -5174,7 +5174,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE20_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE20.png"
     },
     {
         "name": "Akagi-class Aircraft Carrier, Akagi",
@@ -5203,7 +5203,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE21_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE21.png"
     },
     {
         "name": "1st Tenryu-class Light Cruiser, Tenryu",
@@ -5229,7 +5229,7 @@
         "set": "KC",
         "release": "25",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE22_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE22.png"
     },
     {
         "name": "3rd Akatsuki-class Destroyer, Ikaduchi",
@@ -5255,6 +5255,6 @@
         "set": "KC",
         "release": "25",
         "sid": "TE23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KC_S25-TE23_TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/kc_s25/KC_S25_TE23.png"
     }
 ]

--- a/DB/KLK_S27.json
+++ b/DB/KLK_S27.json
@@ -25,7 +25,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E001.png"
     },
     {
         "name": "Mako Can't Stop for Any Reason",
@@ -53,7 +53,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E002.png"
     },
     {
         "name": "Worrying Mako",
@@ -80,7 +80,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E003.png"
     },
     {
         "name": "Fight Club President, Mako",
@@ -108,7 +108,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E004.png"
     },
     {
         "name": "Osaka Sightseeing, Mako",
@@ -134,7 +134,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E005.png"
     },
     {
         "name": "Second Year Class K, Ryuko",
@@ -160,7 +160,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E006.png"
     },
     {
         "name": "Fight Club Member, Ryuko",
@@ -189,7 +189,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E007.png"
     },
     {
         "name": "Ryuko in Pajamas",
@@ -216,7 +216,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E008.png"
     },
     {
         "name": "Motionless Mako",
@@ -243,7 +243,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E009.png"
     },
     {
         "name": "Mako Eating Croquettes",
@@ -272,7 +272,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E010.png"
     },
     {
         "name": "\"Uber\" Own Pace Mother, Sukuyo",
@@ -298,7 +298,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E011.png"
     },
     {
         "name": "Guts 'cause He Eats With Gusto",
@@ -324,7 +324,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E012.png"
     },
     {
         "name": "Mako with Glasses",
@@ -350,7 +350,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E013.png"
     },
     {
         "name": "Out of Place Rascal, Mataro",
@@ -376,7 +376,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E014.png"
     },
     {
         "name": "Ryuko Living with the Mankanshoku Family",
@@ -402,7 +402,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E015.png"
     },
     {
         "name": "Back-alley Doctor, Barazo",
@@ -430,7 +430,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E016.png"
     },
     {
         "name": "Suspicious Croquettes",
@@ -456,7 +456,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E017.png"
     },
     {
         "name": "Classic Trap",
@@ -482,7 +482,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E018.png"
     },
     {
         "name": "So now it's my turn!",
@@ -512,7 +512,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E019.png"
     },
     {
         "name": "Let's Eat!",
@@ -541,7 +541,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E020.png"
     },
     {
         "name": "Ragyo Plots Cocoon Sphere Birth",
@@ -569,7 +569,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E021.png"
     },
     {
         "name": "Spinning Wheel of Fate, Nui",
@@ -598,7 +598,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E022.png"
     },
     {
         "name": "Nui Pulling Thread",
@@ -624,7 +624,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E023.png"
     },
     {
         "name": "Owner of Scissor Blade, Nui",
@@ -653,7 +653,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E024.png"
     },
     {
         "name": "Dodging Nui",
@@ -681,7 +681,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E025.png"
     },
     {
         "name": "CEO of REVOCS, Ragyo",
@@ -711,7 +711,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E026R.png"
     },
     {
         "name": "Grand Couturier, Nui",
@@ -738,7 +738,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E027.png"
     },
     {
         "name": "Head Steward of Kiryuin Family, Kuroido",
@@ -765,7 +765,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E028.png"
     },
     {
         "name": "\"Mind Stitching\" Ragyo",
@@ -792,7 +792,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E029.png"
     },
     {
         "name": "Ready-made Nui",
@@ -819,7 +819,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E030.png"
     },
     {
         "name": "Secretary to Ragyo, Hououmaru",
@@ -847,7 +847,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E031.png"
     },
     {
         "name": "Whimsical Nui",
@@ -873,7 +873,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E032.png"
     },
     {
         "name": "Head of Trap Development, Ogure",
@@ -899,7 +899,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E033.png"
     },
     {
         "name": "Satsuki's Mother, Ragyo",
@@ -925,7 +925,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E034.png"
     },
     {
         "name": "Tennis Club President, Hakodate",
@@ -951,7 +951,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E035.png"
     },
     {
         "name": "Boxing Club President, Fukuroda",
@@ -977,7 +977,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E036.png"
     },
     {
         "name": "Mysterious Girl, Nui",
@@ -1003,7 +1003,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E037.png"
     },
     {
         "name": "Disguise",
@@ -1029,7 +1029,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E038.png"
     },
     {
         "name": "Surprise Confession",
@@ -1058,7 +1058,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E039.png"
     },
     {
         "name": "Shinra Koketsu, Absolute Submission!",
@@ -1087,7 +1087,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E040.png"
     },
     {
         "name": "Towards a New Self, Ryuko",
@@ -1114,7 +1114,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E041.png"
     },
     {
         "name": "Conclusion After Wearing! Ryuko",
@@ -1144,7 +1144,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E042.png"
     },
     {
         "name": "Deep Bonds, Ryuko",
@@ -1171,7 +1171,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E043.png"
     },
     {
         "name": "Taking Back Senketsu! Ryuko",
@@ -1198,7 +1198,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E044.png"
     },
     {
         "name": "Only Clothing Ryuko Has, Senketsu",
@@ -1225,7 +1225,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E045.png"
     },
     {
         "name": "Encounter with Senketsu, Ryuko",
@@ -1252,7 +1252,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E046.png"
     },
     {
         "name": "\"Rampage\" Ryuko",
@@ -1279,7 +1279,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E047.png"
     },
     {
         "name": "War Declaration! Ryuko",
@@ -1309,7 +1309,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E048.png"
     },
     {
         "name": "Ryuko's Father, Isshin",
@@ -1335,7 +1335,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E049.png"
     },
     {
         "name": "Along with Senketsu, Satsuki",
@@ -1361,7 +1361,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E050.png"
     },
     {
         "name": "Ryuko Wearing Junketsu",
@@ -1387,7 +1387,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E051.png"
     },
     {
         "name": "Member of Nudist Beach, Kinagase",
@@ -1413,7 +1413,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E052.png"
     },
     {
         "name": "Voice Heard, Senketsu",
@@ -1442,7 +1442,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E053.png"
     },
     {
         "name": "Same Feelings! Mako",
@@ -1471,7 +1471,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E054.png"
     },
     {
         "name": "Satsuki Wearing Senketsu",
@@ -1500,7 +1500,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E055.png"
     },
     {
         "name": "Ryuko Searching for \"Girl with Scissor Blade\"",
@@ -1526,7 +1526,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E056.png"
     },
     {
         "name": "Next Seat, Mako",
@@ -1552,7 +1552,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E057.png"
     },
     {
         "name": "Transfer Student, Ryuko",
@@ -1578,7 +1578,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E058.png"
     },
     {
         "name": "Talking Sailor Uniform, Senketsu",
@@ -1604,7 +1604,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E059.png"
     },
     {
         "name": "Naniwa Kinman High School, Takarada",
@@ -1630,7 +1630,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E060.png"
     },
     {
         "name": "Power with Senketsu, Ryuko",
@@ -1656,7 +1656,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E061.png"
     },
     {
         "name": "Satsuki Looking Up At the Sky",
@@ -1682,7 +1682,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E062.png"
     },
     {
         "name": "Naked Nudist, Mikisugi",
@@ -1708,7 +1708,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E063.png"
     },
     {
         "name": "Connected by Blood, Ryuko",
@@ -1737,7 +1737,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E064.png"
     },
     {
         "name": "Mysterious Guy, Mikisugi",
@@ -1765,7 +1765,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E065.png"
     },
     {
         "name": "Junketsu",
@@ -1791,7 +1791,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E066.png"
     },
     {
         "name": "Seki Tekko",
@@ -1817,7 +1817,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E067.png"
     },
     {
         "name": "The time comes when a girl outgrows her sailor uniform",
@@ -1846,7 +1846,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E068.png"
     },
     {
         "name": "Battle of Fate",
@@ -1875,7 +1875,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E069.png"
     },
     {
         "name": "Life Fiber Synchronize, Kamui Senketsu!",
@@ -1904,7 +1904,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E070.png"
     },
     {
         "name": "Satsuki's Ambition",
@@ -1931,7 +1931,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E071.png"
     },
     {
         "name": "To Protect the World, Satsuki",
@@ -1961,7 +1961,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E072.png"
     },
     {
         "name": "Before the Final Battle, Satsuki",
@@ -1988,7 +1988,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E073.png"
     },
     {
         "name": "First Step of Lifelong Ambition, Satsuki",
@@ -2014,7 +2014,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E074.png"
     },
     {
         "name": "Genius Hacker, Inumuta",
@@ -2041,7 +2041,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E075.png"
     },
     {
         "name": "Great Spirit, Satsuki",
@@ -2068,7 +2068,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E076.png"
     },
     {
         "name": "High Aspirations, Satsuki",
@@ -2095,7 +2095,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E077.png"
     },
     {
         "name": "Satsuki's Childhood Friend, Jakuzure",
@@ -2125,7 +2125,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E078.png"
     },
     {
         "name": "Sewing Club President, Iori",
@@ -2151,7 +2151,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E079.png"
     },
     {
         "name": "Gamagoori Maintaining Discipline",
@@ -2178,7 +2178,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E080.png"
     },
     {
         "name": "Family Runs a Konnyaku Business, Sanageyama",
@@ -2205,7 +2205,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E081.png"
     },
     {
         "name": "Start of the Song, Jakuzure",
@@ -2231,7 +2231,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E082.png"
     },
     {
         "name": "Satsuki Discovering a Chance for Victory",
@@ -2259,7 +2259,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E083.png"
     },
     {
         "name": "Shingantsu Surpassing Tengantsu, Sanageyama",
@@ -2287,7 +2287,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E084.png"
     },
     {
         "name": "Satsuki's Butler, Soroi",
@@ -2313,7 +2313,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E085.png"
     },
     {
         "name": "Top of the Skyscraper, Satsuki",
@@ -2339,7 +2339,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E086.png"
     },
     {
         "name": "The Elite Four, Inumuta",
@@ -2365,7 +2365,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E087.png"
     },
     {
         "name": "The Elite Four, Jakuzure",
@@ -2391,7 +2391,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E088.png"
     },
     {
         "name": "Absolute Terror, Satsuki",
@@ -2417,7 +2417,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E089.png"
     },
     {
         "name": "Pervert During Every Change, Gamagoori",
@@ -2443,7 +2443,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E090.png"
     },
     {
         "name": "The Elite Four, Sanageyama",
@@ -2469,7 +2469,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E091.png"
     },
     {
         "name": "The Elite Four, Gamagoori",
@@ -2497,7 +2497,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E092.png"
     },
     {
         "name": "Data-minded, Inumuta",
@@ -2525,7 +2525,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E093.png"
     },
     {
         "name": "Smiling Satsuki",
@@ -2553,7 +2553,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E094.png"
     },
     {
         "name": "Junketsu",
@@ -2579,7 +2579,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E095.png"
     },
     {
         "name": "Soroi's Tea",
@@ -2605,7 +2605,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E096.png"
     },
     {
         "name": "To Honnouji Academy",
@@ -2634,7 +2634,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E097.png"
     },
     {
         "name": "My actions are utterly pure!",
@@ -2663,7 +2663,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E098.png"
     },
     {
         "name": "Life Fiber Override, Kamui Junketsu!",
@@ -2692,7 +2692,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E099.png"
     },
     {
         "name": "Honnouji Academy Elite Four, Ultimate Battle Regalia!",
@@ -2722,7 +2722,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E100.png"
     },
     {
         "name": "Mini Mako",
@@ -2750,7 +2750,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E101PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E101.png"
     },
     {
         "name": "Mini Ryuko",
@@ -2776,7 +2776,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E102PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E102.png"
     },
     {
         "name": "Mini \"Life Fiber Synchronize\" Ryuko",
@@ -2802,7 +2802,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E103PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E103.png"
     },
     {
         "name": "Mini Satsuki",
@@ -2830,7 +2830,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_E104PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_E104.png"
     },
     {
         "name": "Swimsuit Ryuko",
@@ -2856,7 +2856,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_PE01.png"
     },
     {
         "name": "Senketsu's Date with Ryuko",
@@ -2882,7 +2882,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_PE02.png"
     },
     {
         "name": "Next Seat, Mako",
@@ -2908,7 +2908,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE01.png"
     },
     {
         "name": "Transfer Student, Ryuko",
@@ -2934,7 +2934,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE02.png"
     },
     {
         "name": "Talking Sailor Uniform, Senketsu",
@@ -2960,7 +2960,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE03.png"
     },
     {
         "name": "Power with Senketsu, Ryuko",
@@ -2986,7 +2986,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE04.png"
     },
     {
         "name": "Connected by Blood, Ryuko",
@@ -3015,7 +3015,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE05.png"
     },
     {
         "name": "Mysterious Guy, Mikisugi",
@@ -3043,7 +3043,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE06.png"
     },
     {
         "name": "Seki Tekko",
@@ -3069,7 +3069,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE07.png"
     },
     {
         "name": "Life Fiber Synchronize, Kamui Senketsu!",
@@ -3098,7 +3098,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE08.png"
     },
     {
         "name": "The Elite Four, Inumuta",
@@ -3124,7 +3124,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE09.png"
     },
     {
         "name": "The Elite Four, Jakuzure",
@@ -3150,7 +3150,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE10.png"
     },
     {
         "name": "Absolute Terror, Satsuki",
@@ -3176,7 +3176,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE11.png"
     },
     {
         "name": "The Elite Four, Sanageyama",
@@ -3202,7 +3202,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE12.png"
     },
     {
         "name": "The Elite Four, Gamagoori",
@@ -3230,7 +3230,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE13.png"
     },
     {
         "name": "My actions are utterly pure!",
@@ -3259,7 +3259,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE14.png"
     },
     {
         "name": "Life Fiber Override, Kamui Junketsu!",
@@ -3288,7 +3288,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE15.png"
     },
     {
         "name": "Wandering High School Girl, Ryuko",
@@ -3317,7 +3317,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE16.png"
     },
     {
         "name": "Another Wielder of Kamui, Satsuki",
@@ -3343,7 +3343,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE17.png"
     },
     {
         "name": "\"Uber\" Air-head Girl, Mako",
@@ -3369,7 +3369,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE18.png"
     },
     {
         "name": "\"Best Friends\" Ryuko & Mako",
@@ -3398,7 +3398,7 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE19.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE19.png"
     },
     {
         "name": "Dominating Student Council President, Satsuki",
@@ -3425,6 +3425,6 @@
         "set": "KLK",
         "release": "27",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KLK_S27_TE20.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/klk_s27/KLK_S27_TE20.png"
     }
 ]

--- a/DB/KS2_W55.json
+++ b/DB/KS2_W55.json
@@ -24,7 +24,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E001.png"
     },
     {
         "name": "\"Iron Wall Crusader\" Darkness",
@@ -51,7 +51,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E002.png"
     },
     {
         "name": "\"Duke of Hell\" Vanir",
@@ -81,7 +81,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E003.png"
     },
     {
         "name": "\"Setting Out\" Darkness",
@@ -110,7 +110,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E004.png"
     },
     {
         "name": "\"Snipe\" Kazuma",
@@ -137,7 +137,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E005.png"
     },
     {
         "name": "\"Decoy\" Kazuma",
@@ -164,7 +164,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E006.png"
     },
     {
         "name": "\"Precious Item\" Chris",
@@ -191,7 +191,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E007.png"
     },
     {
         "name": "\"Sightseeing in Arcanretia\" Darkness",
@@ -217,7 +217,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E008.png"
     },
     {
         "name": "Swimsuit Darkness",
@@ -243,7 +243,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E009.png"
     },
     {
         "name": "\"Herald\" Darkness",
@@ -270,7 +270,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E010.png"
     },
     {
         "name": "\"Power of the Mask\" Darkness",
@@ -300,7 +300,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E011.png"
     },
     {
         "name": "\"Setting Out\" Kazuma",
@@ -329,7 +329,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E012.png"
     },
     {
         "name": "\"Patriarch's Poise\" Darkness' Father",
@@ -355,7 +355,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E013.png"
     },
     {
         "name": "\"Cross-Examination\" Sena",
@@ -381,7 +381,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E014.png"
     },
     {
         "name": "\"Aristocrat Daughter\" Darkness",
@@ -408,7 +408,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E015.png"
     },
     {
         "name": "\"Rock-Paper-Scissors Master\" Kazuma",
@@ -434,7 +434,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E016.png"
     },
     {
         "name": "\"A New Quest\" Kazuma",
@@ -461,7 +461,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E017.png"
     },
     {
         "name": "\"Sending Off\" Ruffian",
@@ -490,7 +490,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E018.png"
     },
     {
         "name": "\"Dead-On Accuracy\" Darkness",
@@ -519,7 +519,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E019.png"
     },
     {
         "name": "\"Iron Will\" Darkness",
@@ -548,7 +548,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E020.png"
     },
     {
         "name": "\"Impromptu Butler\" Kazuma",
@@ -575,7 +575,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E021.png"
     },
     {
         "name": "\"Third Witness\" Clemea & Fio",
@@ -602,7 +602,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E022.png"
     },
     {
         "name": "\"Catharsis\" Coachman",
@@ -628,7 +628,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E023.png"
     },
     {
         "name": "\"In Ecstasy\" Darkness",
@@ -654,7 +654,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E024.png"
     },
     {
         "name": "\"Dignified\" Darkness",
@@ -681,7 +681,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E025.png"
     },
     {
         "name": "\"Second Generation\" Vanir",
@@ -707,7 +707,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E026.png"
     },
     {
         "name": "\"Masked Demon\" Vanir",
@@ -734,7 +734,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E027.png"
     },
     {
         "name": "\"First Witness\" Chris",
@@ -761,7 +761,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E028.png"
     },
     {
         "name": "\"Second Witness\" Mitsurugi",
@@ -787,7 +787,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E029.png"
     },
     {
         "name": "\"Freeze\" Kazuma",
@@ -816,7 +816,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E030.png"
     },
     {
         "name": "\"Embarrassed\" Sena",
@@ -845,7 +845,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E031.png"
     },
     {
         "name": "Aristocratic Insignia",
@@ -871,7 +871,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E032.png"
     },
     {
         "name": "Lurk Skill",
@@ -897,7 +897,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E033.png"
     },
     {
         "name": "Lie-Detecting Device",
@@ -925,7 +925,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E034.png"
     },
     {
         "name": "Chicken Race",
@@ -951,7 +951,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E035.png"
     },
     {
         "name": "Subduing Even My Heart……",
@@ -981,7 +981,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E036.png"
     },
     {
         "name": "First Incitation",
@@ -1010,7 +1010,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E037.png"
     },
     {
         "name": "To the Next Adventure!",
@@ -1040,7 +1040,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E038.png"
     },
     {
         "name": "Unparalled Deleterious Desire",
@@ -1069,7 +1069,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E039.png"
     },
     {
         "name": "Return It to Me!!",
@@ -1098,7 +1098,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E040.png"
     },
     {
         "name": "Swimsuit Megumin",
@@ -1125,7 +1125,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E041.png"
     },
     {
         "name": "\"Bunny Girl\" Yunyun",
@@ -1152,7 +1152,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E042.png"
     },
     {
         "name": "\"Detonative Dame\" Megumin",
@@ -1181,7 +1181,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E043.png"
     },
     {
         "name": "\"Ice Witch\" Wiz",
@@ -1210,7 +1210,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E044.png"
     },
     {
         "name": "\"Having a Nightmare\" Wiz",
@@ -1237,7 +1237,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E045.png"
     },
     {
         "name": "\"Elated\" Wiz",
@@ -1264,7 +1264,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E046.png"
     },
     {
         "name": "\"Chomp Chomp\" Megumin",
@@ -1291,7 +1291,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E047.png"
     },
     {
         "name": "\"Ambush\" Yunyun",
@@ -1318,7 +1318,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E048.png"
     },
     {
         "name": "\"Brightening Eyes\" Megumin",
@@ -1344,7 +1344,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E049.png"
     },
     {
         "name": "\"Tad Bit Shy\" Yunyun",
@@ -1370,7 +1370,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E050.png"
     },
     {
         "name": "\"Setting Out\" Megumin",
@@ -1399,7 +1399,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E051.png"
     },
     {
         "name": "\"Eternal Rival\" Yunyun",
@@ -1429,7 +1429,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E052.png"
     },
     {
         "name": "\"Powered-Up Explosion Magic\" Megumin",
@@ -1459,7 +1459,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E053.png"
     },
     {
         "name": "\"Consecutive Victories\" Megumin",
@@ -1486,7 +1486,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E054.png"
     },
     {
         "name": "Chommusuke",
@@ -1512,7 +1512,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E055.png"
     },
     {
         "name": "\"Radiant Smile\" Megumin",
@@ -1539,7 +1539,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E056.png"
     },
     {
         "name": "\"Taken Aback\" Yunyun",
@@ -1566,7 +1566,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E057.png"
     },
     {
         "name": "\"General Store Shopkeeper\" Wiz",
@@ -1592,7 +1592,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E058.png"
     },
     {
         "name": "\"Developmental Challenge\" Yunyun",
@@ -1618,7 +1618,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E059.png"
     },
     {
         "name": "\"Lonely Birthday\" Yunyun",
@@ -1645,7 +1645,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E060.png"
     },
     {
         "name": "\"Deadly Poison Slime\" Hans",
@@ -1672,7 +1672,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E061.png"
     },
     {
         "name": "\"Nice Assist\" Wiz",
@@ -1701,7 +1701,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E062.png"
     },
     {
         "name": "Hans",
@@ -1727,7 +1727,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E063.png"
     },
     {
         "name": "\"Maxed-Out Motivation\" Yunyun",
@@ -1754,7 +1754,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E064.png"
     },
     {
         "name": "\"Challenge Accepted\" Megumin",
@@ -1780,7 +1780,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E065.png"
     },
     {
         "name": "\"Reminiscent Reunion\" Wiz",
@@ -1806,7 +1806,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E066.png"
     },
     {
         "name": "\"Insufficient Magic Power\" Megumin",
@@ -1832,7 +1832,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E067.png"
     },
     {
         "name": "\"Coming with Gifts\" Yunyun",
@@ -1859,7 +1859,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E068.png"
     },
     {
         "name": "\"Out of the Bath\" Wiz",
@@ -1885,7 +1885,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E069.png"
     },
     {
         "name": "\"Objection!\" Megumin",
@@ -1914,7 +1914,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E070.png"
     },
     {
         "name": "\"In the Dream\" Wiz",
@@ -1943,7 +1943,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E071.png"
     },
     {
         "name": "\"Power of a Demon Army General\" Wiz",
@@ -1972,7 +1972,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E072.png"
     },
     {
         "name": "\"The Rival Makes Her Appearance\" Yunyun",
@@ -2001,7 +2001,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E073.png"
     },
     {
         "name": "Friendship Crystal",
@@ -2028,7 +2028,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E074.png"
     },
     {
         "name": "New Explosion Magic",
@@ -2057,7 +2057,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E075.png"
     },
     {
         "name": "Light of Saber!",
@@ -2086,7 +2086,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E076.png"
     },
     {
         "name": "In the Bath",
@@ -2115,7 +2115,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E077.png"
     },
     {
         "name": "Cursed Crystal Prison!",
@@ -2144,7 +2144,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E078.png"
     },
     {
         "name": "\"Setting Out\" Aqua",
@@ -2170,7 +2170,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E079.png"
     },
     {
         "name": "\"Mesmerizing Water Goddess\" Aqua",
@@ -2200,7 +2200,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E080.png"
     },
     {
         "name": "Swimsuit Eris",
@@ -2227,7 +2227,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E081.png"
     },
     {
         "name": "\"Soul Salvation\" Aqua",
@@ -2254,7 +2254,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E082.png"
     },
     {
         "name": "\"Real Magic Power is Down to Luck Too\" Aqua",
@@ -2281,7 +2281,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E083.png"
     },
     {
         "name": "Swimsuit Aqua",
@@ -2307,7 +2307,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E084.png"
     },
     {
         "name": "\"Furious Fist\" Aqua",
@@ -2338,7 +2338,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E085.png"
     },
     {
         "name": "\"Decoy\" Aqua",
@@ -2365,7 +2365,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E086.png"
     },
     {
         "name": "\"Our Little Secret Here\" Eris",
@@ -2392,7 +2392,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E087.png"
     },
     {
         "name": "\"Who I Really Am\" Aqua",
@@ -2421,7 +2421,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E088.png"
     },
     {
         "name": "\"Swarmed on the Street\" Axis Church Devotee",
@@ -2448,7 +2448,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E089a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E089a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E089a.png"
     },
     {
         "name": "\"Swarmed on the Street\" Axis Church Devotee",
@@ -2475,7 +2475,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E089b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E089b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E089b.png"
     },
     {
         "name": "\"Swarmed on the Street\" Axis Church Devotee",
@@ -2502,7 +2502,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E089c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E089c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E089c.png"
     },
     {
         "name": "\"Swarmed on the Street\" Axis Church Devotee",
@@ -2529,7 +2529,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E089d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E089d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E089d.png"
     },
     {
         "name": "\"Carefree Maid\" Aqua",
@@ -2555,7 +2555,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E090.png"
     },
     {
         "name": "\"Purification\" Aqua",
@@ -2582,7 +2582,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E091.png"
     },
     {
         "name": "\"Sweet Smile\" Axis Church Devotee",
@@ -2608,7 +2608,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E092.png"
     },
     {
         "name": "\"Bewildered\" Eris",
@@ -2637,7 +2637,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E093.png"
     },
     {
         "name": "\"Tipsy\" Aqua",
@@ -2666,7 +2666,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E094.png"
     },
     {
         "name": "The Power of Purification",
@@ -2692,7 +2692,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E095.png"
     },
     {
         "name": "Seizure of Private Property",
@@ -2718,7 +2718,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E096.png"
     },
     {
         "name": "Axis Church Creed",
@@ -2744,7 +2744,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E097.png"
     },
     {
         "name": "In the Name of the Goddess",
@@ -2773,7 +2773,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E098.png"
     },
     {
         "name": "Goddess' Fury",
@@ -2802,7 +2802,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E099.png"
     },
     {
         "name": "Well Then, See You",
@@ -2832,7 +2832,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E100.png"
     },
     {
         "name": "Petit Vanir",
@@ -2858,7 +2858,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E101.png"
     },
     {
         "name": "Petit Wiz",
@@ -2884,7 +2884,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E102.png"
     },
     {
         "name": "Petit Yunyun",
@@ -2910,7 +2910,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E103.png"
     },
     {
         "name": "Petit Eris",
@@ -2937,7 +2937,7 @@
         "set": "KS",
         "release": "55",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W55_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w55/KS_W55_E104.png"
     },
     {
         "name": "\"Heartstrings of the Crimson Demon Race\" Megumin",

--- a/DB/KS_W49.json
+++ b/DB/KS_W49.json
@@ -28,7 +28,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E001.png"
     },
     {
         "name": "“Steal Successful…?” Chris",
@@ -58,7 +58,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E002.png"
     },
     {
         "name": "Kazuma",
@@ -84,7 +84,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E003.png"
     },
     {
         "name": "“Shameful Abuse” Darkness",
@@ -111,7 +111,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E004.png"
     },
     {
         "name": "“Lots of Anxiety” Kazuma",
@@ -138,7 +138,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E005.png"
     },
     {
         "name": "“Bonafide Pervert” Darkness",
@@ -165,7 +165,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E006.png"
     },
     {
         "name": "“Special Talent is Fantasizing” Darkness",
@@ -192,7 +192,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E007.png"
     },
     {
         "name": "“Skill Lecture” Chris",
@@ -219,7 +219,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E008.png"
     },
     {
         "name": "“Decide What They Were Worth on My Own” Chris",
@@ -245,7 +245,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E009.png"
     },
     {
         "name": "“Successful Rescue” Darkness",
@@ -271,7 +271,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E010.png"
     },
     {
         "name": "“Imperial Capital Prosecutor” Sena",
@@ -297,7 +297,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E011.png"
     },
     {
         "name": "Luna",
@@ -323,7 +323,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E012.png"
     },
     {
         "name": "“Standing Tall With Arms Wide Open” Darkness",
@@ -352,7 +352,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E013.png"
     },
     {
         "name": "“Something That Must Be Protected” Darkness",
@@ -382,7 +382,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E014.png"
     },
     {
         "name": "“Please Use Me As A Shield!!” Darkness",
@@ -411,7 +411,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E015.png"
     },
     {
         "name": "“Create Water” Kazuma",
@@ -438,7 +438,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E016.png"
     },
     {
         "name": "“Invitation to Learn Skill” Chris",
@@ -465,7 +465,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E017.png"
     },
     {
         "name": "“Model Knight?” Darkness",
@@ -492,7 +492,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E018.png"
     },
     {
         "name": "Ruffian",
@@ -519,7 +519,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E019.png"
     },
     {
         "name": "Mitsurugi",
@@ -547,7 +547,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E020.png"
     },
     {
         "name": "“Adventurer” Kazuma",
@@ -574,7 +574,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E021.png"
     },
     {
         "name": "“Finished Learning A Skill” Kazuma",
@@ -600,7 +600,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E022.png"
     },
     {
         "name": "“Danger Perception” Darkness",
@@ -626,7 +626,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E023.png"
     },
     {
         "name": "“Charge Attack!” Darkness",
@@ -653,7 +653,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E024.png"
     },
     {
         "name": "“Seems Happy” Darkness",
@@ -680,7 +680,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E025.png"
     },
     {
         "name": "“Steal” Kazuma",
@@ -709,7 +709,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E026.png"
     },
     {
         "name": "“Gathering Ideas” Chris",
@@ -738,7 +738,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E027.png"
     },
     {
         "name": "Freeze",
@@ -764,7 +764,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E028.png"
     },
     {
         "name": "Tremble With Pleasure",
@@ -791,7 +791,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E029.png"
     },
     {
         "name": "Thief Skill",
@@ -821,7 +821,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E030.png"
     },
     {
         "name": "Charging Power",
@@ -850,7 +850,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E031.png"
     },
     {
         "name": "Masochistic Crusader",
@@ -880,7 +880,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E032.png"
     },
     {
         "name": "Shaming By the Devil King's Army…?",
@@ -910,7 +910,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E033.png"
     },
     {
         "name": "“Crimson Demon” Megumin",
@@ -939,7 +939,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E034.png"
     },
     {
         "name": "Megumin",
@@ -968,7 +968,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E035.png"
     },
     {
         "name": "“Lich” Wiz",
@@ -998,7 +998,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E036.png"
     },
     {
         "name": "“Board Game” Megumin",
@@ -1025,7 +1025,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E037.png"
     },
     {
         "name": "“Knowledge of Learning A Skill” Megumin",
@@ -1052,7 +1052,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E038.png"
     },
     {
         "name": "“Polite” Yunyun",
@@ -1079,7 +1079,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E039.png"
     },
     {
         "name": "“Nuisance” Megumin",
@@ -1105,7 +1105,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E040.png"
     },
     {
         "name": "“Pouring Tea” Wiz",
@@ -1131,7 +1131,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E041.png"
     },
     {
         "name": "“Nice Explosion!” Megumin",
@@ -1158,7 +1158,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E042.png"
     },
     {
         "name": "“Can't Say It Straight” Yunyun",
@@ -1184,7 +1184,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E043.png"
     },
     {
         "name": "“Concurrent Strike!!” Wiz",
@@ -1213,7 +1213,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E044.png"
     },
     {
         "name": "“Highly-skilled Arch Wizard” Wiz",
@@ -1239,7 +1239,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E045.png"
     },
     {
         "name": "“Involving Megumin” Yunyun",
@@ -1266,7 +1266,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E046.png"
     },
     {
         "name": "“Shaken” Megumin",
@@ -1293,7 +1293,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E047.png"
     },
     {
         "name": "“Awfully Reserved Today” Megumin",
@@ -1320,7 +1320,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E048.png"
     },
     {
         "name": "“Town Celebrity” Wiz",
@@ -1347,7 +1347,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E049.png"
     },
     {
         "name": "“Fear of Dolls” Megumin",
@@ -1376,7 +1376,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E050.png"
     },
     {
         "name": "“Calling for Teacher” Megumin",
@@ -1405,7 +1405,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E051.png"
     },
     {
         "name": "“Insufficient Magic” Wiz",
@@ -1432,7 +1432,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E052.png"
     },
     {
         "name": "Professor",
@@ -1460,7 +1460,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E053.png"
     },
     {
         "name": "“Marbled Red Crab” Megumin",
@@ -1486,7 +1486,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E054.png"
     },
     {
         "name": "“Insistence” Megumin",
@@ -1512,7 +1512,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E055.png"
     },
     {
         "name": "Giant Toad",
@@ -1539,7 +1539,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E056.png"
     },
     {
         "name": "Cabbage",
@@ -1567,7 +1567,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E057.png"
     },
     {
         "name": "“Dark Purple Smoke” Verdia",
@@ -1594,7 +1594,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E058.png"
     },
     {
         "name": "“Spell Casting” Megumin",
@@ -1620,7 +1620,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E059.png"
     },
     {
         "name": "“Gentle Lich” Wiz",
@@ -1649,7 +1649,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E060.png"
     },
     {
         "name": "“My Name is” Yunyun",
@@ -1677,7 +1677,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E061.png"
     },
     {
         "name": "“Long-term Contract Negotiation” Megumin",
@@ -1706,7 +1706,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E062.png"
     },
     {
         "name": "Rookie Succubus",
@@ -1734,7 +1734,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E063.png"
     },
     {
         "name": "Keeps Firing Explosion Magic Every Single Day!",
@@ -1760,7 +1760,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E064.png"
     },
     {
         "name": "Drain Touch",
@@ -1788,7 +1788,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E065.png"
     },
     {
         "name": "Destroyer Alert!",
@@ -1814,7 +1814,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E066.png"
     },
     {
         "name": "Real Explosion Magic",
@@ -1843,7 +1843,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E067.png"
     },
     {
         "name": "Megumin's Rival",
@@ -1872,7 +1872,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E068.png"
     },
     {
         "name": "Explosion Magic",
@@ -1901,7 +1901,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E069.png"
     },
     {
         "name": "Sending Spirits Home",
@@ -1930,7 +1930,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E070.png"
     },
     {
         "name": "“Troublemaker” Aqua",
@@ -1957,7 +1957,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E071.png"
     },
     {
         "name": "“Blessed With Kind Encounters” Eris",
@@ -1987,7 +1987,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E072.png"
     },
     {
         "name": "Aqua",
@@ -2017,7 +2017,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E073.png"
     },
     {
         "name": "“Gentle Goddess” Eris",
@@ -2044,7 +2044,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E074.png"
     },
     {
         "name": "“Significance of Killing Snow Sprites?” Aqua",
@@ -2070,7 +2070,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E075.png"
     },
     {
         "name": "“Gentle Smile” Eris",
@@ -2097,7 +2097,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E076.png"
     },
     {
         "name": "“Sacred Create Water” Aqua",
@@ -2123,7 +2123,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E077.png"
     },
     {
         "name": "“Sacred Turn Undead” Aqua",
@@ -2150,7 +2150,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E078.png"
     },
     {
         "name": "“Being Shy” Eris",
@@ -2179,7 +2179,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E079.png"
     },
     {
         "name": "“Covered in Snot” Aqua",
@@ -2205,7 +2205,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E080.png"
     },
     {
         "name": "“Full of Smiles” Aqua",
@@ -2231,7 +2231,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E081.png"
     },
     {
         "name": "“Flattering” Aqua",
@@ -2258,7 +2258,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E082.png"
     },
     {
         "name": "“In Deep Sleep” Aqua",
@@ -2284,7 +2284,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E083.png"
     },
     {
         "name": "“Provoking Style” Aqua",
@@ -2310,7 +2310,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E084.png"
     },
     {
         "name": "“Providing Magic” Aqua",
@@ -2339,7 +2339,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E085.png"
     },
     {
         "name": "“Going All Out!” Aqua",
@@ -2368,7 +2368,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E086.png"
     },
     {
         "name": "“Adventure About to Begin…?” Aqua",
@@ -2395,7 +2395,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E087.png"
     },
     {
         "name": "“Goddess In Charge of Backwater?” Eris",
@@ -2421,7 +2421,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E088.png"
     },
     {
         "name": "“Quest Clear” Aqua",
@@ -2447,7 +2447,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E089.png"
     },
     {
         "name": "“Real Goddess?” Aqua",
@@ -2473,7 +2473,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E090.png"
     },
     {
         "name": "“Nature's Beauty” Aqua",
@@ -2500,7 +2500,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E091.png"
     },
     {
         "name": "“Head of the Axis Sect” Aqua",
@@ -2526,7 +2526,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E092.png"
     },
     {
         "name": "“Demand for Apology” Aqua",
@@ -2553,7 +2553,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E093.png"
     },
     {
         "name": "“Tasty Way to Drink” Aqua",
@@ -2582,7 +2582,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E094.png"
     },
     {
         "name": "“Stunned” Aqua",
@@ -2611,7 +2611,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E095.png"
     },
     {
         "name": "God Blow",
@@ -2637,7 +2637,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E096.png"
     },
     {
         "name": "Senpai Appears",
@@ -2664,7 +2664,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E097.png"
     },
     {
         "name": "Resurrection",
@@ -2694,7 +2694,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E098.png"
     },
     {
         "name": "Revival",
@@ -2723,7 +2723,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E099.png"
     },
     {
         "name": "Sacred Break Spell",
@@ -2752,7 +2752,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E100.png"
     },
     {
         "name": "Petit Kazuma",
@@ -2778,7 +2778,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E101.png"
     },
     {
         "name": "Petit Darkness",
@@ -2807,7 +2807,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E102.png"
     },
     {
         "name": "Petit Megumin",
@@ -2834,7 +2834,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E103.png"
     },
     {
         "name": "Petit Aqua",
@@ -2860,7 +2860,7 @@
         "set": "KS",
         "release": "49",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_E104.png"
     },
     {
         "name": "“Middle of a Journey” Darkness",
@@ -2887,7 +2887,7 @@
         "set": "KS",
         "release": "49",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_PE01PR.png"
     },
     {
         "name": "“Crimson Demon With Red Eyes” Megumin",
@@ -2914,7 +2914,7 @@
         "set": "KS",
         "release": "49",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_PE03.png"
     },
     {
         "name": "“Construction Operator” Aqua",
@@ -2941,7 +2941,7 @@
         "set": "KS",
         "release": "49",
         "sid": "PE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_PE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_PE06PR.png"
     },
     {
         "name": "“Choosing A Goddess” Kazuma",
@@ -2968,7 +2968,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE01.png"
     },
     {
         "name": "“Parents' Names” Megumin",
@@ -2995,7 +2995,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE02.png"
     },
     {
         "name": "“Pride of Explosive Magic” Megumin",
@@ -3021,7 +3021,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE03.png"
     },
     {
         "name": "“Reason to Turn Down” Megumin",
@@ -3047,7 +3047,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE04.png"
     },
     {
         "name": "“Explosive Magic Ready” Megumin",
@@ -3074,7 +3074,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE05.png"
     },
     {
         "name": "“Crimson Demon Girl” Megumin",
@@ -3101,7 +3101,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE06.png"
     },
     {
         "name": "“Ultimate Attack Magic” Megumin",
@@ -3129,7 +3129,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE07.png"
     },
     {
         "name": "“Ostracized Forbidden Power” Megumin",
@@ -3157,7 +3157,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE08.png"
     },
     {
         "name": "My Name is Megumin",
@@ -3186,7 +3186,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE09.png"
     },
     {
         "name": "Explosion",
@@ -3215,7 +3215,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE10.png"
     },
     {
         "name": "Kill Quest Start!",
@@ -3244,7 +3244,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE11.png"
     },
     {
         "name": "“Urgent Ally Recruitment!” Aqua",
@@ -3271,7 +3271,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE12.png"
     },
     {
         "name": "“How It Works in Worlds Like This” Aqua",
@@ -3298,7 +3298,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE13.png"
     },
     {
         "name": "“Carefree Moodmaker” Aqua",
@@ -3324,7 +3324,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE14.png"
     },
     {
         "name": "“Forced Entrainment” Aqua",
@@ -3350,7 +3350,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE15.png"
     },
     {
         "name": "“Heaven is A Dreamy Place?” Aqua",
@@ -3378,7 +3378,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE16.png"
     },
     {
         "name": "“Pride of A Goddess” Aqua",
@@ -3407,7 +3407,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE17.png"
     },
     {
         "name": "“Goddess Who Governs Water” Aqua",
@@ -3436,7 +3436,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE18.png"
     },
     {
         "name": "Sympathy of Eris Sect",
@@ -3462,7 +3462,7 @@
         "set": "KS",
         "release": "49",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE19.png"
     },
     {
         "name": "Bonus From Crossing Parallel Worlds",
@@ -3491,6 +3491,6 @@
         "set": "KS",
         "release": "49",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_KS_W49_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w49/KS_W49_TE20.png"
     }
 ]

--- a/DB/KS_W76.json
+++ b/DB/KS_W76.json
@@ -24,7 +24,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E001.png"
     },
     {
         "name": "\"Musclebrained Crusader\" Darkness",
@@ -54,7 +54,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E002.png"
     },
     {
         "name": "\"A Break in the Forest\" Darkness",
@@ -81,7 +81,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E003.png"
     },
     {
         "name": "\"Beauty in a Yukata\" Darkness",
@@ -108,7 +108,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E004.png"
     },
     {
         "name": "\"Important Friend\" Kazuma",
@@ -135,7 +135,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E005.png"
     },
     {
         "name": "\"Shivering from Disparagement\" Darkness",
@@ -162,7 +162,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E006.png"
     },
     {
         "name": "\"Fireworks Display\" Kazuma",
@@ -190,7 +190,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E007.png"
     },
     {
         "name": "\"Fierce Battle\" Vanir",
@@ -219,7 +219,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E008.png"
     },
     {
         "name": "\"My Popular Phase is Here!\" Kazuma",
@@ -248,7 +248,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E009.png"
     },
     {
         "name": "\"S-Rank Luck\" Kazuma",
@@ -275,7 +275,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E010.png"
     },
     {
         "name": "\"Dumbfounded\" Darkness",
@@ -302,7 +302,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E011.png"
     },
     {
         "name": "\"Sightseeing in the Crimson Demon Village!\" Darkness",
@@ -329,7 +329,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E012.png"
     },
     {
         "name": "\"Straightforward Confession\" Kazuma",
@@ -356,7 +356,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E013.png"
     },
     {
         "name": "\"Welcome\" Vanir",
@@ -383,7 +383,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E014.png"
     },
     {
         "name": "\"Sought-After Paradise\" Kazuma",
@@ -412,7 +412,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E015.png"
     },
     {
         "name": "\"Blocking the Way\" Darkness",
@@ -439,7 +439,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E016.png"
     },
     {
         "name": "\"To the Crimson Demon Village!\" Kazuma",
@@ -466,7 +466,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E017.png"
     },
     {
         "name": "\"Mind-Reading Demon\" Vanir",
@@ -492,7 +492,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E018.png"
     },
     {
         "name": "\"Vigorous Assertion\" Kazuma",
@@ -518,7 +518,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E019.png"
     },
     {
         "name": "\"Scope Set!\" Kazuma",
@@ -544,7 +544,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E020.png"
     },
     {
         "name": "\"Bold Bluff\" Kazuma",
@@ -571,7 +571,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E021.png"
     },
     {
         "name": "\"Sole Redeeming Feature\" Darkness",
@@ -598,7 +598,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E022.png"
     },
     {
         "name": "\"To the Crimson Demon Village!\" Darkness",
@@ -624,7 +624,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E023.png"
     },
     {
         "name": "Up Up Down Down Left Right Left Right! There you go!",
@@ -653,7 +653,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E024.png"
     },
     {
         "name": "M-My Defensive Strength?",
@@ -682,7 +682,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E025.png"
     },
     {
         "name": "Orc Invasion!",
@@ -712,7 +712,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E026.png"
     },
     {
         "name": "Thumbs Up!",
@@ -741,7 +741,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E027.png"
     },
     {
         "name": "\"Faith in Comrades\" Yunyun",
@@ -768,7 +768,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E028.png"
     },
     {
         "name": "\"To the Crimson Demon Village!\" Megumin & Yunyun",
@@ -795,7 +795,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E029.png"
     },
     {
         "name": "\"To the Crimson Demon Village!\" Wiz",
@@ -822,7 +822,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E030.png"
     },
     {
         "name": "\"Sentiments Toward Explosion Magic\" Megumin",
@@ -849,7 +849,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E031.png"
     },
     {
         "name": "\"Greatest Mage\" Yunyun",
@@ -879,7 +879,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E032.png"
     },
     {
         "name": "\"Foremost Mage\" Megumin",
@@ -908,7 +908,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E033.png"
     },
     {
         "name": "\"Watching Over Gently\" Yunyun",
@@ -935,7 +935,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E034.png"
     },
     {
         "name": "\"Master of Explosion Magic Someday\" Megumin",
@@ -961,7 +961,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E035.png"
     },
     {
         "name": "\"Shy\" Yunyun",
@@ -987,7 +987,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E036.png"
     },
     {
         "name": "\"Chewing\" Komekko",
@@ -1015,7 +1015,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E037.png"
     },
     {
         "name": "\"Against the Mage Killer\" Wiz",
@@ -1042,7 +1042,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E038.png"
     },
     {
         "name": "\"When Push Comes to Shove\" Megumin",
@@ -1071,7 +1071,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E039.png"
     },
     {
         "name": "\"Embarassed Laugh\" Megumin",
@@ -1100,7 +1100,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E040.png"
     },
     {
         "name": "\"Reunited After a Long Time\" Wiz",
@@ -1129,7 +1129,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E041.png"
     },
     {
         "name": "\"Signature Statement\" Yunyun",
@@ -1158,7 +1158,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E042.png"
     },
     {
         "name": "\"Convenient Transportation Magic\" Wiz",
@@ -1187,7 +1187,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E043.png"
     },
     {
         "name": "\"Breaking Out in Cold Sweat\" Yunyun",
@@ -1214,7 +1214,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E044.png"
     },
     {
         "name": "\"I Am Called\" Funifura",
@@ -1241,7 +1241,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E045.png"
     },
     {
         "name": "\"Sightseeing in the Crimson Demon Village!\" Megumin",
@@ -1267,7 +1267,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E046.png"
     },
     {
         "name": "\"Expert Self-Introduction\" Crimson Demon",
@@ -1294,7 +1294,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E047a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E047a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E047a.png"
     },
     {
         "name": "\"Loading Up with Magic Power\" Wiz",
@@ -1320,7 +1320,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E048.png"
     },
     {
         "name": "\"Unreasonable Demand\" Megumin",
@@ -1347,7 +1347,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E049.png"
     },
     {
         "name": "\"Unyielding Spirit of Rivalry\" Megumin",
@@ -1373,7 +1373,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E050.png"
     },
     {
         "name": "\"Fierce Battle\" Wiz",
@@ -1400,7 +1400,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E051.png"
     },
     {
         "name": "\"Important Friend\" Megumin",
@@ -1427,7 +1427,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E052.png"
     },
     {
         "name": "\"Party Member?\" Yunyun",
@@ -1454,7 +1454,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E053.png"
     },
     {
         "name": "\"Supportive Cover\" Yuiyui",
@@ -1483,7 +1483,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E054.png"
     },
     {
         "name": "\"Receiving Guests\" Komekko",
@@ -1511,7 +1511,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E055.png"
     },
     {
         "name": "\"Today's Explosion Magic\" Megumin",
@@ -1540,7 +1540,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E056.png"
     },
     {
         "name": "\"Beauty in a Yukata\" Megumin",
@@ -1567,7 +1567,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E057.png"
     },
     {
         "name": "Megumin & Komekko",
@@ -1594,7 +1594,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E058.png"
     },
     {
         "name": "Hyoizaburo & Yuiyui",
@@ -1621,7 +1621,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E059.png"
     },
     {
         "name": "\"I Am Called\" Arue",
@@ -1648,7 +1648,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E060.png"
     },
     {
         "name": "\"I Am Called\" Dodonko",
@@ -1675,7 +1675,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E061.png"
     },
     {
         "name": "\"Freezing Magic\" Wiz",
@@ -1702,7 +1702,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E062.png"
     },
     {
         "name": "\"Extreme Misunderstanding\" Yunyun",
@@ -1728,7 +1728,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E063.png"
     },
     {
         "name": "\"Devious Younger Sister\" Komekko",
@@ -1754,7 +1754,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E064.png"
     },
     {
         "name": "\"Do-or-Die Confession\" Yunyun",
@@ -1781,7 +1781,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E065.png"
     },
     {
         "name": "\"Confrontation on the Cliff\" Yunyun",
@@ -1810,7 +1810,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E066.png"
     },
     {
         "name": "\"Suggestive\" Megumin",
@@ -1839,7 +1839,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E067.png"
     },
     {
         "name": "\"Beauty in a Yukata\" Yunyun",
@@ -1868,7 +1868,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E068.png"
     },
     {
         "name": "\"Overflowing Magic Power\" Yunyun",
@@ -1897,7 +1897,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E069.png"
     },
     {
         "name": "Forbidden Weapon",
@@ -1924,7 +1924,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E070.png"
     },
     {
         "name": "Teasing",
@@ -1953,7 +1953,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E071.png"
     },
     {
         "name": "Linked Palms",
@@ -1982,7 +1982,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E072.png"
     },
     {
         "name": "Clap of Thunder",
@@ -2011,7 +2011,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E073.png"
     },
     {
         "name": "Homecoming and Welcome Greetings",
@@ -2040,7 +2040,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E074.png"
     },
     {
         "name": "An Explosion A Day",
@@ -2069,7 +2069,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E075.png"
     },
     {
         "name": "\"Giving Full Support\" Aqua",
@@ -2096,7 +2096,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E076.png"
     },
     {
         "name": "\"To the Crimson Demon Village!\" Aqua",
@@ -2126,7 +2126,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E077.png"
     },
     {
         "name": "\"Occasionally Goddess-Like\" Aqua",
@@ -2153,7 +2153,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E078.png"
     },
     {
         "name": "\"Sightseeing in the Crimson Demon Village!\" Aqua",
@@ -2180,7 +2180,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E079.png"
     },
     {
         "name": "\"Result of Synthesis and Modification\" Sylvia",
@@ -2208,7 +2208,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E080.png"
     },
     {
         "name": "\"Required Quality of Adventurer Life\" Aqua",
@@ -2234,7 +2234,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E081.png"
     },
     {
         "name": "\"Synthesis With the Mage Killer\" Sylvia",
@@ -2263,7 +2263,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E082.png"
     },
     {
         "name": "\"Cunning Idea\" Aqua",
@@ -2290,7 +2290,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E083.png"
     },
     {
         "name": "\"Women and Men's Feelings\" Sylvia",
@@ -2317,7 +2317,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E084.png"
     },
     {
         "name": "\"Devil King Army General\" Sylvia",
@@ -2344,7 +2344,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E085.png"
     },
     {
         "name": "\"Supportive Magic\" Aqua",
@@ -2373,7 +2373,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E086.png"
     },
     {
         "name": "\"Droopy Temptation\" Sylvia",
@@ -2404,7 +2404,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E087.png"
     },
     {
         "name": "\"Beauty in a Yukata\" Aqua",
@@ -2431,7 +2431,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E088.png"
     },
     {
         "name": "\"Surprise Blow\" Aqua",
@@ -2458,7 +2458,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E089.png"
     },
     {
         "name": "\"Chasing Down\" Sylvia",
@@ -2485,7 +2485,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E090.png"
     },
     {
         "name": "\"Composed Retreat\" Sylvia",
@@ -2512,7 +2512,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E091.png"
     },
     {
         "name": "\"Close to Tears\" Aqua",
@@ -2539,7 +2539,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E092.png"
     },
     {
         "name": "\"Burn to Nothingness\" Sylvia",
@@ -2569,7 +2569,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E093.png"
     },
     {
         "name": "\"Menacing Pose\" Aqua",
@@ -2598,7 +2598,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E094.png"
     },
     {
         "name": "\"Discerning Eyes\" Sylvia",
@@ -2626,7 +2626,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E095.png"
     },
     {
         "name": "Devil King Army Invades!",
@@ -2652,7 +2652,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E096.png"
     },
     {
         "name": "Protection of a Goddess",
@@ -2682,7 +2682,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E097.png"
     },
     {
         "name": "Quest Failed",
@@ -2711,7 +2711,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E098.png"
     },
     {
         "name": "Invasion of the Crimson Demon Village",
@@ -2741,7 +2741,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E099.png"
     },
     {
         "name": "Because Something Is!",
@@ -2770,7 +2770,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E100.png"
     },
     {
         "name": "\"A Knight's Duty\" Darkness",
@@ -2797,7 +2797,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E101.png"
     },
     {
         "name": "\"Mattress at Home\" Megumin",
@@ -2824,7 +2824,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E102.png"
     },
     {
         "name": "\"Appearance of the Main Star\" Yunyun",
@@ -2853,7 +2853,7 @@
         "set": "KS",
         "release": "76",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E103.png"
     },
     {
         "name": "\"Magical Academy Field Trip\" Aqua",
@@ -2881,6 +2881,6 @@
         "set": "KS",
         "release": "76",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/KS_W76_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/k/ks_w76/KS_W76_E104.png"
     }
 ]

--- a/DB/LH_SE20.json
+++ b/DB/LH_SE20.json
@@ -23,7 +23,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E01RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E01.png"
     },
     {
         "name": "Assassin, Akatsuki",
@@ -49,7 +49,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E02RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E02.png"
     },
     {
         "name": "Lord's Ninja, Akatsuki",
@@ -77,7 +77,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E03RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E03.png"
     },
     {
         "name": "Crescent Moon Alliance, Serara",
@@ -103,7 +103,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E04R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E04.png"
     },
     {
         "name": "Isuzu",
@@ -129,7 +129,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E05R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E05.png"
     },
     {
         "name": "Dislikes Fashion? Akatsuki",
@@ -155,7 +155,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E06R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E06.png"
     },
     {
         "name": "Adventurer, Rundellhaus",
@@ -181,7 +181,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E07R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E07.png"
     },
     {
         "name": "Serara",
@@ -209,7 +209,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E08R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E08.png"
     },
     {
         "name": "Maiden's Heart, Akatsuki",
@@ -237,7 +237,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E09R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E09.png"
     },
     {
         "name": "Rudy's Owner? Isuzu",
@@ -263,7 +263,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E10U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E10.png"
     },
     {
         "name": "Waltz for Two, Akatsuki",
@@ -289,7 +289,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E11U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E11.png"
     },
     {
         "name": "Henrietta",
@@ -315,7 +315,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E12U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E12.png"
     },
     {
         "name": "Reliable Accountant, Henrietta",
@@ -341,7 +341,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E13U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E13.png"
     },
     {
         "name": "Silent Worker, Akatsuki",
@@ -369,7 +369,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E14U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E14.png"
     },
     {
         "name": "Sorcerer, Rundellhaus",
@@ -397,7 +397,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E15U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E15.png"
     },
     {
         "name": "Rundellhaus",
@@ -423,7 +423,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E16C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E16.png"
     },
     {
         "name": "Loves Nyan-ta, Serara",
@@ -449,7 +449,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E17C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E17.png"
     },
     {
         "name": "Crescent Moon Shopowner, Marielle",
@@ -475,7 +475,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E18C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E18.png"
     },
     {
         "name": "Shoryu",
@@ -501,7 +501,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E19C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E19.png"
     },
     {
         "name": "Petit Akatsuki",
@@ -527,7 +527,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E20C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E20.png"
     },
     {
         "name": "Cleric, Marielle",
@@ -555,7 +555,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E21C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E21.png"
     },
     {
         "name": "Bard, Isuzu",
@@ -583,7 +583,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E22C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E22.png"
     },
     {
         "name": "Dolled Up Akatsuki",
@@ -609,7 +609,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E23C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E23.png"
     },
     {
         "name": "Waltz for Two",
@@ -637,7 +637,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E24C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E24.png"
     },
     {
         "name": "Crescent Moon Alliance",
@@ -666,7 +666,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E25C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E25.png"
     },
     {
         "name": "Nyan-ta",
@@ -694,7 +694,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E26RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E26.png"
     },
     {
         "name": "Field Monitor, Minori",
@@ -722,7 +722,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E27RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E27.png"
     },
     {
         "name": "Log Horizon's Representative, Shiroe",
@@ -750,7 +750,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E28RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E28.png"
     },
     {
         "name": "Full Control Encounter, Shiroe",
@@ -777,7 +777,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E29R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E29.png"
     },
     {
         "name": "Waltz for Two, Shiroe",
@@ -803,7 +803,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E30R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E30.png"
     },
     {
         "name": "Log Horizon, Nyan-ta",
@@ -829,7 +829,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E31R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E31.png"
     },
     {
         "name": "Determination to Change the World, Shiroe",
@@ -856,7 +856,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E32R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E32.png"
     },
     {
         "name": "Reliable Buddy, Naotsugu",
@@ -882,7 +882,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E33R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E33.png"
     },
     {
         "name": "Guardian, Naotsugu",
@@ -910,7 +910,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E34R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E34.png"
     },
     {
         "name": "Guildmaster, Shiroe",
@@ -936,7 +936,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E35U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E35.png"
     },
     {
         "name": "Rayneshia",
@@ -962,7 +962,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E36U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E36.png"
     },
     {
         "name": "Sojiro",
@@ -988,7 +988,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E37",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E37U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E37.png"
     },
     {
         "name": "Everyone's Group Leader, Nyan-ta",
@@ -1014,7 +1014,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E38",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E38U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E38.png"
     },
     {
         "name": "Krusty",
@@ -1040,7 +1040,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E39",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E39U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E39.png"
     },
     {
         "name": "Minori",
@@ -1068,7 +1068,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E40",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E40U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E40.png"
     },
     {
         "name": "Maiden's Heart, Minori",
@@ -1094,7 +1094,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E41",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E41C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E41.png"
     },
     {
         "name": "Petit Naotsugu",
@@ -1120,7 +1120,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E42",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E42C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E42.png"
     },
     {
         "name": "Samurai, Toya",
@@ -1146,7 +1146,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E43",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E43C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E43.png"
     },
     {
         "name": "Toya",
@@ -1172,7 +1172,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E44",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E44C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E44.png"
     },
     {
         "name": "Petit Shiroe",
@@ -1200,7 +1200,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E45",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E45C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E45.png"
     },
     {
         "name": "Scribe, Shiroe",
@@ -1228,7 +1228,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E46",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E46C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E46.png"
     },
     {
         "name": "Isaac",
@@ -1256,7 +1256,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E47",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E47C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E47.png"
     },
     {
         "name": "Mind Shock",
@@ -1282,7 +1282,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E48",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E48C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E48.png"
     },
     {
         "name": "Log Horizon",
@@ -1312,7 +1312,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E49",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E49C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E49.png"
     },
     {
         "name": "Simplified Full Control Encounter",
@@ -1341,7 +1341,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "E50",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_E50C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_E50.png"
     },
     {
         "name": "Holding Hands, Akatsuki",
@@ -1450,7 +1450,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE01TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE01.png"
     },
     {
         "name": "Akatsuki",
@@ -1476,7 +1476,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE02TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE02.png"
     },
     {
         "name": "Marielle Using Telepathy",
@@ -1502,7 +1502,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE03TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE03.png"
     },
     {
         "name": "Revealed Beauty, Akatsuki",
@@ -1528,7 +1528,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE04TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE04.png"
     },
     {
         "name": "Embarassed Akatsuki",
@@ -1554,7 +1554,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE05TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE05.png"
     },
     {
         "name": "Crescent Moon Alliance Accountant, Henrietta",
@@ -1582,7 +1582,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE06TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE06.png"
     },
     {
         "name": "Crescent Moon Alliance Representative, Marielle",
@@ -1611,7 +1611,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE07TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE07.png"
     },
     {
         "name": "Furious Akatsuki",
@@ -1639,7 +1639,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE08TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE08.png"
     },
     {
         "name": "Assassination",
@@ -1668,7 +1668,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE09TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE09.png"
     },
     {
         "name": "Chef, Nyan-ta",
@@ -1694,7 +1694,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE10TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE10.png"
     },
     {
         "name": "Shiroe Riding a Gryphon",
@@ -1720,7 +1720,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE11TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE11.png"
     },
     {
         "name": "Swashbuckler, Nyan-ta",
@@ -1746,7 +1746,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE12TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE12.png"
     },
     {
         "name": "First Battle, Naotsugu",
@@ -1772,7 +1772,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE13TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE13.png"
     },
     {
         "name": "Composed Expression, Shiroe",
@@ -1798,7 +1798,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE14TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE14.png"
     },
     {
         "name": "Shiroe",
@@ -1826,7 +1826,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE15TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE15.png"
     },
     {
         "name": "Naotsugu",
@@ -1854,7 +1854,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE16TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE16.png"
     },
     {
         "name": "Enchanter, Shiroe",
@@ -1883,7 +1883,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE17TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE17.png"
     },
     {
         "name": "Enchanter's Support",
@@ -1909,7 +1909,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE18TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE18.png"
     },
     {
         "name": "Sophisticated Cooperation",
@@ -1938,7 +1938,7 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE19TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE19.png"
     },
     {
         "name": "First Spoils of Victory",
@@ -1967,6 +1967,6 @@
         "set": "LH",
         "release": "E20",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LH_SE20_TE20TD.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lh_se20/LH_SE20_TE20.png"
     }
 ]

--- a/DB/LL2_W34.json
+++ b/DB/LL2_W34.json
@@ -24,7 +24,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E001RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E001.png"
     },
     {
         "name": "\"Happy Maker!\" Nico Yazawa",
@@ -51,7 +51,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E002RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E002.png"
     },
     {
         "name": "\"Happy Maker!\" Nozomi Tojo",
@@ -78,7 +78,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E003RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E003.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Nozomi Tojo",
@@ -105,7 +105,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E004Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E004.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Eli Ayase",
@@ -132,7 +132,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E005Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E005.png"
     },
     {
         "name": "\"Forever and Ever\" Nico Yazawa",
@@ -159,7 +159,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E006Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E006.png"
     },
     {
         "name": "\"Forever and Ever\" Nozomi Tojo",
@@ -186,7 +186,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E007Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E007.png"
     },
     {
         "name": "\"Forever and Ever\"Eli Ayase",
@@ -211,7 +211,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E008Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E008.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Nico Yazawa",
@@ -236,7 +236,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E009Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E009.png"
     },
     {
         "name": "Real?Showdown, Nico",
@@ -264,7 +264,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E010Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E010.png"
     },
     {
         "name": "\"Door to Our Dreams\"Eli Ayase",
@@ -291,7 +291,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E011Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E011.png"
     },
     {
         "name": "Frozen Nico",
@@ -317,7 +317,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E012Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E012.png"
     },
     {
         "name": "Forestalling, Eli",
@@ -343,7 +343,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E013Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E013.png"
     },
     {
         "name": "Tea Time, Nozomi",
@@ -369,7 +369,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E014Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E014.png"
     },
     {
         "name": "\"The Glass Garden\" Nozomi Tojo",
@@ -395,7 +395,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E015Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E015.png"
     },
     {
         "name": "Cocoro Yazawa",
@@ -420,7 +420,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E016Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E016.png"
     },
     {
         "name": "\"Snow Halation\" Nico Yazawa",
@@ -445,7 +445,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E017Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E017.png"
     },
     {
         "name": "\"Door to Our Dreams\" Nozomi Tojo",
@@ -470,7 +470,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E018Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E018.png"
     },
     {
         "name": "\"Snow Halation\" Eli Ayase",
@@ -495,7 +495,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E019Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E019.png"
     },
     {
         "name": "\"Snow Halation\" Nozomi Tojo",
@@ -520,7 +520,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E020Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E020.png"
     },
     {
         "name": "\"Door to Our Dreams\" Nico Yazawa",
@@ -547,7 +547,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E021Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E021.png"
     },
     {
         "name": "\"Nico Pri Way of the Maiden\" Nico Yazawa",
@@ -572,7 +572,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E022Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E022.png"
     },
     {
         "name": "μ's Backup Dancer? Eli",
@@ -598,7 +598,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E023Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E023.png"
     },
     {
         "name": "Full of Smiles, Nozomi",
@@ -624,7 +624,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E024Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E024.png"
     },
     {
         "name": "Innocent Arisa",
@@ -649,7 +649,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E025Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E025.png"
     },
     {
         "name": "\"The Glass Garden\"Eli Ayase",
@@ -674,7 +674,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E026Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E026.png"
     },
     {
         "name": "The Moment Now is the Best",
@@ -699,7 +699,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E027Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E027.png"
     },
     {
         "name": "Super Idol Nico",
@@ -724,7 +724,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E028Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E028.png"
     },
     {
         "name": "The Morning of Graduation",
@@ -749,7 +749,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E029Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E029.png"
     },
     {
         "name": "Important Friends",
@@ -777,7 +777,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E030CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E030.png"
     },
     {
         "name": "Looking Back at Memories",
@@ -805,7 +805,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E031CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E031.png"
     },
     {
         "name": "When These 9 People are Around",
@@ -833,7 +833,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E032CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E032.png"
     },
     {
         "name": "Unfulfilled Wishes",
@@ -861,7 +861,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E033CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E033.png"
     },
     {
         "name": "\"Happy Maker!\" Honoka Kosaka",
@@ -888,7 +888,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E034RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E034.png"
     },
     {
         "name": "\"Happy Maker!\" Kotori Minami",
@@ -916,7 +916,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E035RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E035.png"
     },
     {
         "name": "\"Happy Maker!\" Umi Sonoda",
@@ -943,7 +943,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E036RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E036.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Umi Sonoda",
@@ -970,7 +970,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E037Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E037.png"
     },
     {
         "name": "\"Forever and Ever\" Umi Sonoda",
@@ -997,7 +997,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E038Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E038.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Honoka Kosaka",
@@ -1024,7 +1024,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E039Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E039.png"
     },
     {
         "name": "\"Forever and Ever\" Kotori Minami",
@@ -1049,7 +1049,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E040Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E040.png"
     },
     {
         "name": "\"Door to Our Dreams\" Umi Sonoda",
@@ -1076,7 +1076,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E041Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E041.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Kotori Minami",
@@ -1101,7 +1101,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E042Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E042.png"
     },
     {
         "name": "\"Forever and Ever\" Honoka Kosaka",
@@ -1127,7 +1127,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E043Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E043.png"
     },
     {
         "name": "In a Slump, Kotori",
@@ -1154,7 +1154,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E044Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E044.png"
     },
     {
         "name": "Image Change, Honoka",
@@ -1182,7 +1182,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E045Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E045.png"
     },
     {
         "name": "\"Door to Our Dreams\" Kotori Minami",
@@ -1209,7 +1209,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E046Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E046.png"
     },
     {
         "name": "Reawakened Memories, Honoka",
@@ -1235,7 +1235,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E047Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E047.png"
     },
     {
         "name": "Gentle Smile, Umi",
@@ -1261,7 +1261,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E048Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E048.png"
     },
     {
         "name": "Sightseeing, Umi",
@@ -1287,7 +1287,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E049Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E049.png"
     },
     {
         "name": "\"Snow Halation\" Honoka Kosaka",
@@ -1312,7 +1312,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E050Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E050.png"
     },
     {
         "name": "\"Snow Halation\" Kotori Minami",
@@ -1337,7 +1337,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E051Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E051.png"
     },
     {
         "name": "\"Snow Halation\" Umi Sonoda",
@@ -1362,7 +1362,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E052Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E052.png"
     },
     {
         "name": "Invitation to School, Erena",
@@ -1387,7 +1387,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E053Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E053.png"
     },
     {
         "name": "Invitation to School, Anju",
@@ -1412,7 +1412,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E054Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E054.png"
     },
     {
         "name": "\"Anemone Heart\" Umi Sonada",
@@ -1437,7 +1437,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E055Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E055.png"
     },
     {
         "name": "Invitation to School, Tsubasa",
@@ -1462,7 +1462,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E056Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E056.png"
     },
     {
         "name": "\"Door to Our Dreams\" Honoka Kosaka",
@@ -1487,7 +1487,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E057Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E057.png"
     },
     {
         "name": "Startling Fact, Honoka",
@@ -1513,7 +1513,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E058Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E058.png"
     },
     {
         "name": "Image Change, Kotori",
@@ -1539,7 +1539,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E059Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E059.png"
     },
     {
         "name": "Forceful Fact, Yukiho",
@@ -1564,7 +1564,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E060Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E060.png"
     },
     {
         "name": "Unwavering Feelings, Kotori",
@@ -1590,7 +1590,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E061Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E061.png"
     },
     {
         "name": "Desperate Emotions",
@@ -1615,7 +1615,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E062Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E062.png"
     },
     {
         "name": "Unexpected Failure",
@@ -1640,7 +1640,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E063Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E063.png"
     },
     {
         "name": "Keep Up Your Fighting Spirit!",
@@ -1665,7 +1665,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E064Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E064.png"
     },
     {
         "name": "Nap Time Umi",
@@ -1693,7 +1693,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E065CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E065.png"
     },
     {
         "name": "Sakura Tree Facing the Blue Sky",
@@ -1721,7 +1721,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E066CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E066.png"
     },
     {
         "name": "Nap Time Kotori",
@@ -1749,7 +1749,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E067CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E067.png"
     },
     {
         "name": "Memory That We are All Here at This Very Moment",
@@ -1777,7 +1777,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E068CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E068.png"
     },
     {
         "name": "\"Happy Maker!\" Rin Hoshizora",
@@ -1804,7 +1804,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E069RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E069.png"
     },
     {
         "name": "\"Happy Maker!\" Maki Nishikino",
@@ -1831,7 +1831,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E070RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E070.png"
     },
     {
         "name": "\"Happy Maker!\" Hanayo Koizumi",
@@ -1858,7 +1858,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E071RRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E071.png"
     },
     {
         "name": "\"Forever and Ever\" Rin Hoshizora",
@@ -1885,7 +1885,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E072Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E072.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Hanayo Koizumi",
@@ -1912,7 +1912,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E073Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E073.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation! \"Maki Nishikino",
@@ -1937,7 +1937,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E074Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E074.png"
     },
     {
         "name": "\"Jump Rope\" Hanayo Koizumi",
@@ -1962,7 +1962,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E075Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E075.png"
     },
     {
         "name": "\"Forever and Ever\" Hanaya Koizumi",
@@ -1987,7 +1987,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E076Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E076.png"
     },
     {
         "name": "\"Forever and Ever\" Maki Nishikino",
@@ -2012,7 +2012,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E077Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E077.png"
     },
     {
         "name": "\"KiRa-KiRa Sensation!\" Rin Hoshizora",
@@ -2037,7 +2037,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E078Ro.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E078.png"
     },
     {
         "name": "\"Snow Halation\" Hanayo Koizumi",
@@ -2064,7 +2064,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E079Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E079.png"
     },
     {
         "name": "With Everyone's Strength, Rin",
@@ -2092,7 +2092,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E080Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E080.png"
     },
     {
         "name": "\"Door to Our Dreams\" Rin Hoshizora",
@@ -2118,7 +2118,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E081Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E081.png"
     },
     {
         "name": "\"Door to Our Dreams\" Hanayo Koizumi",
@@ -2143,7 +2143,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E082Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E082.png"
     },
     {
         "name": "Food Supplies Before the Live, Maki",
@@ -2171,7 +2171,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E083Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E083.png"
     },
     {
         "name": "\"Door to Our Dreams\" Maki Nishikino",
@@ -2196,7 +2196,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E084Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E084.png"
     },
     {
         "name": "\"Snow Halation\" Maki Nishikino",
@@ -2223,7 +2223,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E085Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E085.png"
     },
     {
         "name": "Dressed Up, Maki",
@@ -2251,7 +2251,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E086Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E086.png"
     },
     {
         "name": "\"Snow Halation\" Rin Hoshizora",
@@ -2276,7 +2276,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E087Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E087.png"
     },
     {
         "name": "Huge Riceball, Hanayo",
@@ -2302,7 +2302,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E088Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E088.png"
     },
     {
         "name": "Present for You, Maki",
@@ -2328,7 +2328,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E089Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E089.png"
     },
     {
         "name": "\"Beat in Angel\" Rin Hoshizora",
@@ -2353,7 +2353,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E090Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E090.png"
     },
     {
         "name": "Memories of Live, Rin",
@@ -2379,7 +2379,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E091Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E091.png"
     },
     {
         "name": "Alpaca",
@@ -2404,7 +2404,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E092Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E092.png"
     },
     {
         "name": "Memories of Live, Hanayo",
@@ -2430,7 +2430,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E093Co.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E093.png"
     },
     {
         "name": "\"Love Wing Bell\"",
@@ -2455,7 +2455,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E094Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E094.png"
     },
     {
         "name": "Invitation from Friends",
@@ -2480,7 +2480,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E095Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E095.png"
     },
     {
         "name": "Golden Rice Temptation",
@@ -2505,7 +2505,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E096Uo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E096.png"
     },
     {
         "name": "Full of Energy Guts Pose",
@@ -2534,7 +2534,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E097CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E097.png"
     },
     {
         "name": "Nap Time Maki",
@@ -2562,7 +2562,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E098CRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E098.png"
     },
     {
         "name": "The Answer That Everyone Decided",
@@ -2590,7 +2590,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E099CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E099.png"
     },
     {
         "name": "☆New Club Leader Arises☆",
@@ -2618,7 +2618,7 @@
         "set": "LL",
         "release": "34",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_E100CCo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_E100.png"
     },
     {
         "name": "“Dancing stars on me!” Eli Ayase",
@@ -2929,7 +2929,7 @@
         "set": "LL",
         "release": "34",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W34_PE03PRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w34/LL_W34_PE03.png"
     },
     {
         "name": "\"Summer Uniform\" Maki Nishikino",
@@ -2954,7 +2954,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE01TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE01.png"
     },
     {
         "name": "\"Summer Uniform\" Kotori Minami",
@@ -2979,7 +2979,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE02TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE02.png"
     },
     {
         "name": "\"Summer Glances☆\" Nico Yazawa",
@@ -3005,7 +3005,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE03TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE03.png"
     },
     {
         "name": "\"Treasured Things\" μ's",
@@ -3030,7 +3030,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE04TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE04.png"
     },
     {
         "name": "\"Summer Uniform\" Honoka Kosaka",
@@ -3055,7 +3055,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE05TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE05.png"
     },
     {
         "name": "\"Summer Uniform\" Nozomi Tojo",
@@ -3080,7 +3080,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE06TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE06.png"
     },
     {
         "name": "\"Summer Uniform\" Umi Sonoda",
@@ -3105,7 +3105,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE07TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE07.png"
     },
     {
         "name": "\"Summer Uniform\" Hanayo Koizumi",
@@ -3130,7 +3130,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE08TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE08.png"
     },
     {
         "name": "\"Summer Uniform\" Eli Ayase",
@@ -3155,7 +3155,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE09TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE09.png"
     },
     {
         "name": "“Lovely Marine Girl” Kotori Minami",
@@ -3181,7 +3181,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE10TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE10.png"
     },
     {
         "name": "“Fruit of Summer☆” Nozomi Tojo",
@@ -3207,7 +3207,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE11TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE11.png"
     },
     {
         "name": "“Queen of the Shore” Hanayo Koizumi",
@@ -3235,7 +3235,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE12TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE12.png"
     },
     {
         "name": "“Summer Uniform” Rin Hoshizora",
@@ -3260,7 +3260,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE13TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE13.png"
     },
     {
         "name": "“Today is Umi's Day??”Umi Sonoda",
@@ -3289,7 +3289,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE14TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE14.png"
     },
     {
         "name": "“Bewitching Mermaid” Eli Ayase",
@@ -3318,7 +3318,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE15TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE15.png"
     },
     {
         "name": "“Singing by the Shore” Maki Nishikino",
@@ -3347,7 +3347,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE16TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE16.png"
     },
     {
         "name": "“Summer Sunset Girl” Rin Hoshizora",
@@ -3375,7 +3375,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE17TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE17.png"
     },
     {
         "name": "“Summer Uniform” Nico Yazawa",
@@ -3402,7 +3402,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE18TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE18.png"
     },
     {
         "name": "“Sun on the Seashore” Honoka Kosaka",
@@ -3430,7 +3430,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE19TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE19.png"
     },
     {
         "name": "Valentime's Day",
@@ -3455,7 +3455,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE20TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE20.png"
     },
     {
         "name": "Shout Out to You",
@@ -3484,7 +3484,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE21TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE21.png"
     },
     {
         "name": "Winning Smile",
@@ -3513,7 +3513,7 @@
         "set": "LL",
         "release": "36",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE22TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE22.png"
     },
     {
         "name": "Thank you for your hard work!",
@@ -3541,6 +3541,6 @@
         "set": "LL",
         "release": "36",
         "sid": "TE23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W36_TE23TDo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w36/LL_W36_TE23.png"
     }
 ]

--- a/DB/LLDX2_W02.json
+++ b/DB/LLDX2_W02.json
@@ -24,7 +24,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E001.png"
     },
     {
         "name": "Tea Time, Kotori & Hanayo",
@@ -50,7 +50,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E002.png"
     },
     {
         "name": "Leader of μ's, Honoka",
@@ -76,7 +76,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E003.png"
     },
     {
         "name": "“Summer Festival Date” Eli Ayase",
@@ -102,7 +102,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E004.png"
     },
     {
         "name": "“Angelic Angel” Nozomi Tojo",
@@ -128,7 +128,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E005.png"
     },
     {
         "name": "“Summer Festival Date” Nico Yazawa",
@@ -155,7 +155,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E006.png"
     },
     {
         "name": "“Angelic Angel” Eli Ayase",
@@ -184,7 +184,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E007.png"
     },
     {
         "name": "“Summer Festival Date” Nozomi Tojo",
@@ -214,7 +214,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E008.png"
     },
     {
         "name": "“We Are A Single Light” Nico Yazawa",
@@ -243,7 +243,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E009.png"
     },
     {
         "name": "“Dressed Up” Nozomi Tojo",
@@ -270,7 +270,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E010.png"
     },
     {
         "name": "“Angelic Angel” Nico Yazawa",
@@ -297,7 +297,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E011.png"
     },
     {
         "name": "“Sweets Fairy” Nozomi Tojo",
@@ -324,7 +324,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E012.png"
     },
     {
         "name": "“Sweets Fairy” Nico Yazawa",
@@ -351,7 +351,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E013.png"
     },
     {
         "name": "“Dressed Up” Eli Ayase",
@@ -377,7 +377,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E014.png"
     },
     {
         "name": "“？←Heartbeat” Eli Ayase",
@@ -404,7 +404,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E015.png"
     },
     {
         "name": "“？←Heartbeat” Nozomi Tojo",
@@ -431,7 +431,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E016.png"
     },
     {
         "name": "“Sweets Fairy” Eli Ayase",
@@ -458,7 +458,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E017.png"
     },
     {
         "name": "“Dressed Up” Nico Yazawa",
@@ -487,7 +487,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E018.png"
     },
     {
         "name": "Taking Care of Nails, Nico",
@@ -513,7 +513,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E019.png"
     },
     {
         "name": "“Apple Candy and You” Eli Ayase",
@@ -539,7 +539,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E020.png"
     },
     {
         "name": "“Great Summer Break” Nico Yazawa",
@@ -565,7 +565,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E021.png"
     },
     {
         "name": "Someday from Here On, Maki & Nico & Rin",
@@ -591,7 +591,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E022.png"
     },
     {
         "name": "Snack Time, Nozomi & Nico",
@@ -617,7 +617,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E023.png"
     },
     {
         "name": "“Christmas Date” Nico Yazawa",
@@ -643,7 +643,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E024.png"
     },
     {
         "name": "“Festival Girl” Nozomi Tojo",
@@ -673,7 +673,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E025.png"
     },
     {
         "name": "“Christmas Date” Nozomi Tojo",
@@ -702,7 +702,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E026.png"
     },
     {
         "name": "“A Present for You” Eli Ayase",
@@ -731,7 +731,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E027.png"
     },
     {
         "name": "Secret Gift",
@@ -757,7 +757,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E028.png"
     },
     {
         "name": "Happiest Girl",
@@ -783,7 +783,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E029.png"
     },
     {
         "name": "Lucky New Year",
@@ -809,7 +809,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E030.png"
     },
     {
         "name": "“Your Special Santa” Nozomi Tojo",
@@ -836,7 +836,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E031.png"
     },
     {
         "name": "“New Year's Treat” Nico Yazawa",
@@ -863,7 +863,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E032.png"
     },
     {
         "name": "“Autumn With Books” Eli Ayase",
@@ -889,7 +889,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E033.png"
     },
     {
         "name": "“Chinese Vampire” Nozomi Tojo",
@@ -916,7 +916,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E034.png"
     },
     {
         "name": "“Marching Girl” Eli Ayase",
@@ -942,7 +942,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E035.png"
     },
     {
         "name": "“Western Girl” Nico Yazawa",
@@ -968,7 +968,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E036.png"
     },
     {
         "name": "“Doll Festival” Nico Yazawa",
@@ -995,7 +995,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E037.png"
     },
     {
         "name": "Student of Otonokizaka High, Alisa",
@@ -1022,7 +1022,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E038.png"
     },
     {
         "name": "“Sunny Day Song” Eli Ayase",
@@ -1048,7 +1048,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E039.png"
     },
     {
         "name": "“Light Umbrella” Eli Ayase",
@@ -1074,7 +1074,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E040.png"
     },
     {
         "name": "“Shrine Maiden Outfit” Nozomi Tojo",
@@ -1100,7 +1100,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E041.png"
     },
     {
         "name": "“Sunny Day Song” Alisa Ayase",
@@ -1127,7 +1127,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E042.png"
     },
     {
         "name": "“Good Girl Christmas” Nico Yazawa",
@@ -1153,7 +1153,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E043.png"
     },
     {
         "name": "School Matters, Eli",
@@ -1181,7 +1181,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E044.png"
     },
     {
         "name": "“Special Stew” Eli Ayase",
@@ -1209,7 +1209,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E045.png"
     },
     {
         "name": "“Homely Idol” Nico Yazawa",
@@ -1238,7 +1238,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E046.png"
     },
     {
         "name": "“Christmas Date” Eli Ayase",
@@ -1267,7 +1267,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E047.png"
     },
     {
         "name": "“Full Course of Luck” Nozomi Tojo",
@@ -1295,7 +1295,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E048.png"
     },
     {
         "name": "“Sunny Day Song” Nico Yazawa",
@@ -1323,7 +1323,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E049.png"
     },
     {
         "name": "“Sunny Day Song” Nozomi Tojo",
@@ -1352,7 +1352,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E050.png"
     },
     {
         "name": "“Hug Attack” Nozomi Tojo",
@@ -1381,7 +1381,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E051.png"
     },
     {
         "name": "A Piece of Chocolate",
@@ -1410,7 +1410,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E052.png"
     },
     {
         "name": "Special Chocolate",
@@ -1439,7 +1439,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E053.png"
     },
     {
         "name": "We Are A Single Light",
@@ -1468,7 +1468,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E054a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E054a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E054a.png"
     },
     {
         "name": "We Are A Single Light",
@@ -1497,7 +1497,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E054b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E054b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E054b.png"
     },
     {
         "name": "We Are A Single Light",
@@ -1526,7 +1526,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E054c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E054c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E054c.png"
     },
     {
         "name": "Happy Valentine",
@@ -1555,7 +1555,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E055.png"
     },
     {
         "name": "？←Heartbeat",
@@ -1584,7 +1584,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E056.png"
     },
     {
         "name": "Angelic Angel",
@@ -1613,7 +1613,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E057.png"
     },
     {
         "name": "“We Are A Single Light” Kotori Minami",
@@ -1640,7 +1640,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E058.png"
     },
     {
         "name": "“Angelic Angel” Umi Sonoda",
@@ -1667,7 +1667,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E059.png"
     },
     {
         "name": "“Summer Festival Date” Kotori Minami",
@@ -1696,7 +1696,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E060.png"
     },
     {
         "name": "“Summer Festival Date” Honoka Kosaka",
@@ -1725,7 +1725,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E061.png"
     },
     {
         "name": "“Summer Festival Date” Umi Sonoda",
@@ -1754,7 +1754,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E062.png"
     },
     {
         "name": "“Sunny Day Song” Honoka Kosaka",
@@ -1783,7 +1783,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E063.png"
     },
     {
         "name": "“Dressed Up” Honoka Kosaka",
@@ -1810,7 +1810,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E064.png"
     },
     {
         "name": "“Sweets Fairy” Kotori Minami",
@@ -1836,7 +1836,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E065.png"
     },
     {
         "name": "“Dressed Up” Kotori Minami",
@@ -1863,7 +1863,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E066.png"
     },
     {
         "name": "“Dressed Up” Umi Sonoda",
@@ -1889,7 +1889,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E067.png"
     },
     {
         "name": "“Sweets Fairy” Umi Sonoda",
@@ -1915,7 +1915,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E068.png"
     },
     {
         "name": "“Sweets Fairy” Honoka Kosaka",
@@ -1944,7 +1944,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E069.png"
     },
     {
         "name": "“Sunny Day Song” Umi Sonoda",
@@ -1973,7 +1973,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E070.png"
     },
     {
         "name": "“Angelic Angel” Honoka Kosaka",
@@ -2002,7 +2002,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E071.png"
     },
     {
         "name": "“Angelic Angel” Kotori Minami",
@@ -2031,7 +2031,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E072.png"
     },
     {
         "name": "The First Step, Honoka",
@@ -2058,7 +2058,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E073.png"
     },
     {
         "name": "“Everyone's Festival” Honoka Kosaka",
@@ -2084,7 +2084,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E074.png"
     },
     {
         "name": "“Christmas Date” Kotori Minami",
@@ -2110,7 +2110,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E075.png"
     },
     {
         "name": "“Pure Night” Umi Sonoda",
@@ -2137,7 +2137,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E076.png"
     },
     {
         "name": "\"Lets go slowly!\" Honoka Kosaka",
@@ -2166,7 +2166,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E077.png"
     },
     {
         "name": "“Cool Evening Breeze” Kotori Minami",
@@ -2195,7 +2195,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E078.png"
     },
     {
         "name": "“Christmas Date” Umi Sonoda",
@@ -2224,7 +2224,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E079.png"
     },
     {
         "name": "“Christmas Date” Honoka Kosaka",
@@ -2253,7 +2253,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E080.png"
     },
     {
         "name": "Happy New Year☆",
@@ -2280,7 +2280,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E081.png"
     },
     {
         "name": "New Year's Dream",
@@ -2307,7 +2307,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E082.png"
     },
     {
         "name": "Yearly Greetings",
@@ -2333,7 +2333,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E083.png"
     },
     {
         "name": "Maid Outfit Umi",
@@ -2359,7 +2359,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E084.png"
     },
     {
         "name": "“Snow Lady” Umi Sonoda",
@@ -2386,7 +2386,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E085.png"
     },
     {
         "name": "“White Christmas” Kotori Minami",
@@ -2413,7 +2413,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E086.png"
     },
     {
         "name": "“Taisho Era Girl” Honoka Kosaka",
@@ -2439,7 +2439,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E087.png"
     },
     {
         "name": "“Snowy Night” Umi Sonoda",
@@ -2465,7 +2465,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E088.png"
     },
     {
         "name": "“Cotton Kimono” Umi Sonoda",
@@ -2491,7 +2491,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E089.png"
     },
     {
         "name": "“In Practice” Umi Sonoda",
@@ -2518,7 +2518,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E090.png"
     },
     {
         "name": "“Sunny Day Song” Kotori Minami",
@@ -2545,7 +2545,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E091.png"
     },
     {
         "name": "“Sunny Day Song” Yukiho Kosaka",
@@ -2572,7 +2572,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E092.png"
     },
     {
         "name": "Student of Otonokizaka High, Yukiho",
@@ -2598,7 +2598,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E093.png"
     },
     {
         "name": "“Sunny Day Song” Tsubasa Kira",
@@ -2624,7 +2624,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E094.png"
     },
     {
         "name": "“Sunny Day Song” Erena Todo",
@@ -2650,7 +2650,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E095.png"
     },
     {
         "name": "“Sunny Day Song” Anju Yuki",
@@ -2676,7 +2676,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E096.png"
     },
     {
         "name": "“Future Style” Honoka Kosaka",
@@ -2703,7 +2703,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E097.png"
     },
     {
         "name": "“Angel Nurse” Kotori Minami",
@@ -2730,7 +2730,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E098.png"
     },
     {
         "name": "“Blissful Snacks” Honoka Kosaka",
@@ -2756,7 +2756,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E099.png"
     },
     {
         "name": "“Candle Night” Honoka Kosaka",
@@ -2783,7 +2783,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E100.png"
     },
     {
         "name": "“Angel? Nurse?” Kotori Minami",
@@ -2809,7 +2809,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E101.png"
     },
     {
         "name": "“Bird Watching” Kotori Minami",
@@ -2835,7 +2835,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E102.png"
     },
     {
         "name": "“Future Style” Umi Sonoda",
@@ -2861,7 +2861,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E103.png"
     },
     {
         "name": "“Homura's Star” Honoka Kosaka",
@@ -2887,7 +2887,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E104.png"
     },
     {
         "name": "“Hiking” Honoka Kosaka",
@@ -2916,7 +2916,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E105.png"
     },
     {
         "name": "Female Singer",
@@ -2945,7 +2945,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E106.png"
     },
     {
         "name": "Swimsuit Kotori",
@@ -2973,7 +2973,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E107.png"
     },
     {
         "name": "“Thankful Feast” Umi Sonoda",
@@ -3002,7 +3002,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E108.png"
     },
     {
         "name": "“Open Wide♪” Kotori Minami",
@@ -3031,7 +3031,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E109.png"
     },
     {
         "name": "Find Your Answer",
@@ -3058,7 +3058,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E110.png"
     },
     {
         "name": "Secret Desire",
@@ -3087,7 +3087,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E111.png"
     },
     {
         "name": "We Are A Single Light",
@@ -3116,7 +3116,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E112a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E112a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E112a.png"
     },
     {
         "name": "We Are A Single Light",
@@ -3145,7 +3145,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E112b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E112b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E112b.png"
     },
     {
         "name": "We Are A Single Light",
@@ -3174,7 +3174,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E112c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E112c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E112c.png"
     },
     {
         "name": "Lots o' Animals",
@@ -3203,7 +3203,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E113.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E113.png"
     },
     {
         "name": "Sweet and Smooth♪",
@@ -3232,7 +3232,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E114.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E114.png"
     },
     {
         "name": "Future Style",
@@ -3261,7 +3261,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E115.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E115.png"
     },
     {
         "name": "Sunny Day Song",
@@ -3290,7 +3290,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E116.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E116.png"
     },
     {
         "name": "“Summer Festival Date” Maki Nishikino",
@@ -3316,7 +3316,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E117.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E117.png"
     },
     {
         "name": "“Hello, Count the Stars” Rin Hoshizora",
@@ -3343,7 +3343,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E118.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E118.png"
     },
     {
         "name": "“We Are A Single Light” Maki Nishikino",
@@ -3370,7 +3370,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E119.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E119.png"
     },
     {
         "name": "“Summer Festival Date” Rin Hoshizora",
@@ -3399,7 +3399,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E120",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E120.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E120.png"
     },
     {
         "name": "“Summer Festival Date” Hanayo Koizumi",
@@ -3428,7 +3428,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E121.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E121.png"
     },
     {
         "name": "“Angelic Angel” Hanayo Koizumi",
@@ -3458,7 +3458,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E122.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E122.png"
     },
     {
         "name": "“Sweets Fairy” Hanayo Koizumi",
@@ -3484,7 +3484,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E123.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E123.png"
     },
     {
         "name": "“Sweets Fairy” Rin Hoshizora",
@@ -3510,7 +3510,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E124",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E124.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E124.png"
     },
     {
         "name": "“Sunny Day Song” Hanayo Koizumi",
@@ -3537,7 +3537,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E125",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E125.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E125.png"
     },
     {
         "name": "“Dressed Up” Rin Hoshizora",
@@ -3563,7 +3563,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E126",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E126.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E126.png"
     },
     {
         "name": "“Angelic Angel” Maki Nishikino",
@@ -3590,7 +3590,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E127",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E127.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E127.png"
     },
     {
         "name": "“Dressed Up” Hanayo Koizumi",
@@ -3617,7 +3617,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E128",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E128.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E128.png"
     },
     {
         "name": "“Sweets Fairy” Maki Nishikino",
@@ -3645,7 +3645,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E129",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E129.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E129.png"
     },
     {
         "name": "“Angelic Angel” Rin Hoshizora",
@@ -3674,7 +3674,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E130",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E130.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E130.png"
     },
     {
         "name": "“Dressed Up” Maki Nishikino",
@@ -3703,7 +3703,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E131",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E131.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E131.png"
     },
     {
         "name": "“Secret Expression” Maki",
@@ -3730,7 +3730,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E132",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E132.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E132.png"
     },
     {
         "name": "Melody Played, Maki",
@@ -3757,7 +3757,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E133",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E133.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E133.png"
     },
     {
         "name": "In the Middle of Recording! Rin & Hanayo\nIn the Middle of Recording! Rin & Hanayo\nIn the Middle of Recording! Rin & Hanayo\nIn the Middle of Recording! Rin & Hanayo",
@@ -3783,7 +3783,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E134",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E134.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E134.png"
     },
     {
         "name": "“Christmas Date” Hanayo Koizumi",
@@ -3810,7 +3810,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E135",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E135.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E135.png"
     },
     {
         "name": "“Bon Dance!” Rin Hoshizora",
@@ -3837,7 +3837,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E136",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E136.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E136.png"
     },
     {
         "name": "“Goldfish Scooper?” Maki Nishikino",
@@ -3864,7 +3864,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E137",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E137.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E137.png"
     },
     {
         "name": "“Christmas Date” Rin Hoshizora",
@@ -3893,7 +3893,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E138",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E138.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E138.png"
     },
     {
         "name": "“Night Stall-Hopping♪” Hanayo Koizumi",
@@ -3922,7 +3922,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E139",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E139.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E139.png"
     },
     {
         "name": "“Christmas Date” Maki Nishikino",
@@ -3951,7 +3951,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E140",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E140.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E140.png"
     },
     {
         "name": "Alpaca （♀）",
@@ -3979,7 +3979,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E141",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E141.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E141.png"
     },
     {
         "name": "Finest Once a Year",
@@ -4005,7 +4005,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E142",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E142.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E142.png"
     },
     {
         "name": "Mochi is Rice Too",
@@ -4031,7 +4031,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E143",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E143.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E143.png"
     },
     {
         "name": "365 Happy Days!",
@@ -4058,7 +4058,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E144",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E144.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E144.png"
     },
     {
         "name": "“Gothic Girl” Maki Nishikino",
@@ -4085,7 +4085,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E145",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E145.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E145.png"
     },
     {
         "name": "“Princess Kaguya” Rin Hoshizora",
@@ -4112,7 +4112,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E146",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E146.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E146.png"
     },
     {
         "name": "“Elven Ties” Hanayo Koizumi",
@@ -4139,7 +4139,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E147",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E147.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E147.png"
     },
     {
         "name": "“Let's Skate Together” Hanayo Koizumi",
@@ -4166,7 +4166,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E148",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E148.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E148.png"
     },
     {
         "name": "“Christmas Carol” Maki Nishikino",
@@ -4192,7 +4192,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E149",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E149.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E149.png"
     },
     {
         "name": "“Scattering Beans” Maki Nishikino",
@@ -4219,7 +4219,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E150",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E150.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E150.png"
     },
     {
         "name": "“Sunny Day Song” Rin Hoshizora",
@@ -4245,7 +4245,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E151",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E151.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E151.png"
     },
     {
         "name": "“A Service for You♪” Maki Nishikino",
@@ -4272,7 +4272,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E152",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E152.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E152.png"
     },
     {
         "name": "“Christmas Bells” Rin Hoshizora",
@@ -4298,7 +4298,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E153",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E153.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E153.png"
     },
     {
         "name": "“Secret Recipes” Maki Nishikino",
@@ -4324,7 +4324,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E154",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E154.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E154.png"
     },
     {
         "name": "“My Christmas Treat” Hanayo Koizumi",
@@ -4350,7 +4350,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E155",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E155.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E155.png"
     },
     {
         "name": "Fluffy Alpaca",
@@ -4376,7 +4376,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E156",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E156.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E156.png"
     },
     {
         "name": "“Home-made Ramen” Rin Hoshizora",
@@ -4403,7 +4403,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E157",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E157.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E157.png"
     },
     {
         "name": "“Snow Sprite” Rin Hoshizora",
@@ -4432,7 +4432,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E158",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E158.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E158.png"
     },
     {
         "name": "“Sunny Day Song” Maki Nishikino",
@@ -4459,7 +4459,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E159",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E159.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E159.png"
     },
     {
         "name": "“View the Full Moon!” Rin Hoshizora",
@@ -4488,7 +4488,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E160",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E160.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E160.png"
     },
     {
         "name": "“Healing Menu” Hanayo Koizumi",
@@ -4517,7 +4517,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E161",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E161.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E161.png"
     },
     {
         "name": "“Clam Hunting” Hanayo Koizumi",
@@ -4545,7 +4545,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E162",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E162.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E162.png"
     },
     {
         "name": "“Hello, Count the Stars” Hanayo Koizumi",
@@ -4574,7 +4574,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E163",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E163.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E163.png"
     },
     {
         "name": "Romantic Valentine",
@@ -4604,7 +4604,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E164",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E164.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E164.png"
     },
     {
         "name": "We Are A Single Light",
@@ -4634,7 +4634,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E165a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E165a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E165a.png"
     },
     {
         "name": "We Are A Single Light",
@@ -4664,7 +4664,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E165b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E165b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E165b.png"
     },
     {
         "name": "We Are A Single Light",
@@ -4694,7 +4694,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E165c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E165c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E165c.png"
     },
     {
         "name": "Rin's Secret",
@@ -4723,7 +4723,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E166",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E166.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E166.png"
     },
     {
         "name": "Maki's Secret",
@@ -4752,7 +4752,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E167",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E167.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E167.png"
     },
     {
         "name": "Hello, Count the Stars",
@@ -4781,7 +4781,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E168",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E168.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E168.png"
     },
     {
         "name": "Time for Home Economics",
@@ -4810,7 +4810,7 @@
         "set": "LL",
         "release": "02",
         "sid": "E169",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W02_E169.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w02/LL_EN_W02_E169.png"
     },
     {
         "name": "“To An Unknown Land” Honoka Kosaka",

--- a/DB/LLDX_W01.json
+++ b/DB/LLDX_W01.json
@@ -23,7 +23,7 @@
         "set": "LL",
         "release": "01",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_001RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_001.png"
     },
     {
         "name": "\"Sun Shower\" Eli",
@@ -52,7 +52,7 @@
         "set": "LL",
         "release": "01",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_002RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_002.png"
     },
     {
         "name": "\"The Sheep's Feelings\" Kotori",
@@ -81,7 +81,7 @@
         "set": "LL",
         "release": "01",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_003RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_003.png"
     },
     {
         "name": "\"Whimsical Girl\" Rin",
@@ -110,7 +110,7 @@
         "set": "LL",
         "release": "01",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_004RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_004.png"
     },
     {
         "name": "\"No Brand Girls\" Nozomi",
@@ -139,7 +139,7 @@
         "set": "LL",
         "release": "01",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_005RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_005.png"
     },
     {
         "name": "\"Strange Sympathy\" Hanayo",
@@ -168,7 +168,7 @@
         "set": "LL",
         "release": "01",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_006RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_006.png"
     },
     {
         "name": "\"Towards a Dream\" μ's",
@@ -198,7 +198,7 @@
         "set": "LL",
         "release": "01",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_007RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_007.png"
     },
     {
         "name": "\"After-School Song Princess\" Maki",
@@ -225,7 +225,7 @@
         "set": "LL",
         "release": "01",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_008R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_008.png"
     },
     {
         "name": "\"That's Our Miracle\" Nico Yazawa",
@@ -252,7 +252,7 @@
         "set": "LL",
         "release": "01",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_009R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_009.png"
     },
     {
         "name": "\"That's Our Miracle\" Kotori Minami",
@@ -279,7 +279,7 @@
         "set": "LL",
         "release": "01",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_010R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_010.png"
     },
     {
         "name": "\"No Brand Girls\" Nico",
@@ -306,7 +306,7 @@
         "set": "LL",
         "release": "01",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_011R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_011.png"
     },
     {
         "name": "\"No Brand Girls\" Kotori",
@@ -334,7 +334,7 @@
         "set": "LL",
         "release": "01",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_012R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_012.png"
     },
     {
         "name": "\"No Brand Girls\" Umi",
@@ -360,7 +360,7 @@
         "set": "LL",
         "release": "01",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_013R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_013.png"
     },
     {
         "name": "\"No Brand Girls\" Rin",
@@ -387,7 +387,7 @@
         "set": "LL",
         "release": "01",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_014R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_014.png"
     },
     {
         "name": "\"No Brand Girls\" Maki",
@@ -413,7 +413,7 @@
         "set": "LL",
         "release": "01",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_015R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_015.png"
     },
     {
         "name": "\"That's Our Miracle\" Maki Nishikino",
@@ -439,7 +439,7 @@
         "set": "LL",
         "release": "01",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_016R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_016.png"
     },
     {
         "name": "\"That's Our Miracle\" Nozomi Tojo",
@@ -465,7 +465,7 @@
         "set": "LL",
         "release": "01",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_017R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_017.png"
     },
     {
         "name": "\"No Brand Girls\" Hanayo",
@@ -491,7 +491,7 @@
         "set": "LL",
         "release": "01",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_018R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_018.png"
     },
     {
         "name": "\"No Brand Girls\" Eli",
@@ -520,7 +520,7 @@
         "set": "LL",
         "release": "01",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_019R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_019.png"
     },
     {
         "name": "\"That's Our Miracle\" Umi Sonoda",
@@ -547,7 +547,7 @@
         "set": "LL",
         "release": "01",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_020R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_020.png"
     },
     {
         "name": "\"That's Our Miracle\" Rin Hoshizora",
@@ -576,7 +576,7 @@
         "set": "LL",
         "release": "01",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_021R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_021.png"
     },
     {
         "name": "\"No Brand Girls\" Honoka",
@@ -604,7 +604,7 @@
         "set": "LL",
         "release": "01",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_022R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_022.png"
     },
     {
         "name": "\"That's Our Miracle\" Eli Ayase",
@@ -632,7 +632,7 @@
         "set": "LL",
         "release": "01",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_023R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_023.png"
     },
     {
         "name": "\"Destiny Card\" Nozomi",
@@ -658,7 +658,7 @@
         "set": "LL",
         "release": "01",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_024U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_024.png"
     },
     {
         "name": "\"Love Bind\" Umi",
@@ -684,7 +684,7 @@
         "set": "LL",
         "release": "01",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_025U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_025.png"
     },
     {
         "name": "\"Heart of Fire\" Honoka",
@@ -710,7 +710,7 @@
         "set": "LL",
         "release": "01",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_026U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_026.png"
     },
     {
         "name": "\"Please Look at Rin♪\" Rin",
@@ -736,7 +736,7 @@
         "set": "LL",
         "release": "01",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_027U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_027.png"
     },
     {
         "name": "\"Secret Examination Room\" Maki",
@@ -762,7 +762,7 @@
         "set": "LL",
         "release": "01",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_028U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_028.png"
     },
     {
         "name": "\"Spiritual Power\" Nozomi",
@@ -788,7 +788,7 @@
         "set": "LL",
         "release": "01",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_029U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_029.png"
     },
     {
         "name": "\"Nico Is Popular\" Nico",
@@ -814,7 +814,7 @@
         "set": "LL",
         "release": "01",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_030U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_030.png"
     },
     {
         "name": "\"Goddess of Healing\" Kotori",
@@ -840,7 +840,7 @@
         "set": "LL",
         "release": "01",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_031U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_031.png"
     },
     {
         "name": "\"It's Piping Hot Rice♪\" Hanayo",
@@ -868,7 +868,7 @@
         "set": "LL",
         "release": "01",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_032U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_032.png"
     },
     {
         "name": "\"Feigning Sleep♪\" Nozomi",
@@ -896,7 +896,7 @@
         "set": "LL",
         "release": "01",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_033U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_033.png"
     },
     {
         "name": "\"I'm Gonna Eat It!\" Honoka",
@@ -924,7 +924,7 @@
         "set": "LL",
         "release": "01",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_034U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_034.png"
     },
     {
         "name": "Tsubasa Kira",
@@ -952,7 +952,7 @@
         "set": "LL",
         "release": "01",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_035U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_035.png"
     },
     {
         "name": "\"Here's the Item You Ordered♪\" Hanayo",
@@ -979,7 +979,7 @@
         "set": "LL",
         "release": "01",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_036C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_036.png"
     },
     {
         "name": "\"Nico-Nico-Ni!\" Nico",
@@ -1005,7 +1005,7 @@
         "set": "LL",
         "release": "01",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_037C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_037.png"
     },
     {
         "name": "\"Khorosho♪\" Eli",
@@ -1031,7 +1031,7 @@
         "set": "LL",
         "release": "01",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_038C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_038.png"
     },
     {
         "name": "\"Full Smile!\" Honoka",
@@ -1057,7 +1057,7 @@
         "set": "LL",
         "release": "01",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_039C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_039.png"
     },
     {
         "name": "\"All Psyched Up\" Umi",
@@ -1083,7 +1083,7 @@
         "set": "LL",
         "release": "01",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_040C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_040.png"
     },
     {
         "name": "\"That's Our Miracle\" Hanayo Koizumi",
@@ -1109,7 +1109,7 @@
         "set": "LL",
         "release": "01",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_041C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_041.png"
     },
     {
         "name": "\"I'll Teach You♪\" Nico",
@@ -1137,7 +1137,7 @@
         "set": "LL",
         "release": "01",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_042C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_042.png"
     },
     {
         "name": "\"Eli's Confession Room\" Eli",
@@ -1165,7 +1165,7 @@
         "set": "LL",
         "release": "01",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_043C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_043.png"
     },
     {
         "name": "Erena Todo",
@@ -1193,7 +1193,7 @@
         "set": "LL",
         "release": "01",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_044C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_044.png"
     },
     {
         "name": "\"Wonderful Candy\" Kotori",
@@ -1221,7 +1221,7 @@
         "set": "LL",
         "release": "01",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_045C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_045.png"
     },
     {
         "name": "Anju Yuki",
@@ -1249,7 +1249,7 @@
         "set": "LL",
         "release": "01",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_046C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_046.png"
     },
     {
         "name": "\"μ’s Energy Seal\" Rin",
@@ -1277,7 +1277,7 @@
         "set": "LL",
         "release": "01",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_047C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_047.png"
     },
     {
         "name": "\"White Rabbit of Good Fortune\" Umi",
@@ -1306,7 +1306,7 @@
         "set": "LL",
         "release": "01",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_048C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_048.png"
     },
     {
         "name": "\"You're My Next Catch\" Maki",
@@ -1334,7 +1334,7 @@
         "set": "LL",
         "release": "01",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_049C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_049.png"
     },
     {
         "name": "Slump",
@@ -1360,7 +1360,7 @@
         "set": "LL",
         "release": "01",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_050U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_050.png"
     },
     {
         "name": "Snow Halation",
@@ -1390,7 +1390,7 @@
         "set": "LL",
         "release": "01",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_051CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_051.png"
     },
     {
         "name": "That's Our Miracle",
@@ -1419,7 +1419,7 @@
         "set": "LL",
         "release": "01",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_052CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_052.png"
     },
     {
         "name": "Forever and Ever",
@@ -1448,7 +1448,7 @@
         "set": "LL",
         "release": "01",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_053CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_053.png"
     },
     {
         "name": "Door to Our Dreams",
@@ -1478,7 +1478,7 @@
         "set": "LL",
         "release": "01",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_054CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_054.png"
     },
     {
         "name": "Shocking Party",
@@ -1508,7 +1508,7 @@
         "set": "LL",
         "release": "01",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_055CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_055.png"
     },
     {
         "name": "Nico in Training Wear",
@@ -1536,7 +1536,7 @@
         "set": "LL",
         "release": "01",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_056RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_056.png"
     },
     {
         "name": "Nozomi in Training Wear",
@@ -1565,7 +1565,7 @@
         "set": "LL",
         "release": "01",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_057R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_057.png"
     },
     {
         "name": "Eli in Training Wear",
@@ -1592,7 +1592,7 @@
         "set": "LL",
         "release": "01",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_058U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_058.png"
     },
     {
         "name": "\"Great Idea\" Eli",
@@ -1619,7 +1619,7 @@
         "set": "LL",
         "release": "01",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_059U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_059.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Nozomi",
@@ -1645,7 +1645,7 @@
         "set": "LL",
         "release": "01",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_060U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_060.png"
     },
     {
         "name": "Nico in Pajamas",
@@ -1671,7 +1671,7 @@
         "set": "LL",
         "release": "01",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_061U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_061.png"
     },
     {
         "name": "Taking Pride in Lyrics, Nico",
@@ -1698,7 +1698,7 @@
         "set": "LL",
         "release": "01",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_062U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_062.png"
     },
     {
         "name": "Nozomi in Pajamas",
@@ -1724,7 +1724,7 @@
         "set": "LL",
         "release": "01",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_063U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_063.png"
     },
     {
         "name": "Eli in Regular Clothes",
@@ -1750,7 +1750,7 @@
         "set": "LL",
         "release": "01",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_064U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_064.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Eli",
@@ -1776,7 +1776,7 @@
         "set": "LL",
         "release": "01",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_065C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_065.png"
     },
     {
         "name": "Taking Care of Juniors, Nozomi",
@@ -1802,7 +1802,7 @@
         "set": "LL",
         "release": "01",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_066C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_066.png"
     },
     {
         "name": "Nozomi in Regular Clothes",
@@ -1828,7 +1828,7 @@
         "set": "LL",
         "release": "01",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_067C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_067.png"
     },
     {
         "name": "Nico in Regular Clothes",
@@ -1854,7 +1854,7 @@
         "set": "LL",
         "release": "01",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_068C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_068.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Nico",
@@ -1880,7 +1880,7 @@
         "set": "LL",
         "release": "01",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_069C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_069.png"
     },
     {
         "name": "Eli in Pajamas",
@@ -1908,7 +1908,7 @@
         "set": "LL",
         "release": "01",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_070C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_070.png"
     },
     {
         "name": "With a Summer Smile 1,2,Jump!",
@@ -1937,7 +1937,7 @@
         "set": "LL",
         "release": "01",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_071CC.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_071.png"
     },
     {
         "name": "\"School idol festival\" Umi",
@@ -1964,7 +1964,7 @@
         "set": "LL",
         "release": "01",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_072RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_072.png"
     },
     {
         "name": "\"School idol festival\" Honoka",
@@ -1990,7 +1990,7 @@
         "set": "LL",
         "release": "01",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_073R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_073.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Honoka",
@@ -2016,7 +2016,7 @@
         "set": "LL",
         "release": "01",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_074R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_074.png"
     },
     {
         "name": "Umi in Regular Clothes",
@@ -2045,7 +2045,7 @@
         "set": "LL",
         "release": "01",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_075R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_075.png"
     },
     {
         "name": "Kotori in Training Wear",
@@ -2073,7 +2073,7 @@
         "set": "LL",
         "release": "01",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_076R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_076.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Kotori",
@@ -2100,7 +2100,7 @@
         "set": "LL",
         "release": "01",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_077U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_077.png"
     },
     {
         "name": "Kotori in Regular Clothes",
@@ -2126,7 +2126,7 @@
         "set": "LL",
         "release": "01",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_078U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_078.png"
     },
     {
         "name": "Umi in Pajamas",
@@ -2155,7 +2155,7 @@
         "set": "LL",
         "release": "01",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_079U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_079.png"
     },
     {
         "name": "Honoka in Pajamas",
@@ -2184,7 +2184,7 @@
         "set": "LL",
         "release": "01",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_080U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_080.png"
     },
     {
         "name": "Kotori in Pajamas",
@@ -2213,7 +2213,7 @@
         "set": "LL",
         "release": "01",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_081U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_081.png"
     },
     {
         "name": "Honoka in Regular Clothes",
@@ -2240,7 +2240,7 @@
         "set": "LL",
         "release": "01",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_082C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_082.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Umi",
@@ -2266,7 +2266,7 @@
         "set": "LL",
         "release": "01",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_083C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_083.png"
     },
     {
         "name": "Student Council President, Honoka",
@@ -2292,7 +2292,7 @@
         "set": "LL",
         "release": "01",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_084C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_084.png"
     },
     {
         "name": "\"School idol festival\" Kotori",
@@ -2319,7 +2319,7 @@
         "set": "LL",
         "release": "01",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_085C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_085.png"
     },
     {
         "name": "Designer, Kotori",
@@ -2345,7 +2345,7 @@
         "set": "LL",
         "release": "01",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_086C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_086.png"
     },
     {
         "name": "Honoka in Training Wear",
@@ -2371,7 +2371,7 @@
         "set": "LL",
         "release": "01",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_087C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_087.png"
     },
     {
         "name": "Attacking the Peak, Umi",
@@ -2399,7 +2399,7 @@
         "set": "LL",
         "release": "01",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_088C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_088.png"
     },
     {
         "name": "Umi in Training Wear",
@@ -2427,7 +2427,7 @@
         "set": "LL",
         "release": "01",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_089C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_089.png"
     },
     {
         "name": "Wonderful Rush",
@@ -2456,7 +2456,7 @@
         "set": "LL",
         "release": "01",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_090CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_090.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Maki",
@@ -2485,7 +2485,7 @@
         "set": "LL",
         "release": "01",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_091RR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_091.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Hanayo",
@@ -2511,7 +2511,7 @@
         "set": "LL",
         "release": "01",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_092R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_092.png"
     },
     {
         "name": "Rin in Regular Clothes",
@@ -2538,7 +2538,7 @@
         "set": "LL",
         "release": "01",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_093U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_093.png"
     },
     {
         "name": "Spotting an Idol! Hanayo",
@@ -2564,7 +2564,7 @@
         "set": "LL",
         "release": "01",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_094U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_094.png"
     },
     {
         "name": "Hanayo in Pajamas",
@@ -2591,7 +2591,7 @@
         "set": "LL",
         "release": "01",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_095U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_095.png"
     },
     {
         "name": "\"Let's Go Out Together♪\" Rin",
@@ -2617,7 +2617,7 @@
         "set": "LL",
         "release": "01",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_096U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_096.png"
     },
     {
         "name": "Alpaca",
@@ -2643,7 +2643,7 @@
         "set": "LL",
         "release": "01",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_097U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_097.png"
     },
     {
         "name": "Rin in Pajamas",
@@ -2672,7 +2672,7 @@
         "set": "LL",
         "release": "01",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_098U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_098.png"
     },
     {
         "name": "Maki in Training Wear",
@@ -2701,7 +2701,7 @@
         "set": "LL",
         "release": "01",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_099U.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_099.png"
     },
     {
         "name": "Composing, Maki",
@@ -2727,7 +2727,7 @@
         "set": "LL",
         "release": "01",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_100C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_100.png"
     },
     {
         "name": "Maki in Regular Clothes",
@@ -2753,7 +2753,7 @@
         "set": "LL",
         "release": "01",
         "sid": "101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_101C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_101.png"
     },
     {
         "name": "Maki in Pajamas",
@@ -2779,7 +2779,7 @@
         "set": "LL",
         "release": "01",
         "sid": "102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_102C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_102.png"
     },
     {
         "name": "Hanayo in Regular Clothes",
@@ -2805,7 +2805,7 @@
         "set": "LL",
         "release": "01",
         "sid": "103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_103C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_103.png"
     },
     {
         "name": "Rin in Training Wear",
@@ -2831,7 +2831,7 @@
         "set": "LL",
         "release": "01",
         "sid": "104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_104C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_104.png"
     },
     {
         "name": "Wailing Rin",
@@ -2860,7 +2860,7 @@
         "set": "LL",
         "release": "01",
         "sid": "105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_105C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_105.png"
     },
     {
         "name": "Hanayo in Training Wear",
@@ -2888,7 +2888,7 @@
         "set": "LL",
         "release": "01",
         "sid": "106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_106C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_106.png"
     },
     {
         "name": "Tight Hug, and Closing In on \"love\"!",
@@ -2918,7 +2918,7 @@
         "set": "LL",
         "release": "01",
         "sid": "107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_107CR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_107.png"
     },
     {
         "name": "\"School idol festival\" Eli",
@@ -2944,7 +2944,7 @@
         "set": "LL",
         "release": "01",
         "sid": "108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_108PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_108.png"
     },
     {
         "name": "\"School idol festival\" Rin",
@@ -2970,7 +2970,7 @@
         "set": "LL",
         "release": "01",
         "sid": "109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_109PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_109.png"
     },
     {
         "name": "\"School idol festival\" Maki",
@@ -2998,7 +2998,7 @@
         "set": "LL",
         "release": "01",
         "sid": "110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_110PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_110.png"
     },
     {
         "name": "\"School idol festival\" Nozomi",
@@ -3025,7 +3025,7 @@
         "set": "LL",
         "release": "01",
         "sid": "111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_111PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_111.png"
     },
     {
         "name": "\"School idol festival\" Hanayo",
@@ -3053,7 +3053,7 @@
         "set": "LL",
         "release": "01",
         "sid": "112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_112PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_112.png"
     },
     {
         "name": "\"School idol festival\" Nico",
@@ -3079,7 +3079,7 @@
         "set": "LL",
         "release": "01",
         "sid": "113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LLEN_W01_113PR.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_en_w01/LL_EN_W01_113.png"
     },
     {
         "name": "Love Live! School idol festival",
@@ -3108,7 +3108,7 @@
         "set": "LL",
         "release": "28",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W28_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w28/LL_W28_PE01.png"
     },
     {
         "name": "Both in Swimsuits, Honoka & Umi",
@@ -3136,6 +3136,6 @@
         "set": "LL",
         "release": "E19",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_WE19_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_we19/LL_WE19_PE02.png"
     }
 ]

--- a/DB/LL_W24.json
+++ b/DB/LL_W24.json
@@ -23,7 +23,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E001.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Honoka Kosaka",
@@ -49,7 +49,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E002.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Nozomi Tojo",
@@ -77,7 +77,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E003.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Umi Sonoda",
@@ -104,7 +104,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E004.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Eli Ayase",
@@ -130,7 +130,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E005.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -156,7 +156,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006a.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -182,7 +182,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006b.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -208,7 +208,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006c.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -234,7 +234,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006d.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -260,7 +260,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006e.png"
     },
     {
         "name": "\"With a `Summer Smile 1,2,Jump!\" μ's",
@@ -286,7 +286,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006f",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006f.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006f.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -312,7 +312,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006g",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006g.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006g.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -338,7 +338,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006h",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006h.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006h.png"
     },
     {
         "name": "\"With a Summer Smile 1,2,Jump!\" μ's",
@@ -364,7 +364,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E006i",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E006i.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E006i.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Kotori Minami",
@@ -390,7 +390,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E007.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Rin Hoshizora",
@@ -419,7 +419,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E008.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Nico Yazawa",
@@ -448,7 +448,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E009.png"
     },
     {
         "name": "\"Our LIVE, the LIFE with You\" Hanayo Koizumi",
@@ -476,7 +476,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E010.png"
     },
     {
         "name": "Kotori Minami",
@@ -502,7 +502,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E011.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -528,7 +528,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012a.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -554,7 +554,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012b.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -580,7 +580,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012c.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -606,7 +606,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012d.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -632,7 +632,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012e.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -658,7 +658,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012f",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012f.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012f.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -684,7 +684,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012g",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012g.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012g.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -710,7 +710,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012h",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012h.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012h.png"
     },
     {
         "name": "\"Tight Hug, and Closing In on \"love\"!\" μ's",
@@ -736,7 +736,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E012i",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E012i.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E012i.png"
     },
     {
         "name": "Umi Sonoda",
@@ -764,7 +764,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E013.png"
     },
     {
         "name": "\"We Are Now Waiting In the Shining Light\" μ's",
@@ -793,7 +793,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E014.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -819,7 +819,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015a.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -845,7 +845,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015b.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -871,7 +871,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015c.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -897,7 +897,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015d.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -923,7 +923,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015e.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -949,7 +949,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015f",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015f.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015f.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -975,7 +975,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015g",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015g.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015g.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -1001,7 +1001,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015h",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015h.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015h.png"
     },
     {
         "name": "\"A New Start\" μ's",
@@ -1027,7 +1027,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E015i",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E015i.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E015i.png"
     },
     {
         "name": "Eli Ayase",
@@ -1053,7 +1053,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E016.png"
     },
     {
         "name": "Nico Yazawa",
@@ -1079,7 +1079,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E017.png"
     },
     {
         "name": "Hanayo Koizumi",
@@ -1105,7 +1105,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E018.png"
     },
     {
         "name": "Rin Hoshizora",
@@ -1133,7 +1133,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E019.png"
     },
     {
         "name": "Nozomi Tojo",
@@ -1159,7 +1159,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E020.png"
     },
     {
         "name": "Maki Nishikino",
@@ -1188,7 +1188,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E021.png"
     },
     {
         "name": "Honoka Kosaka",
@@ -1216,7 +1216,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E022.png"
     },
     {
         "name": "Youthfulness Must Be Listening",
@@ -1246,7 +1246,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E023.png"
     },
     {
         "name": "Our LIVE, the LIFE with You",
@@ -1275,7 +1275,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E024.png"
     },
     {
         "name": "Mermaid festa vol.2",
@@ -1304,7 +1304,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E025.png"
     },
     {
         "name": "Student Council President, Eli",
@@ -1331,7 +1331,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E026.png"
     },
     {
         "name": "Idol Otaku, Nico",
@@ -1360,7 +1360,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E027.png"
     },
     {
         "name": "Spiritual Power, Nozomi",
@@ -1386,7 +1386,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E028.png"
     },
     {
         "name": "Otonokizaka High 3rd Year, Nico",
@@ -1414,7 +1414,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E029.png"
     },
     {
         "name": "Otonokizaka High 3rd Year, Nozomi",
@@ -1443,7 +1443,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E030.png"
     },
     {
         "name": "Otonokizaka High 3rd Year, Eli",
@@ -1472,7 +1472,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E031.png"
     },
     {
         "name": "Club Leader, Nico",
@@ -1499,7 +1499,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E032.png"
     },
     {
         "name": "Swimsuit Nozomi",
@@ -1526,7 +1526,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E033.png"
     },
     {
         "name": "Maid Outfit Nico",
@@ -1552,7 +1552,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E034.png"
     },
     {
         "name": "Nico Likes Pranks",
@@ -1580,7 +1580,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E035.png"
     },
     {
         "name": "\"Secrets\" Nozomi",
@@ -1608,7 +1608,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E036.png"
     },
     {
         "name": "Caring for Friends, Nozomi",
@@ -1634,7 +1634,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E037.png"
     },
     {
         "name": "Alisa Ayase",
@@ -1660,7 +1660,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E038.png"
     },
     {
         "name": "\"Khorosho\" Eli",
@@ -1686,7 +1686,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E039.png"
     },
     {
         "name": "Swimsuit Eli",
@@ -1712,7 +1712,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E040.png"
     },
     {
         "name": "Plotting Secretly, Nico",
@@ -1739,7 +1739,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E041.png"
     },
     {
         "name": "Maid Outfit Eli",
@@ -1766,7 +1766,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E042.png"
     },
     {
         "name": "Maid Outfit Nozomi",
@@ -1792,7 +1792,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E043.png"
     },
     {
         "name": "A Quarter Russian, Eli",
@@ -1820,7 +1820,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E044.png"
     },
     {
         "name": "Ascension",
@@ -1846,7 +1846,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E045.png"
     },
     {
         "name": "Everyone at the Beach",
@@ -1872,7 +1872,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E046.png"
     },
     {
         "name": "Memories of That Day",
@@ -1898,7 +1898,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E047.png"
     },
     {
         "name": "Work that Brings a Smile",
@@ -1927,7 +1927,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E048.png"
     },
     {
         "name": "What I Really Want to Do",
@@ -1956,7 +1956,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E049.png"
     },
     {
         "name": "Tarot Reading",
@@ -1985,7 +1985,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E050.png"
     },
     {
         "name": "Otonokizaka High 2nd Year, Kotori",
@@ -2012,7 +2012,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E051.png"
     },
     {
         "name": "Otonokizaka High 2nd Year, Umi",
@@ -2042,7 +2042,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E052.png"
     },
     {
         "name": "Secondary Leader Type, Kotori",
@@ -2069,7 +2069,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E053.png"
     },
     {
         "name": "Energetic by Nature, Honoka",
@@ -2096,7 +2096,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E054.png"
     },
     {
         "name": "Driving Force Behind μ's, Honoka",
@@ -2125,7 +2125,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E055.png"
     },
     {
         "name": "True Japanese Lady, Umi",
@@ -2154,7 +2154,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E056.png"
     },
     {
         "name": "Maid Outfit Umi",
@@ -2181,7 +2181,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E057.png"
     },
     {
         "name": "Maid Outfit Honoka",
@@ -2208,7 +2208,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E058.png"
     },
     {
         "name": "Archery Club, Umi",
@@ -2234,7 +2234,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E059.png"
     },
     {
         "name": "Real Feelings, Kotori",
@@ -2262,7 +2262,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E060.png"
     },
     {
         "name": "\"Not Fair\" Kotori",
@@ -2290,7 +2290,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E061.png"
     },
     {
         "name": "Runaway Delusions, Umi",
@@ -2316,7 +2316,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E062.png"
     },
     {
         "name": "Daughter of a Japanese Confectionery, Honoka",
@@ -2342,7 +2342,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E063.png"
     },
     {
         "name": "\"Minalinsky\" Kotori",
@@ -2368,7 +2368,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E064.png"
     },
     {
         "name": "Yukiho Kosaka",
@@ -2394,7 +2394,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E065.png"
     },
     {
         "name": "Daughter of the Chairman, Kotori",
@@ -2420,7 +2420,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E066.png"
     },
     {
         "name": "Childhood Umi",
@@ -2446,7 +2446,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E067.png"
     },
     {
         "name": "Swimsuit Honoka",
@@ -2472,7 +2472,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E068.png"
     },
     {
         "name": "Otonokizaka High 2nd Year, Honoka",
@@ -2500,7 +2500,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E069.png"
     },
     {
         "name": "Makeshift Approach",
@@ -2526,7 +2526,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E070.png"
     },
     {
         "name": "Climbing a Tree Together",
@@ -2552,7 +2552,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E071.png"
     },
     {
         "name": "Uncool Step",
@@ -2578,7 +2578,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E072.png"
     },
     {
         "name": "First Thoughts",
@@ -2607,7 +2607,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E073.png"
     },
     {
         "name": "Favorite Place",
@@ -2636,7 +2636,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E074.png"
     },
     {
         "name": "You're the worst!",
@@ -2665,7 +2665,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E075.png"
     },
     {
         "name": "Otonokizaka High 1st Year, Rin",
@@ -2692,7 +2692,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E076.png"
     },
     {
         "name": "Loves Idols, Hanayo",
@@ -2720,7 +2720,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E077.png"
     },
     {
         "name": "Rin's Childhood Friend, Hanayo",
@@ -2747,7 +2747,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E078.png"
     },
     {
         "name": "Great at Singing, Maki",
@@ -2775,7 +2775,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E079.png"
     },
     {
         "name": "Hanayo's Childhood Friend, Rin",
@@ -2802,7 +2802,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E080.png"
     },
     {
         "name": "Otonokizaka High 1st Year, Maki",
@@ -2832,7 +2832,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E081.png"
     },
     {
         "name": "Powerful Pride, Maki",
@@ -2859,7 +2859,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E082.png"
     },
     {
         "name": "\"Secrets\" Maki",
@@ -2886,7 +2886,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E083.png"
     },
     {
         "name": "Swimsuit Hanayo",
@@ -2912,7 +2912,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E084.png"
     },
     {
         "name": "Encouraging Maki",
@@ -2938,7 +2938,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E085.png"
     },
     {
         "name": "Maid Outfit Rin",
@@ -2966,7 +2966,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E086.png"
     },
     {
         "name": "Athletic Rin",
@@ -2992,7 +2992,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E087.png"
     },
     {
         "name": "Alpaca",
@@ -3018,7 +3018,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E088.png"
     },
     {
         "name": "Swimsuit Rin",
@@ -3044,7 +3044,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E089.png"
     },
     {
         "name": "Maid Outfit Hanayo",
@@ -3070,7 +3070,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E090.png"
     },
     {
         "name": "Otonokizaka High 1st Year, Hanayo",
@@ -3097,7 +3097,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E091.png"
     },
     {
         "name": "Strong-minded Maki",
@@ -3125,7 +3125,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E092.png"
     },
     {
         "name": "Rin During an Interview",
@@ -3153,7 +3153,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E093.png"
     },
     {
         "name": "Discovering Oneself, Hanayo",
@@ -3181,7 +3181,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E094.png"
     },
     {
         "name": "Smile! Push-ups!",
@@ -3207,7 +3207,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E095.png"
     },
     {
         "name": "Childhood Dreams",
@@ -3233,7 +3233,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E096.png"
     },
     {
         "name": "Great Day for Practice?",
@@ -3259,7 +3259,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E097.png"
     },
     {
         "name": "μ's Teammates",
@@ -3288,7 +3288,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E098.png"
     },
     {
         "name": "Declaration of Participation",
@@ -3317,7 +3317,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E099.png"
     },
     {
         "name": "Music Room Girl",
@@ -3346,7 +3346,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E100.png"
     },
     {
         "name": "\"Wonderful Rush\" Nico Yazawa",
@@ -3372,7 +3372,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E101.png"
     },
     {
         "name": "\"Wonderful Rush\" Umi Sonoda",
@@ -3399,7 +3399,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E102.png"
     },
     {
         "name": "\"Wonderful Rush\" Eli Ayase",
@@ -3425,7 +3425,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E103.png"
     },
     {
         "name": "\"Wonderful Rush\" Maki Nishikino",
@@ -3451,7 +3451,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E104.png"
     },
     {
         "name": "\"Wonderful Rush\" Nozomi Tojo",
@@ -3479,7 +3479,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E105.png"
     },
     {
         "name": "\"Wonderful Rush\" Hanayo Koizumi",
@@ -3508,7 +3508,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E106.png"
     },
     {
         "name": "\"Wonderful Rush\" Rin Hoshizora",
@@ -3536,7 +3536,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E107.png"
     },
     {
         "name": "\"Wonderful Rush\" Kotori Minami",
@@ -3564,7 +3564,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E108.png"
     },
     {
         "name": "\"Wonderful Rush\" Honoka Kosaka",
@@ -3593,7 +3593,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E109.png"
     },
     {
         "name": "\"Oh ,Love & Peace!\" μ's",
@@ -3619,7 +3619,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E110.png"
     },
     {
         "name": "Wonderful Rush",
@@ -3648,7 +3648,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E111.png"
     },
     {
         "name": "We Are Now Waiting In the Shining Light",
@@ -3677,7 +3677,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E112a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e112a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E112a.png"
     },
     {
         "name": "We Are Now Waiting In the Shining Light",
@@ -3706,7 +3706,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E112b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e112b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E112b.png"
     },
     {
         "name": "We Are Now Waiting In the Shining Light",
@@ -3735,7 +3735,7 @@
         "set": "LL",
         "release": "24",
         "sid": "E112c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_e112c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_E112c.png"
     },
     {
         "name": "Mini Honoka",
@@ -4001,7 +4001,7 @@
         "set": "LL",
         "release": "24",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_PE01.png"
     },
     {
         "name": "Preparations for X'mas, Kotori & Honoka & Umi",
@@ -4027,7 +4027,7 @@
         "set": "LL",
         "release": "24",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_LL_W24_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/updates/PR/LL_W24_PE03.png"
     },
     {
         "name": "Runaway Delusions, Umi",
@@ -4053,7 +4053,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE01.png"
     },
     {
         "name": "Daughter of a Japanese Confectionery, Honoka",
@@ -4079,7 +4079,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE02.png"
     },
     {
         "name": "Daughter of the Chairman, Kotori",
@@ -4105,7 +4105,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE03.png"
     },
     {
         "name": "Archery Club, Umi",
@@ -4131,7 +4131,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE04.png"
     },
     {
         "name": "Otonokizaka High 2nd Year, Honoka",
@@ -4159,7 +4159,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE05.png"
     },
     {
         "name": "\"Not Fair\" Kotori",
@@ -4187,7 +4187,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE06.png"
     },
     {
         "name": "Climbing a Tree Together",
@@ -4214,7 +4214,7 @@
         "set": "LL",
         "release": "24",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE07.png"
     },
     {
         "name": "First Thoughts",
@@ -4243,6 +4243,6 @@
         "set": "LL",
         "release": "24",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_ll_w24_te08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/ll_w24/LL_W24_TE08.png"
     }
 ]

--- a/DB/LSSE1_WE27.json
+++ b/DB/LSSE1_WE27.json
@@ -23,7 +23,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE01.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Yoshiko Tsushima",
@@ -49,7 +49,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE02.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Hanamaru Kunikida",
@@ -77,7 +77,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE03.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Yoshiko Tsushima",
@@ -105,7 +105,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE04.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Ruby Kurosawa",
@@ -133,7 +133,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE05.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Hanamaru Kunikida",
@@ -162,7 +162,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE06.png"
     },
     {
         "name": "Aqours's Dollhouse",
@@ -190,7 +190,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE07.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Chika Takami",
@@ -216,7 +216,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE08.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" You Watanabe",
@@ -242,7 +242,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE09.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Chika Takami",
@@ -267,7 +267,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE10.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" You Watanabe",
@@ -293,7 +293,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE11.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Riko Sakurauchi",
@@ -320,7 +320,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE12.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Riko Sakurauchi",
@@ -348,7 +348,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE13.png"
     },
     {
         "name": "End of the Journey",
@@ -376,7 +376,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE14.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Dia Kurosawa",
@@ -401,7 +401,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE15.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Mari Ohara",
@@ -427,7 +427,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE16.png"
     },
     {
         "name": "\"HAPPY PARTY TRAIN\" Kanan Matsuura",
@@ -452,7 +452,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE17.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Mari Ohara",
@@ -477,7 +477,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE18.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Dia Kurosawa",
@@ -503,7 +503,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE19.png"
     },
     {
         "name": "\"Now Then, Where Shall We Go?\" Kanan Matsuura",
@@ -532,7 +532,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE20.png"
     },
     {
         "name": "TRAIN to go!",
@@ -558,7 +558,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE21.png"
     },
     {
         "name": "HAPPY PARTY TRAIN",
@@ -587,7 +587,7 @@
         "set": "LSS",
         "release": "53",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_W53_TE22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w53/LSS_W53_TE22.png"
     },
     {
         "name": "\"MIRAI TICKET\" Hanamaru Kunikida",
@@ -614,7 +614,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E01.png"
     },
     {
         "name": "\"MIRAI TICKET\" Ruby Kurosawa",
@@ -643,7 +643,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E02.png"
     },
     {
         "name": "\"MIRAI TICKET\" Yoshiko Tsushima",
@@ -672,7 +672,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E03.png"
     },
     {
         "name": "\"Do Your Rubesty\" Ruby Kurosawa",
@@ -699,7 +699,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E04.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Hanamaru Kunikida",
@@ -726,7 +726,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E05.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Ruby Kurosawa",
@@ -753,7 +753,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E06.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Yoshiko Tsushima",
@@ -779,7 +779,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E07.png"
     },
     {
         "name": "\"Aim to Shine\" Hanamaru Kunikida",
@@ -806,7 +806,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E08.png"
     },
     {
         "name": "\"My Dear Sister\" Ruby Kurosawa",
@@ -833,7 +833,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E09.png"
     },
     {
         "name": "\"Tears of a Fallen Angel\" Yoshiko Tsushima",
@@ -860,7 +860,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E10.png"
     },
     {
         "name": "\"Today's Ultimate Ragnarok\" Yoshiko Tsushima",
@@ -889,7 +889,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E11.png"
     },
     {
         "name": "\"Together with Everyone\" Hanamaru Kunikida",
@@ -918,7 +918,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E12.png"
     },
     {
         "name": "\"Aim to Shine\" Yoshiko Tsushima",
@@ -945,7 +945,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E13.png"
     },
     {
         "name": "\"Aim to Shine\" Ruby Kurosawa",
@@ -974,7 +974,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E14.png"
     },
     {
         "name": "\"Encountering the Future\" Hanamaru Kunikida",
@@ -1003,7 +1003,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E15.png"
     },
     {
         "name": "Th-This is a PC!",
@@ -1029,7 +1029,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E16.png"
     },
     {
         "name": "MIRAI TICKET",
@@ -1059,7 +1059,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E17.png"
     },
     {
         "name": "Mijuku DREAMER",
@@ -1088,7 +1088,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E18.png"
     },
     {
         "name": "\"MIRAI TICKET\" Riko Sakurauchi",
@@ -1117,7 +1117,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E19.png"
     },
     {
         "name": "\"MIRAI TICKET\" Chika Takami",
@@ -1146,7 +1146,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E20.png"
     },
     {
         "name": "\"MIRAI TICKET\" You Watanabe",
@@ -1175,7 +1175,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E21.png"
     },
     {
         "name": "\"Mijuku DREAMER\" You Watanabe",
@@ -1201,7 +1201,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E22.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Chika Takami",
@@ -1228,7 +1228,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E23.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E23.png"
     },
     {
         "name": "\"Aim to Shine\" You Watanabe",
@@ -1257,7 +1257,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E24.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E24.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Riko Sakurauchi",
@@ -1287,7 +1287,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E25.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E25.png"
     },
     {
         "name": "\"Aim to Shine\" Chika Takami",
@@ -1314,7 +1314,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E26.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E26.png"
     },
     {
         "name": "\"Shining All Together\" You Watanabe",
@@ -1340,7 +1340,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E27.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E27.png"
     },
     {
         "name": "\"From Zero to One!\" Riko Sakurauchi",
@@ -1369,7 +1369,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E28.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E28.png"
     },
     {
         "name": "\"From Zero to One!\" Chika Takami",
@@ -1395,7 +1395,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E29.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E29.png"
     },
     {
         "name": "\"Aim to Shine\" Riko Sakurauchi",
@@ -1422,7 +1422,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E30.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E30.png"
     },
     {
         "name": "\"From Zero to One!\" You Watanabe",
@@ -1449,7 +1449,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E31.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E31.png"
     },
     {
         "name": "\"Pool Cleaning\" You Watanabe",
@@ -1475,7 +1475,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E32.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E32.png"
     },
     {
         "name": "\"Something Precious\" Chika Takami",
@@ -1504,7 +1504,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E33.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E33.png"
     },
     {
         "name": "Shining Much Brighter Than Anyone Could Alone",
@@ -1531,7 +1531,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E34.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E34.png"
     },
     {
         "name": "Mijuku DREAMER",
@@ -1560,7 +1560,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E35.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E35.png"
     },
     {
         "name": "Feelings, Become One!",
@@ -1589,7 +1589,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E36.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E36.png"
     },
     {
         "name": "\"MIRAI TICKET\" Mari Ohara",
@@ -1616,7 +1616,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E37",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E37.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E37.png"
     },
     {
         "name": "\"MIRAI TICKET\" Dia Kurosawa",
@@ -1643,7 +1643,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E38",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E38.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E38.png"
     },
     {
         "name": "\"MIRAI TICKET\" Kanan Matsuura",
@@ -1673,7 +1673,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E39",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E39.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E39.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Dia Kurosawa\"",
@@ -1700,7 +1700,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E40",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E40.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E40.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Kanan Matsuura",
@@ -1729,7 +1729,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E41",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E41.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E41.png"
     },
     {
         "name": "\"Aim to Shine\" Dia Kurosawa",
@@ -1758,7 +1758,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E42",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E42.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E42.png"
     },
     {
         "name": "\"Mijuku DREAMER\" Mari Ohara",
@@ -1787,7 +1787,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E43",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E43.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E43.png"
     },
     {
         "name": "\"GLAMorous Swimsuit Figure\" Kanan Matsuura",
@@ -1814,7 +1814,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E44",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E44.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E44.png"
     },
     {
         "name": "\"Aim to Shine\" Mari Ohara",
@@ -1843,7 +1843,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E45",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E45.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E45.png"
     },
     {
         "name": "\"Welcome to Aqours!\" Dia Kurosawa",
@@ -1871,7 +1871,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E46",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E46.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E46.png"
     },
     {
         "name": "\"Reminiscent Hug\" Kanan Matsuura",
@@ -1897,7 +1897,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E47",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E47.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E47.png"
     },
     {
         "name": "\"Escaping Reality\" Dia Kurosawa",
@@ -1924,7 +1924,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E48",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E48.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E48.png"
     },
     {
         "name": "\"My Best Friend\" Mari Ohara",
@@ -1950,7 +1950,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E49",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E49.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E49.png"
     },
     {
         "name": "\"Aim to Shine\" Kanan Matsuura",
@@ -1977,7 +1977,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E50",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E50.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E50.png"
     },
     {
         "name": "\"Stewshine\" Mari Ohara",
@@ -2005,7 +2005,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E51",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E51.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E51.png"
     },
     {
         "name": "Thinking For the Other",
@@ -2031,7 +2031,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E52",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E52.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E52.png"
     },
     {
         "name": "MIRAI TICKET",
@@ -2061,7 +2061,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E53",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E53.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E53.png"
     },
     {
         "name": "Mijuku DREAMER",
@@ -2090,7 +2090,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E54",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E54.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E54.png"
     },
     {
         "name": "Mini Yoshiko",
@@ -2117,7 +2117,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E55",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E55.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E55.png"
     },
     {
         "name": "Mini Ruby",
@@ -2143,7 +2143,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E56",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E56.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E56.png"
     },
     {
         "name": "Mini Hanamaru",
@@ -2172,7 +2172,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E57",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E57.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E57.png"
     },
     {
         "name": "Mini You",
@@ -2198,7 +2198,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E58",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E58.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E58.png"
     },
     {
         "name": "Mini Chika",
@@ -2225,7 +2225,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E59",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E59.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E59.png"
     },
     {
         "name": "Mini Riko",
@@ -2251,7 +2251,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E60",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E60.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E60.png"
     },
     {
         "name": "Mini Kanan",
@@ -2278,7 +2278,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E61",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E61.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E61.png"
     },
     {
         "name": "Mini Mari",
@@ -2304,7 +2304,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E62",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E62.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E62.png"
     },
     {
         "name": "Mini Dia",
@@ -2333,7 +2333,7 @@
         "set": "LSS",
         "release": "E27",
         "sid": "E63",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_LSS_WE27_E63.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_we27/LSS_WE27_E63.png"
     },
     {
         "name": "\"Let's Sing Together!\" Kanan & Dia & Mari",

--- a/DB/LSS_W45.json
+++ b/DB/LSS_W45.json
@@ -23,7 +23,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E001.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Ruby Kurosawa",
@@ -52,7 +52,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E002.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Hanamaru Kunikida",
@@ -81,7 +81,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E003.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Hanamaru Kunikida",
@@ -106,7 +106,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E004.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Ruby Kurosawa",
@@ -132,7 +132,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E005.png"
     },
     {
         "name": "Hanamaru Kunikida",
@@ -157,7 +157,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E006.png"
     },
     {
         "name": "Yoshiko Tsushima",
@@ -187,7 +187,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E007.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Yoshiko Tsushima",
@@ -215,7 +215,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E008.png"
     },
     {
         "name": "Ruby Kurosawa",
@@ -244,7 +244,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E009.png"
     },
     {
         "name": "\"Long-awaited New Comer\" Yoshiko Tsushima",
@@ -270,7 +270,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E010.png"
     },
     {
         "name": "\"Yohane-sama's Little Demon No.4\" Ruby Kurosawa",
@@ -296,7 +296,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E011.png"
     },
     {
         "name": "\"Tokyo? Coordinate\" Ruby Kurosawa",
@@ -322,7 +322,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E012.png"
     },
     {
         "name": "\"Normal Clothes\" Hanamaru Kunikida",
@@ -347,7 +347,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E013.png"
     },
     {
         "name": "\"Fallen Angel Mode Release\" Yoshiko Tsushima",
@@ -374,7 +374,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E014.png"
     },
     {
         "name": "\"Special Friend\" Ruby Kurosawa",
@@ -401,7 +401,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E015.png"
     },
     {
         "name": "\"Special Friend\" Hanamaru Kunikida",
@@ -428,7 +428,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E016.png"
     },
     {
         "name": "\"Girl Going to School\" Yoshiko Tsushima",
@@ -456,7 +456,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E017.png"
     },
     {
         "name": "\"My Retreat\" Hanamaru Kunikida",
@@ -485,7 +485,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E018.png"
     },
     {
         "name": "\"Wearing a Smile with Sadness\" Yoshiko Tsushima",
@@ -512,7 +512,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E019.png"
     },
     {
         "name": "\"Tokyo? Coordinate\" Hanamaru Kunikida",
@@ -537,7 +537,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E020.png"
     },
     {
         "name": "\"Club Application Form\" Ruby Kurosawa",
@@ -563,7 +563,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E021.png"
     },
     {
         "name": "\"Polite Bow\" Hanamaru Kunikida",
@@ -588,7 +588,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E022.png"
     },
     {
         "name": "\"Favorite School Idol\" Ruby Kurosawa",
@@ -613,7 +613,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E023.png"
     },
     {
         "name": "\"Fallen Angel Yohane's Demon Eyes\" Yoshiko Tsushima",
@@ -641,7 +641,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E024.png"
     },
     {
         "name": "\"Morning Escape\" Yoshiko Tsushima",
@@ -666,7 +666,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E025.png"
     },
     {
         "name": "\"Live Invitation\" Ruby Kurosawa",
@@ -693,7 +693,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E026.png"
     },
     {
         "name": "\"Actually an Angel?\" Hanamaru Kunikida",
@@ -720,7 +720,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E027.png"
     },
     {
         "name": "The Smiles of Pretty Girls",
@@ -745,7 +745,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E028.png"
     },
     {
         "name": "?Little Demon Summoning?",
@@ -770,7 +770,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E029.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Hanamaru",
@@ -798,7 +798,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E030.png"
     },
     {
         "name": "Make Our Dreams Come True",
@@ -826,7 +826,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E031.png"
     },
     {
         "name": "\"We Want to Shine!\" Hanamaru & Ruby & Yoshiko",
@@ -854,7 +854,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E032.png"
     },
     {
         "name": "Your Favorite Self",
@@ -882,7 +882,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E033.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Riko Sakurauchi",
@@ -908,7 +908,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E034.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Chika Takami",
@@ -934,7 +934,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E035.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" You Watanabe",
@@ -962,7 +962,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E036.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" You Watanabe",
@@ -988,7 +988,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E037.png"
     },
     {
         "name": "Riko Sakurauchi",
@@ -1013,7 +1013,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E038.png"
     },
     {
         "name": "You Watanabe",
@@ -1039,7 +1039,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E039.png"
     },
     {
         "name": "Chika Takami",
@@ -1067,7 +1067,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E040.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Chika Takami",
@@ -1096,7 +1096,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E041.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Riko Sakurauchi",
@@ -1124,7 +1124,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E042.png"
     },
     {
         "name": "\"A Wonderful Thing\" Chika Takami",
@@ -1150,7 +1150,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E043.png"
     },
     {
         "name": "\"Cute Salute?\" You Watanabe",
@@ -1175,7 +1175,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E044.png"
     },
     {
         "name": "\"High Dive\" You Watanabe",
@@ -1201,7 +1201,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E045.png"
     },
     {
         "name": "\"A Maiden's Excitement?\" Riko Sakurauchi",
@@ -1228,7 +1228,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E046.png"
     },
     {
         "name": "\"Daisuki Dattara Daijoubu!\" Chika Takami",
@@ -1253,7 +1253,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E047.png"
     },
     {
         "name": "\"What's Good About Uchiura?\" Chika Takami",
@@ -1282,7 +1282,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E048.png"
     },
     {
         "name": "\"Silence Retuns to the Sandy Beach\" Riko Sakurauchi",
@@ -1308,7 +1308,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E049.png"
     },
     {
         "name": "\"Yume no Tobira\" Riko Sakurauchi",
@@ -1336,7 +1336,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E050.png"
     },
     {
         "name": "\"Disappearance of the Subject\" You Watanabe",
@@ -1365,7 +1365,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E051.png"
     },
     {
         "name": "\"A Wonderful Thing\" Riko Sakurauchi",
@@ -1390,7 +1390,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E052.png"
     },
     {
         "name": "\"Normal Girl\" Chika Takami",
@@ -1415,7 +1415,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E053.png"
     },
     {
         "name": "\"I'll Start from Here\" Chika Takami",
@@ -1440,7 +1440,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E054.png"
     },
     {
         "name": "\"Daisuki Dattara Daijoubu!\" Riko Sakurauchi",
@@ -1466,7 +1466,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E055.png"
     },
     {
         "name": "\"Aye Aye?\"You Watanabe",
@@ -1491,7 +1491,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E056.png"
     },
     {
         "name": "\"Daisuki Dattara Daijoubu!\" You Watanabe",
@@ -1517,7 +1517,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E057.png"
     },
     {
         "name": "\"Let's All Walk Together\" You Watanabe",
@@ -1544,7 +1544,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E058.png"
     },
     {
         "name": "\"Sparkling Shine\" Chika Takami",
@@ -1572,7 +1572,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E059.png"
     },
     {
         "name": "\"Live Invitation\" Riko Sakurauchi",
@@ -1599,7 +1599,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E060.png"
     },
     {
         "name": "Honest Words",
@@ -1625,7 +1625,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E061.png"
     },
     {
         "name": "Niceoodles",
@@ -1651,7 +1651,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E062.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Chika",
@@ -1679,7 +1679,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E063.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" You",
@@ -1705,7 +1705,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E064.png"
     },
     {
         "name": "\"We Want to Shine!\" You & Chika & Riko",
@@ -1733,7 +1733,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E065.png"
     },
     {
         "name": "Outstretched Hand",
@@ -1761,7 +1761,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E066.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Dia Kurosawa",
@@ -1787,7 +1787,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E067.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Mari Ohara",
@@ -1814,7 +1814,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E068.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Kanan Matsuura",
@@ -1843,7 +1843,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E069.png"
     },
     {
         "name": "Dia Kurosawa",
@@ -1869,7 +1869,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E070.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Mari Ohara",
@@ -1895,7 +1895,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E071.png"
     },
     {
         "name": "Kanan Matsuura",
@@ -1921,7 +1921,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E072.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Kanan Matsuura",
@@ -1947,7 +1947,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E073.png"
     },
     {
         "name": "\"Koini Naritai AQUARIUM\" Dia Kurosawa",
@@ -1976,7 +1976,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E074.png"
     },
     {
         "name": "Mari Ohara",
@@ -2004,7 +2004,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E075.png"
     },
     {
         "name": "\"Approved♪\" Mari Ohara",
@@ -2030,7 +2030,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E076.png"
     },
     {
         "name": "\"Capture Stance\" Kanan Matsuura",
@@ -2056,7 +2056,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E077.png"
     },
     {
         "name": "\"Gentle Smile\" Dia Kurosawa",
@@ -2081,7 +2081,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E078.png"
     },
     {
         "name": "\"Tokyo Chance\" Kanan Matsuura",
@@ -2106,7 +2106,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E079.png"
     },
     {
         "name": "\"Friendly Sisters\" Dia Kurosawa",
@@ -2132,7 +2132,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E080.png"
     },
     {
         "name": "\"Expectations and Insecurities\" Mari Ohara",
@@ -2158,7 +2158,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E081.png"
     },
     {
         "name": "\"New Chairman\" Mari Ohara",
@@ -2186,7 +2186,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E082.png"
     },
     {
         "name": "\"Looking Ahead\" Kanan Matsuura",
@@ -2215,7 +2215,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E083.png"
     },
     {
         "name": "\"Beautiful Dance\" Dia Kurosawa",
@@ -2243,7 +2243,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E084.png"
     },
     {
         "name": "\"Unconveyed Feelings\" Mari Ohara",
@@ -2268,7 +2268,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E085.png"
     },
     {
         "name": "\"Confrontation at the Beach\" Kanan Matsuura",
@@ -2293,7 +2293,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E086.png"
     },
     {
         "name": "\"Dear Sister\" Dia Kurosawa",
@@ -2320,7 +2320,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E087.png"
     },
     {
         "name": "\"Favorite School Idol\" Dia Kurosawa",
@@ -2345,7 +2345,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E088.png"
     },
     {
         "name": "\"View from the Helicopter\" Mari Ohara",
@@ -2370,7 +2370,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E089.png"
     },
     {
         "name": "\"Hug\" Kanan Matsuura",
@@ -2395,7 +2395,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E090.png"
     },
     {
         "name": "\"First Live\" Kanan Matsuura",
@@ -2424,7 +2424,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E091.png"
     },
     {
         "name": "\"Unnoticed Feelings\" Mari Ohara",
@@ -2452,7 +2452,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E092.png"
     },
     {
         "name": "\"Firm Refusal\" Dia Kurosawa",
@@ -2480,7 +2480,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E093.png"
     },
     {
         "name": "Lost Time",
@@ -2506,7 +2506,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E094.png"
     },
     {
         "name": "The Truth Beind the Name",
@@ -2531,7 +2531,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E095.png"
     },
     {
         "name": "\"Aozora Jumping Heart\" Kanan",
@@ -2559,7 +2559,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E096.png"
     },
     {
         "name": "\"We Want to Shine!\" Mari & Kanan & Dia",
@@ -2587,7 +2587,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E097.png"
     },
     {
         "name": "Two Favorite People",
@@ -2613,7 +2613,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E098.png"
     },
     {
         "name": "Conveyed Feelings",
@@ -2641,7 +2641,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E099.png"
     },
     {
         "name": "\"We Want to Shine!\" Aqours",
@@ -2669,7 +2669,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E100.png"
     },
     {
         "name": "Petit Yoshiko",
@@ -2694,7 +2694,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E101.png"
     },
     {
         "name": "Petit Hanamaru",
@@ -2719,7 +2719,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E102.png"
     },
     {
         "name": "Petit Ruby",
@@ -2746,7 +2746,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E103.png"
     },
     {
         "name": "Petit Riko",
@@ -2771,7 +2771,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E104.png"
     },
     {
         "name": "Petit You",
@@ -2796,7 +2796,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E105.png"
     },
     {
         "name": "Petit Chika",
@@ -2821,7 +2821,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E106.png"
     },
     {
         "name": "Petit Dia",
@@ -2846,7 +2846,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E107.png"
     },
     {
         "name": "Petit Kanan",
@@ -2873,7 +2873,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E108.png"
     },
     {
         "name": "Petit Mari",
@@ -2900,7 +2900,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_E109.png"
     },
     {
         "name": "\"Summer School Uniform\" Chika Takami",
@@ -2977,7 +2977,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE01.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Yoshiko Tsushima",
@@ -3002,7 +3002,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE02.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Hanamaru Kunikida",
@@ -3027,7 +3027,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE03.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Yoshiko Tsushima",
@@ -3052,7 +3052,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE04.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Hanamaru Kunikida",
@@ -3077,7 +3077,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE05.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Ruby Kurosawa",
@@ -3102,7 +3102,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE06.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Hanamaru & Ruby & Yoshiko",
@@ -3130,7 +3130,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE07.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" You Watanabe",
@@ -3156,7 +3156,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE08.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Riko Sakurauchi",
@@ -3182,7 +3182,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE09.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Chika Takami",
@@ -3210,7 +3210,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE10.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Chika Takami",
@@ -3238,7 +3238,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE11.png"
     },
     {
         "name": "\"Midsummer Aquarium\" You Watanabe",
@@ -3265,7 +3265,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE12.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Riko Sakurauchi",
@@ -3292,7 +3292,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE13.png"
     },
     {
         "name": "Make Our Dreams Come True",
@@ -3317,7 +3317,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE14.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Chika & Riko & You",
@@ -3345,7 +3345,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE15.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Kanan Matsuura",
@@ -3370,7 +3370,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE16.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Dia Kurosawa",
@@ -3395,7 +3395,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE17.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Mari Ohara",
@@ -3420,7 +3420,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE18.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Kanan Matsuura",
@@ -3448,7 +3448,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE19.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Dia Kurosawa",
@@ -3476,7 +3476,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE20.png"
     },
     {
         "name": "\"Kimino Kokorowa Kagayaiterukai?\" Mari Ohara",
@@ -3504,7 +3504,7 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE21.png"
     },
     {
         "name": "\"Midsummer Aquarium\" Mari & Kanan & Dia",
@@ -3532,6 +3532,6 @@
         "set": "LSS",
         "release": "45",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/LSS_W45_TE22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/l/lss_w45/LSS_W45_TE22.png"
     }
 ]

--- a/DB/MK_S11.json
+++ b/DB/MK_S11.json
@@ -25,7 +25,7 @@
         "set": "MK",
         "release": "11",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_E101.png"
     },
     {
         "name": "\"Milky Holmes\" Ellie",
@@ -51,7 +51,7 @@
         "set": "MK",
         "release": "11",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_E103.png"
     },
     {
         "name": "\"Milky Holmes\" Nero",
@@ -77,7 +77,7 @@
         "set": "MK",
         "release": "11",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_E105.png"
     },
     {
         "name": "Joint Investigation, Kokoro & Shalo",
@@ -103,7 +103,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE02.png"
     },
     {
         "name": "Shalo Under the Cherry Blossoms",
@@ -129,7 +129,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE03.png"
     },
     {
         "name": "Problem Child, Nero",
@@ -155,7 +155,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE04.png"
     },
     {
         "name": "Leader of G4, Kokoro",
@@ -181,7 +181,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE05.png"
     },
     {
         "name": "Direct Hack",
@@ -210,7 +210,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE08.png"
     },
     {
         "name": "Psychokinesis",
@@ -239,7 +239,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE09.png"
     },
     {
         "name": "Cordelia Glauca",
@@ -265,7 +265,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE10.png"
     },
     {
         "name": "Pessimistic Thoughts, Ellie",
@@ -291,7 +291,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE11.png"
     },
     {
         "name": "Shy Girl, Ellie",
@@ -319,7 +319,7 @@
         "set": "MK",
         "release": "11",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE14.png"
     },
     {
         "name": "Cat Ears Magnifying Glass",
@@ -345,6 +345,6 @@
         "set": "MK",
         "release": "11",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MK_S11_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mk_s11/MK_S11_TE15.png"
     }
 ]

--- a/DB/MMR_W35.json
+++ b/DB/MMR_W35.json
@@ -23,7 +23,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E001RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E001.png"
     },
     {
         "name": "One Guided By the Law of the Cycle, Nagisa",
@@ -52,7 +52,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E002RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E002.png"
     },
     {
         "name": "Mami & Nagisa",
@@ -78,7 +78,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E003R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E003.png"
     },
     {
         "name": "In Top Form, Mami",
@@ -105,7 +105,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E004R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E004.png"
     },
     {
         "name": "Desired Direction, Mami",
@@ -132,7 +132,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E005R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E005.png"
     },
     {
         "name": "One Who Knows the Truth, Nagisa",
@@ -158,7 +158,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E006R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E006.png"
     },
     {
         "name": "“I'm Happy Now” Mami",
@@ -187,7 +187,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E007R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E007.png"
     },
     {
         "name": "Living Everyday Like a Dream, Mami",
@@ -214,7 +214,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E008U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E008.png"
     },
     {
         "name": "Lively Evening, Mami",
@@ -241,7 +241,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E009U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E009.png"
     },
     {
         "name": "Hills in the Morning Glow, Mami",
@@ -268,7 +268,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E010U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E010.png"
     },
     {
         "name": "Elegant Strike, Mami",
@@ -295,7 +295,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E011U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E011.png"
     },
     {
         "name": "“Magical Girls' Tea Party” Mami",
@@ -324,7 +324,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E012U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E012.png"
     },
     {
         "name": "Pinpoint Targeting, Nagisa",
@@ -353,7 +353,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E013U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E013.png"
     },
     {
         "name": "“Puella Magi Holy Quintet” Mami",
@@ -379,7 +379,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E014C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E014.png"
     },
     {
         "name": "Fair and Beautiful, Mami",
@@ -406,7 +406,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E015C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E015.png"
     },
     {
         "name": "Mami's Friend, Bebe",
@@ -432,7 +432,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E016C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E016.png"
     },
     {
         "name": "Kyubey Manifestation",
@@ -458,7 +458,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E017C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E017.png"
     },
     {
         "name": "Innocent Girl, Nagisa",
@@ -487,7 +487,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E018C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E018.png"
     },
     {
         "name": "Young-looking Magical Girl, Nagisa",
@@ -515,7 +515,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E019C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E019.png"
     },
     {
         "name": "Junior and Senior, Mami & Madoka",
@@ -544,7 +544,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E020C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E020.png"
     },
     {
         "name": "Exterminating Nightmares, Mami",
@@ -572,7 +572,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E021C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E021.png"
     },
     {
         "name": "A New Encounter",
@@ -597,7 +597,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E022U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E022.png"
     },
     {
         "name": "Unavoidable Clash",
@@ -625,7 +625,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E023RRR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E023.png"
     },
     {
         "name": "Bearer of Memories",
@@ -654,7 +654,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E024CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E024.png"
     },
     {
         "name": "Tiro Duet",
@@ -683,7 +683,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E025CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E025.png"
     },
     {
         "name": "“For Madoka's Sake” Homura",
@@ -713,7 +713,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E026RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E026.png"
     },
     {
         "name": "“A Painful Thing” Madoka",
@@ -741,7 +741,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E027RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E027.png"
     },
     {
         "name": "“A Lonely Fight” Homura",
@@ -768,7 +768,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E028R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E028.png"
     },
     {
         "name": "“Real Memories” Homura",
@@ -794,7 +794,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E029R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E029.png"
     },
     {
         "name": "Madoka from the New World",
@@ -819,7 +819,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E030R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E030.png"
     },
     {
         "name": "“A Desired Form” Madoka",
@@ -844,7 +844,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E031R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E031.png"
     },
     {
         "name": "Madoka Thinking of Homura",
@@ -870,7 +870,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E032R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E032.png"
     },
     {
         "name": "Unchanging Smile, Madoka",
@@ -897,7 +897,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E033R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E033.png"
     },
     {
         "name": "Homura Became a Demon",
@@ -927,7 +927,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E034R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E034.png"
     },
     {
         "name": "Worrying Madoka",
@@ -953,7 +953,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E035U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E035.png"
     },
     {
         "name": "“Puella Magi Holy Quintet” Homura",
@@ -980,7 +980,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E036U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E036.png"
     },
     {
         "name": "Hills in the Morning Glow, Homura",
@@ -1006,7 +1006,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E037U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E037.png"
     },
     {
         "name": "“Usual” Homura",
@@ -1033,7 +1033,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E038U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E038.png"
     },
     {
         "name": "Resolution to Become a Witch, Homura",
@@ -1062,7 +1062,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E039U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E039.png"
     },
     {
         "name": "“True Power” Madoka",
@@ -1088,7 +1088,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E040U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E040.png"
     },
     {
         "name": "The Only Hope, Homura",
@@ -1118,7 +1118,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E041U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E041.png"
     },
     {
         "name": "Hills in the Morning Glow, Madoka",
@@ -1146,7 +1146,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E042U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E042.png"
     },
     {
         "name": "Ultimate Madoka",
@@ -1174,7 +1174,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E043U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E043.png"
     },
     {
         "name": "Ladylike, Madoka",
@@ -1200,7 +1200,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E044C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E044.png"
     },
     {
         "name": "Exterminating Nightmares, Madoka",
@@ -1225,7 +1225,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E045C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E045.png"
     },
     {
         "name": "Two Best Friends, Homura & Madoka",
@@ -1251,7 +1251,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E046C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E046.png"
     },
     {
         "name": "“Rebel” Homura",
@@ -1277,7 +1277,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E047C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E047.png"
     },
     {
         "name": "Mission to Fight, Homura & Madoka",
@@ -1303,7 +1303,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E048C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E048.png"
     },
     {
         "name": "Homura's Confrontation with Mami",
@@ -1329,7 +1329,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E049C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E049.png"
     },
     {
         "name": "Deceptive Homura",
@@ -1355,7 +1355,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E050C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E050.png"
     },
     {
         "name": "Change of Stance, Kyubey",
@@ -1382,7 +1382,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E051C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E051.png"
     },
     {
         "name": "“Puella Magi Holy Quintet” Madoka",
@@ -1409,7 +1409,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E052C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E052.png"
     },
     {
         "name": "“No Matter What Happens” Madoka & Homura",
@@ -1438,7 +1438,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E053C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E053.png"
     },
     {
         "name": "Homura's “Determination”",
@@ -1466,7 +1466,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E054C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E054.png"
     },
     {
         "name": "Feelings of Love, Hitomi",
@@ -1493,7 +1493,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E055C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E055.png"
     },
     {
         "name": "Homura's Despair",
@@ -1518,7 +1518,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E056U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E056.png"
     },
     {
         "name": "Truth Behind the Barrier",
@@ -1546,7 +1546,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E057CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E057.png"
     },
     {
         "name": "Guide to Salvation",
@@ -1574,7 +1574,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E058CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E058.png"
     },
     {
         "name": "Mild Days",
@@ -1602,7 +1602,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E059CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E059.png"
     },
     {
         "name": "To the Outside World",
@@ -1630,7 +1630,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E060CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E060.png"
     },
     {
         "name": "Doubt Towards the World, Kyoko",
@@ -1657,7 +1657,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E061RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E061.png"
     },
     {
         "name": "Intuitive Type, Kyoko",
@@ -1686,7 +1686,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E062RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E062.png"
     },
     {
         "name": "Mild Autumn Days, Kyoko",
@@ -1713,7 +1713,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E063R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E063.png"
     },
     {
         "name": "“Magical Girls' Tea Party” Kyoko",
@@ -1739,7 +1739,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E064R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E064.png"
     },
     {
         "name": "Exterminating Nightmares, Kyoko",
@@ -1768,7 +1768,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E065R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E065.png"
     },
     {
         "name": "Unyielding Girl, Kyoko",
@@ -1797,7 +1797,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E066R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E066.png"
     },
     {
         "name": "“Puella Magi Holy Quintet” Kyoko",
@@ -1826,7 +1826,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E067U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E067.png"
     },
     {
         "name": "Mascot? Kyubey",
@@ -1855,7 +1855,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E068U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E068.png"
     },
     {
         "name": "A Morning Sight, Kyoko",
@@ -1883,7 +1883,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E069U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E069.png"
     },
     {
         "name": "“Farewell to Nightmares” Kyoko",
@@ -1910,7 +1910,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E070C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E070.png"
     },
     {
         "name": "Kyoko & Homura",
@@ -1936,7 +1936,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E071C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E071.png"
     },
     {
         "name": "Hills in the Morning Glow, Kyoko",
@@ -1962,7 +1962,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E072C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E072.png"
     },
     {
         "name": "Conducting an Experiment, Kyubey",
@@ -1988,7 +1988,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E073C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E073.png"
     },
     {
         "name": "A Straight Thought, Kyoko",
@@ -2014,7 +2014,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E074C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E074.png"
     },
     {
         "name": "A New Morning, Kyoko",
@@ -2040,7 +2040,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E075C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E075.png"
     },
     {
         "name": "A World Tampered With",
@@ -2065,7 +2065,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E076U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E076.png"
     },
     {
         "name": "Town With No Way Out",
@@ -2090,7 +2090,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E077U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E077.png"
     },
     {
         "name": "Reunion and Alliance",
@@ -2118,7 +2118,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E078CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E078.png"
     },
     {
         "name": "New Days",
@@ -2146,7 +2146,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E079CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E079.png"
     },
     {
         "name": "Law of the Cycle Observer",
@@ -2174,7 +2174,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E080CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E080.png"
     },
     {
         "name": "“My Role” Sayaka",
@@ -2203,7 +2203,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E081RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E081.png"
     },
     {
         "name": "One Guided By the Law of the Cycle, Sayaka",
@@ -2233,7 +2233,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E082RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E082.png"
     },
     {
         "name": "Memories of a Witch, Sayaka",
@@ -2259,7 +2259,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E083R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E083.png"
     },
     {
         "name": "Mild Autumn Days, Sayaka",
@@ -2286,7 +2286,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E084R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E084.png"
     },
     {
         "name": "“Magical Girls' Tea Party” Sayaka",
@@ -2313,7 +2313,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E085R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E085.png"
     },
     {
         "name": "Exterminating Nightmares, Sayaka",
@@ -2342,7 +2342,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E086R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E086.png"
     },
     {
         "name": "“Farewell to Nightmares” Sayaka",
@@ -2369,7 +2369,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E087U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E087.png"
     },
     {
         "name": "“Puella Magi Holy Quintet” Sayaka",
@@ -2396,7 +2396,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E088U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E088.png"
     },
     {
         "name": "Spectacular Plan, Kyubey",
@@ -2422,7 +2422,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E089U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E089.png"
     },
     {
         "name": "Combination, Sayaka",
@@ -2451,7 +2451,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E090U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E090.png"
     },
     {
         "name": "Kyubey Saying Kyu-",
@@ -2478,7 +2478,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E091C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E091.png"
     },
     {
         "name": "Sayaka & Madoka in Winter Days",
@@ -2504,7 +2504,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E092C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E092.png"
     },
     {
         "name": "“Mysterious Gal” Sayaka",
@@ -2530,7 +2530,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E093C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E093.png"
     },
     {
         "name": "Hills in the Morning Glow, Sayaka",
@@ -2557,7 +2557,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E094C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E094.png"
     },
     {
         "name": "Honest Question, Sayaka",
@@ -2583,7 +2583,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E095C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E095.png"
     },
     {
         "name": "Kazuko Saotome",
@@ -2611,7 +2611,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E096C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E096.png"
     },
     {
         "name": "Hitomi's Nightmare",
@@ -2636,7 +2636,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E097U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E097.png"
     },
     {
         "name": "Mermaid Witch Appears",
@@ -2662,7 +2662,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E098U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E098.png"
     },
     {
         "name": "Sayaka's True Identity",
@@ -2691,7 +2691,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E099CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E099.png"
     },
     {
         "name": "True Dream",
@@ -2719,7 +2719,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E100CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E100.png"
     },
     {
         "name": "SD Mami",
@@ -2746,7 +2746,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E101PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E101.png"
     },
     {
         "name": "SD Nagisa",
@@ -2774,7 +2774,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E102PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E102.png"
     },
     {
         "name": "SD Madoka",
@@ -2799,7 +2799,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E103PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E103.png"
     },
     {
         "name": "SD Homura",
@@ -2825,7 +2825,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E104PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E104.png"
     },
     {
         "name": "SD Kyoko",
@@ -2853,7 +2853,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E105PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E105.png"
     },
     {
         "name": "SD Sayaka",
@@ -2881,7 +2881,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E106PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E106.png"
     },
     {
         "name": "Hope and Acceptance, Homura",
@@ -2910,7 +2910,7 @@
         "set": "MM",
         "release": "35",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_E107PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_E107.png"
     },
     {
         "name": "Homura in Archery Uniform",
@@ -2936,7 +2936,7 @@
         "set": "MM",
         "release": "35",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_PE01.png"
     },
     {
         "name": "Madoka in Archery Uniform",
@@ -2963,6 +2963,6 @@
         "set": "MM",
         "release": "35",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W35_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w35/MM_W35_PE02.png"
     }
 ]

--- a/DB/MM_W17.json
+++ b/DB/MM_W17.json
@@ -25,7 +25,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E001.png"
     },
     {
         "name": "Mami Tomoe",
@@ -54,7 +54,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E002.png"
     },
     {
         "name": "Kyubey Urges for a Contract",
@@ -82,7 +82,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E003.png"
     },
     {
         "name": "Senior Magical Girl, Mami",
@@ -109,7 +109,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E004.png"
     },
     {
         "name": "Mami in Pajamas",
@@ -135,7 +135,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E005.png"
     },
     {
         "name": "Mami Endures Her Fate",
@@ -163,7 +163,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E006.png"
     },
     {
         "name": "\"Sweets Witch\", Charlotte",
@@ -190,7 +190,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E007.png"
     },
     {
         "name": "Mami is \"No Longer Alone\"",
@@ -216,7 +216,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E008.png"
     },
     {
         "name": "Mami's Wish in Order to Live",
@@ -245,7 +245,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E009.png"
     },
     {
         "name": "Mami's Bind Magic",
@@ -273,7 +273,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E010.png"
     },
     {
         "name": "Mami Enjoys Tea",
@@ -300,7 +300,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E011.png"
     },
     {
         "name": "Mami's Advice",
@@ -326,7 +326,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E012.png"
     },
     {
         "name": "Veteran Magical Girl, Mami",
@@ -353,7 +353,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E013.png"
     },
     {
         "name": "Mami Passes on Hope",
@@ -379,7 +379,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E014.png"
     },
     {
         "name": "Mami Watches Over Quietly",
@@ -405,7 +405,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E015.png"
     },
     {
         "name": "Elegant Mami",
@@ -433,7 +433,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E016.png"
     },
     {
         "name": "Grief Seed",
@@ -458,7 +458,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E017.png"
     },
     {
         "name": "In an Instant",
@@ -483,7 +483,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E018.png"
     },
     {
         "name": "I'm not afraid of anything anymore",
@@ -512,7 +512,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E019.png"
     },
     {
         "name": "Tiro Finale",
@@ -540,7 +540,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E020.png"
     },
     {
         "name": "Homura's Sad Resignation",
@@ -569,7 +569,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E021.png"
     },
     {
         "name": "Madoka's \"Secret\"",
@@ -598,7 +598,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E022.png"
     },
     {
         "name": "Fair and Beautiful, Homura",
@@ -625,7 +625,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E023.png"
     },
     {
         "name": "Homura Watches Over",
@@ -651,7 +651,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E024.png"
     },
     {
         "name": "Homura's Hidden Feelings",
@@ -677,7 +677,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E025.png"
     },
     {
         "name": "Magical Girl of Bows, Madoka",
@@ -702,7 +702,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E026.png"
     },
     {
         "name": "Madoka's Swaying Feelings",
@@ -730,7 +730,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E027.png"
     },
     {
         "name": "Magical Girl of Time, Homura",
@@ -759,7 +759,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E028.png"
     },
     {
         "name": "End of Karma for Madoka",
@@ -787,7 +787,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E029.png"
     },
     {
         "name": "Ultimate Madoka",
@@ -815,7 +815,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E030.png"
     },
     {
         "name": "Madoka's Bond with Homura",
@@ -841,7 +841,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E031.png"
     },
     {
         "name": "Madoka's Battle with Walpurgisnacht",
@@ -866,7 +866,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E032.png"
     },
     {
         "name": "Madoka Protects Hope",
@@ -894,7 +894,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E033.png"
     },
     {
         "name": "Homura's Determination",
@@ -923,7 +923,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E034.png"
     },
     {
         "name": "Time Regressor, Homura",
@@ -951,7 +951,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E035.png"
     },
     {
         "name": "Homura \"Fights On\"",
@@ -980,7 +980,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E036.png"
     },
     {
         "name": "Madoka Kaname",
@@ -1009,7 +1009,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E037.png"
     },
     {
         "name": "Homura Akemi",
@@ -1038,7 +1038,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E038.png"
     },
     {
         "name": "Transfer Student, Homura",
@@ -1064,7 +1064,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E039.png"
     },
     {
         "name": "Homura, Girl Who Embraces the Bond",
@@ -1090,7 +1090,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E040.png"
     },
     {
         "name": "Homura Cares for Madoka",
@@ -1116,7 +1116,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E041.png"
     },
     {
         "name": "Madoka: \"In order to protect everyone\"",
@@ -1141,7 +1141,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E042.png"
     },
     {
         "name": "Nurse's Aide, Madoka",
@@ -1166,7 +1166,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E043.png"
     },
     {
         "name": "Hitomi Shizuki",
@@ -1191,7 +1191,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E044.png"
     },
     {
         "name": "Dark-haired Girl, Homura",
@@ -1217,7 +1217,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E045.png"
     },
     {
         "name": "Second-year of Mitakihara Middle School, Madoka",
@@ -1243,7 +1243,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E046.png"
     },
     {
         "name": "Best Friends, Madoka & Homura",
@@ -1269,7 +1269,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E047.png"
     },
     {
         "name": "Madoka of the Blue Skies",
@@ -1294,7 +1294,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E048.png"
     },
     {
         "name": "Junko Kaname",
@@ -1321,7 +1321,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E049.png"
     },
     {
         "name": "Homura's Lonely Battle",
@@ -1348,7 +1348,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E050.png"
     },
     {
         "name": "\"Stage-constructing Witch\", Walpurgisnacht",
@@ -1375,7 +1375,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E051.png"
     },
     {
         "name": "Madoka's Fluffy Skirt",
@@ -1402,7 +1402,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E052.png"
     },
     {
         "name": "Law of the Cycle",
@@ -1427,7 +1427,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E053.png"
     },
     {
         "name": "Meaningless Chain",
@@ -1452,7 +1452,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E054.png"
     },
     {
         "name": "Madoka's Wish",
@@ -1480,7 +1480,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E055.png"
     },
     {
         "name": "I won't rely on anyone anymore",
@@ -1508,7 +1508,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E056.png"
     },
     {
         "name": "Time Manipulation",
@@ -1536,7 +1536,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E057.png"
     },
     {
         "name": "My very best friend",
@@ -1564,7 +1564,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E058.png"
     },
     {
         "name": "Don't tell anyone else in class, okay?",
@@ -1592,7 +1592,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E059.png"
     },
     {
         "name": "Girl from the Dream",
@@ -1620,7 +1620,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E060.png"
     },
     {
         "name": "Aggressively Hostile Kyoko",
@@ -1647,7 +1647,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E061.png"
     },
     {
         "name": "Kyoko Sakura",
@@ -1676,7 +1676,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E062.png"
     },
     {
         "name": "Kyoko Shares an Apple",
@@ -1703,7 +1703,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E063.png"
     },
     {
         "name": "Kyoko's Multi-segment Spear",
@@ -1732,7 +1732,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E064.png"
     },
     {
         "name": "Egoist, Kyoko",
@@ -1760,7 +1760,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E065.png"
     },
     {
         "name": "Howling Kyoko",
@@ -1788,7 +1788,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E066.png"
     },
     {
         "name": "Supporting Role, Kyubey",
@@ -1814,7 +1814,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E067.png"
     },
     {
         "name": "Kyoko Confesses Her Past",
@@ -1840,7 +1840,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E068.png"
     },
     {
         "name": "Kyoko Wishes for a Miracle",
@@ -1866,7 +1866,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E069.png"
     },
     {
         "name": "Kyoko in the Alley",
@@ -1895,7 +1895,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E070.png"
     },
     {
         "name": "Kyoko's Red Soul Gem",
@@ -1921,7 +1921,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E071.png"
     },
     {
         "name": "Kyoko Parts at the Subway Platform",
@@ -1947,7 +1947,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E072.png"
     },
     {
         "name": "New Magical Girl, Kyoko",
@@ -1973,7 +1973,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E073.png"
     },
     {
         "name": "Kyoko Arrives",
@@ -1999,7 +1999,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E074.png"
     },
     {
         "name": "Extraterrestrial Lifeform, Kyubey",
@@ -2025,7 +2025,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E075.png"
     },
     {
         "name": "Magical Girl of Spears, Kyoko",
@@ -2054,7 +2054,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E076.png"
     },
     {
         "name": "Kyoko's Resolution",
@@ -2079,7 +2079,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E077.png"
     },
     {
         "name": "Magical Girl Appears",
@@ -2104,7 +2104,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E078.png"
     },
     {
         "name": "Sayaka VS Kyoko",
@@ -2132,7 +2132,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E079.png"
     },
     {
         "name": "It sure is lonely, being the only one left",
@@ -2160,7 +2160,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E080.png"
     },
     {
         "name": "Rookie Magical Girl, Sayaka",
@@ -2187,7 +2187,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E081.png"
     },
     {
         "name": "Sayaka Miki",
@@ -2217,7 +2217,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E082.png"
     },
     {
         "name": "Sayaka Fights for Others",
@@ -2244,7 +2244,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E083.png"
     },
     {
         "name": "Sayaka Looks Up to Mami",
@@ -2271,7 +2271,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E084.png"
     },
     {
         "name": "Sayaka's Healing Prayers",
@@ -2297,7 +2297,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E085.png"
     },
     {
         "name": "Sayaka's Blank Stare",
@@ -2326,7 +2326,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E086.png"
     },
     {
         "name": "Classmate, Sayaka",
@@ -2352,7 +2352,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E087.png"
     },
     {
         "name": "Sayaka Finds Her Wish",
@@ -2378,7 +2378,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E088.png"
     },
     {
         "name": "Ally of Justice, Sayaka",
@@ -2406,7 +2406,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E089.png"
     },
     {
         "name": "\"Mermaid Witch\"",
@@ -2434,7 +2434,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E090.png"
     },
     {
         "name": "Sayaka's Confrontation",
@@ -2460,7 +2460,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E091.png"
     },
     {
         "name": "Kyosuke Kamijo",
@@ -2485,7 +2485,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E092.png"
     },
     {
         "name": "Childhood Friend of Kamijo, Sayaka",
@@ -2511,7 +2511,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E093.png"
     },
     {
         "name": "Second-year of Mitakihara Middle School, Sayaka",
@@ -2537,7 +2537,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E094.png"
     },
     {
         "name": "Magical Girl of Swords, Sayaka",
@@ -2565,7 +2565,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E095.png"
     },
     {
         "name": "Sayaka Getting Hurt in the Fight",
@@ -2594,7 +2594,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E096.png"
     },
     {
         "name": "Incubator",
@@ -2619,7 +2619,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E097.png"
     },
     {
         "name": "Sayaka's Wish",
@@ -2644,7 +2644,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E098.png"
     },
     {
         "name": "I was stupid, so stupid",
@@ -2672,7 +2672,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E099.png"
     },
     {
         "name": "Miracles and magic are real",
@@ -2700,7 +2700,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E100.png"
     },
     {
         "name": "Battle with Walpurgisnacht, Homura",
@@ -2725,7 +2725,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e101.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E101.png"
     },
     {
         "name": "Common Wishes, Sayaka & Kyoko",
@@ -2753,7 +2753,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e102.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E102.png"
     },
     {
         "name": "A Lonely Fight, Homura",
@@ -2780,7 +2780,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e103.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E103.png"
     },
     {
         "name": "Smiling Sayaka",
@@ -2809,7 +2809,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e104.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E104.png"
     },
     {
         "name": "Ordinary Girl, Madoka",
@@ -2834,7 +2834,7 @@
         "set": "MM",
         "release": "17",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_e105.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_E105.png"
     },
     {
         "name": "Mini Mami",
@@ -2995,7 +2995,7 @@
         "set": "MM",
         "release": "17",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_pe02.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_PE02.png"
     },
     {
         "name": "Fighting Against Fate, Sayaka",
@@ -3021,7 +3021,7 @@
         "set": "MM",
         "release": "17",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_pe03.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_PE03.png"
     },
     {
         "name": "Fighting Against Fate, Mami",
@@ -3047,7 +3047,7 @@
         "set": "MM",
         "release": "17",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W17_PE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_PE04.png"
     },
     {
         "name": "Fighting Against Fate, Kyoko",
@@ -3073,7 +3073,7 @@
         "set": "MM",
         "release": "17",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_pe05.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_PE05.png"
     },
     {
         "name": "Swimsuit Mami",
@@ -3099,7 +3099,7 @@
         "set": "MM",
         "release": "17",
         "sid": "PE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_MM_W17_PE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_PE06.png"
     },
     {
         "name": "Dark-haired Girl, Homura",
@@ -3125,7 +3125,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te01.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE01.png"
     },
     {
         "name": "Nurse's Aide, Madoka",
@@ -3150,7 +3150,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te02.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE02.png"
     },
     {
         "name": "Madoka of the Blue Skies",
@@ -3175,7 +3175,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te03.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE03.png"
     },
     {
         "name": "Madoka Kaname",
@@ -3204,7 +3204,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE04.png"
     },
     {
         "name": "Homura Akemi",
@@ -3233,7 +3233,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/dc_w00_00.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE05.png"
     },
     {
         "name": "Law of the Cycle",
@@ -3258,7 +3258,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te06.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE06.png"
     },
     {
         "name": "I won't rely on anyone anymore!",
@@ -3286,7 +3286,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te07.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE07.png"
     },
     {
         "name": "The Girl from the Dream",
@@ -3314,7 +3314,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te08.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE08.png"
     },
     {
         "name": "Kyosuke Kamijo",
@@ -3339,7 +3339,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te09.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE09.png"
     },
     {
         "name": "Childhood Friend of Kyosuke, Sayaka",
@@ -3365,7 +3365,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te10.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE10.png"
     },
     {
         "name": "Second-year of Mitakihara Middle School, Sayaka",
@@ -3391,7 +3391,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te11.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE11.png"
     },
     {
         "name": "Magical Girl of Swords, Sayaka",
@@ -3419,7 +3419,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te12.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE12.png"
     },
     {
         "name": "Ally of Justice, Sayaka",
@@ -3447,7 +3447,7 @@
         "set": "MM",
         "release": "17",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te13.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE13.png"
     },
     {
         "name": "Miracles and magic are real",
@@ -3475,6 +3475,6 @@
         "set": "MM",
         "release": "17",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/mm_w17_te14.gif"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/m/mm_w17/MM_W17_TE14.png"
     }
 ]

--- a/DB/NKE1_WE22.json
+++ b/DB/NKE1_WE22.json
@@ -24,7 +24,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E01R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E01.png"
     },
     {
         "name": "Pajama Party, Chitoge",
@@ -54,7 +54,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E02R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E02.png"
     },
     {
         "name": "Magical Gorilla, Chitoge",
@@ -81,7 +81,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E03C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E03.png"
     },
     {
         "name": "To and From School, Raku",
@@ -108,7 +108,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E04C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E04.png"
     },
     {
         "name": "New Life! Chitoge",
@@ -134,7 +134,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E05C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E05.png"
     },
     {
         "name": "Great Style! Chitoge",
@@ -163,7 +163,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E06C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E06.png"
     },
     {
         "name": "But It's All About You",
@@ -193,7 +193,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E07C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E07.png"
     },
     {
         "name": "Neighbor, Haru",
@@ -219,7 +219,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E08R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E08.png"
     },
     {
         "name": "New Life! Haru",
@@ -246,7 +246,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E09R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E09.png"
     },
     {
         "name": "Tsugumyaa",
@@ -273,7 +273,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E10R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E10.png"
     },
     {
         "name": "Swimsuit Haru",
@@ -302,7 +302,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E11R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E11.png"
     },
     {
         "name": "Pajama Party, Haru",
@@ -330,7 +330,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E12R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E12.png"
     },
     {
         "name": "New Life! Seishiro",
@@ -357,7 +357,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E13C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E13.png"
     },
     {
         "name": "Haru's Friend, Fuu",
@@ -384,7 +384,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E14C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E14.png"
     },
     {
         "name": "Clue, Haru",
@@ -411,7 +411,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E15C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E15.png"
     },
     {
         "name": "Paula McCoy",
@@ -437,7 +437,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E16C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E16.png"
     },
     {
         "name": "From Here On, Seishiro",
@@ -464,7 +464,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E17C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E17.png"
     },
     {
         "name": "Haru Onodera",
@@ -491,7 +491,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E18C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E18.png"
     },
     {
         "name": "Beehive's “White Fang” Paula",
@@ -517,7 +517,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E19C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E19.png"
     },
     {
         "name": "Someday My Prince Will……",
@@ -546,7 +546,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E20C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E20.png"
     },
     {
         "name": "Magical Police Marika",
@@ -573,7 +573,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E21R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E21.png"
     },
     {
         "name": "Marika's Dress Look",
@@ -599,7 +599,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E22C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E22.png"
     },
     {
         "name": "New Life! Marika",
@@ -628,7 +628,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E23C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E23.png"
     },
     {
         "name": "Draw of the Shop, Haru",
@@ -655,7 +655,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E24R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E24.png"
     },
     {
         "name": "Freshman, Haru",
@@ -681,7 +681,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E25R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E25.png"
     },
     {
         "name": "Magical Patissiere, Kosaki",
@@ -710,7 +710,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E26R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E26.png"
     },
     {
         "name": "Pajama Party, Kosaki",
@@ -739,7 +739,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E27R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E27.png"
     },
     {
         "name": "Sisters Taking a Bath, Kosaki",
@@ -766,7 +766,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E28C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E28.png"
     },
     {
         "name": "Rurin",
@@ -792,7 +792,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E29C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E29.png"
     },
     {
         "name": "Fuu's Prank, Haru",
@@ -818,7 +818,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E30C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E30.png"
     },
     {
         "name": "Sisters Taking a Bath, Haru",
@@ -845,7 +845,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E31C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E31.png"
     },
     {
         "name": "1/10000 Miracle, Kosaki",
@@ -871,7 +871,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E32C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E32.png"
     },
     {
         "name": "New Life! Kosaki",
@@ -898,7 +898,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E33C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E33.png"
     },
     {
         "name": "Head Tilt Haru",
@@ -926,7 +926,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E34C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E34.png"
     },
     {
         "name": "New Life! Ruri",
@@ -954,7 +954,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E35C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E35.png"
     },
     {
         "name": "Contract Concluded☆",
@@ -983,7 +983,7 @@
         "set": "NK",
         "release": "E22",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_E36C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_E36.png"
     },
     {
         "name": "Scouting for a Magical Girl, Magical Patissiere, Kosaki",
@@ -1009,6 +1009,6 @@
         "set": "NK",
         "release": "E22",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_WE22_PE01PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_we22/NK_WE22_PE01.png"
     }
 ]

--- a/DB/NK_W30.json
+++ b/DB/NK_W30.json
@@ -26,7 +26,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E001.png"
     },
     {
         "name": "The One, Chitoge",
@@ -55,7 +55,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E002.png"
     },
     {
         "name": "Not Good at Romance, Chitoge",
@@ -82,7 +82,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E003.png"
     },
     {
         "name": "Great Disguise!? Seishiro",
@@ -108,7 +108,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E004.png"
     },
     {
         "name": "Weekend Date, Chitoge",
@@ -134,7 +134,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E005.png"
     },
     {
         "name": "Swimsuit Seishiro",
@@ -160,7 +160,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E006.png"
     },
     {
         "name": "Chitoge Out of the Bath",
@@ -187,7 +187,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E007.png"
     },
     {
         "name": "Raku Ichijo",
@@ -213,7 +213,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E008.png"
     },
     {
         "name": "Chitoge in Yukata",
@@ -239,7 +239,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E009.png"
     },
     {
         "name": "Heart Beating Faster, Seishiro",
@@ -268,7 +268,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E010.png"
     },
     {
         "name": "Swimsuit Chitoge",
@@ -296,7 +296,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E011.png"
     },
     {
         "name": "Ties with You, Chitoge",
@@ -325,7 +325,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E012.png"
     },
     {
         "name": "Wonderful Darling!? Raku",
@@ -354,7 +354,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E013.png"
     },
     {
         "name": "Childhood Chitoge",
@@ -381,7 +381,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E014.png"
     },
     {
         "name": "Change of Heart, Seishiro",
@@ -408,7 +408,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E015.png"
     },
     {
         "name": "Transfer Student, Chitoge",
@@ -434,7 +434,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E016.png"
     },
     {
         "name": "First Date, Chitoge",
@@ -460,7 +460,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E017.png"
     },
     {
         "name": "Heroine in Love",
@@ -486,7 +486,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E018.png"
     },
     {
         "name": "Seishiro Tsugumi",
@@ -514,7 +514,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E019.png"
     },
     {
         "name": "Lovers!? Chitoge",
@@ -543,7 +543,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E020.png"
     },
     {
         "name": "Claude",
@@ -571,7 +571,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E021.png"
     },
     {
         "name": "Promised Pendant",
@@ -597,7 +597,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E022.png"
     },
     {
         "name": "Diary",
@@ -626,7 +626,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E023.png"
     },
     {
         "name": "Fake Love",
@@ -656,7 +656,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E024.png"
     },
     {
         "name": "Hair Ornament",
@@ -686,7 +686,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E025.png"
     },
     {
         "name": "The One, Seishiro",
@@ -715,7 +715,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E026.png"
     },
     {
         "name": "After School Date, Kosaki",
@@ -745,7 +745,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E027.png"
     },
     {
         "name": "Learning About Love, Seishiro",
@@ -771,7 +771,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E028.png"
     },
     {
         "name": "Girl's Uniform, Seishiro",
@@ -798,7 +798,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E029.png"
     },
     {
         "name": "Swimsuit Kosaki",
@@ -827,7 +827,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E030.png"
     },
     {
         "name": "Brilliant Smile, Kosaki",
@@ -856,7 +856,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E031.png"
     },
     {
         "name": "Love Story, Seishiro",
@@ -885,7 +885,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E032.png"
     },
     {
         "name": "Draw of the Shop, Kosaki",
@@ -911,7 +911,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E033.png"
     },
     {
         "name": "Transfer Student, Seishiro",
@@ -938,7 +938,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E034.png"
     },
     {
         "name": "Fateful Lottery, Kosaki",
@@ -965,7 +965,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E035.png"
     },
     {
         "name": "Crack Hit-man, Seishiro",
@@ -992,7 +992,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E036.png"
     },
     {
         "name": "Troubled by Love, Seishiro",
@@ -1021,7 +1021,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E037.png"
     },
     {
         "name": "Seishiro Cannot be Honest with Herself",
@@ -1048,7 +1048,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E038.png"
     },
     {
         "name": "Rival!? Seishiro",
@@ -1074,7 +1074,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E039.png"
     },
     {
         "name": "Kosaki in Yukata",
@@ -1100,7 +1100,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E040.png"
     },
     {
         "name": "Seishiro in Yukata",
@@ -1126,7 +1126,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E041.png"
     },
     {
         "name": "Thoughtfulness, Raku",
@@ -1152,7 +1152,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E042.png"
     },
     {
         "name": "Gentle Smile, Kosaki",
@@ -1178,7 +1178,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E043.png"
     },
     {
         "name": "Shocking Truth, Seishiro",
@@ -1206,7 +1206,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E044.png"
     },
     {
         "name": "Overwhelming Feelings, Kosaki",
@@ -1234,7 +1234,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E045.png"
     },
     {
         "name": "Promised Pendant",
@@ -1261,7 +1261,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E046.png"
     },
     {
         "name": "Poker Face!?",
@@ -1287,7 +1287,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E047.png"
     },
     {
         "name": "Huge Back",
@@ -1316,7 +1316,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E048.png"
     },
     {
         "name": "\"Close Quarters\"",
@@ -1345,7 +1345,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E049.png"
     },
     {
         "name": "Your Only Juliet",
@@ -1374,7 +1374,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E050.png"
     },
     {
         "name": "Deep Friendship, Chitoge",
@@ -1403,7 +1403,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E051.png"
     },
     {
         "name": "The One, Marika",
@@ -1432,7 +1432,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E052.png"
     },
     {
         "name": "Surprising Side, Chitoge",
@@ -1459,7 +1459,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E053.png"
     },
     {
         "name": "Aggressive Girl, Marika",
@@ -1486,7 +1486,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E054.png"
     },
     {
         "name": "Chitoge as Juliet",
@@ -1513,7 +1513,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E055.png"
     },
     {
         "name": "Marika's Ordeal",
@@ -1539,7 +1539,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E056.png"
     },
     {
         "name": "Police Commissioner's Daughter, Marika",
@@ -1568,7 +1568,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E057.png"
     },
     {
         "name": "First Love, Chitoge",
@@ -1595,7 +1595,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E058.png"
     },
     {
         "name": "Head Tilt Marika",
@@ -1622,7 +1622,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E059.png"
     },
     {
         "name": "Words of Promise, Chitoge",
@@ -1649,7 +1649,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E060.png"
     },
     {
         "name": "Sweet Princess, Marika",
@@ -1676,7 +1676,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E061.png"
     },
     {
         "name": "Promise of a Date, Marika",
@@ -1705,7 +1705,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E062.png"
     },
     {
         "name": "Marika in Yukata",
@@ -1732,7 +1732,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E063.png"
     },
     {
         "name": "Spoiled Child, Marika",
@@ -1758,7 +1758,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E064.png"
     },
     {
         "name": "Long-awaited Reunion, Marika",
@@ -1784,7 +1784,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E065.png"
     },
     {
         "name": "Fake Lovers, Raku",
@@ -1810,7 +1810,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E066.png"
     },
     {
         "name": "Transfer Student, Marika",
@@ -1836,7 +1836,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E067.png"
     },
     {
         "name": "Chitoge as a Ghost",
@@ -1865,7 +1865,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E068.png"
     },
     {
         "name": "Incomprehensible, Chitoge",
@@ -1894,7 +1894,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E069.png"
     },
     {
         "name": "Raku's Fiancee, Marika",
@@ -1922,7 +1922,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E070.png"
     },
     {
         "name": "Promised Pendant",
@@ -1948,7 +1948,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E071.png"
     },
     {
         "name": "For Your Sake…",
@@ -1974,7 +1974,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E072.png"
     },
     {
         "name": "Feelings for the Last 10 Years",
@@ -2003,7 +2003,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E073.png"
     },
     {
         "name": "Adlib",
@@ -2032,7 +2032,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E074.png"
     },
     {
         "name": "Beloved Juliet",
@@ -2061,7 +2061,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E075.png"
     },
     {
         "name": "The One, Kosaki",
@@ -2091,7 +2091,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E076.png"
     },
     {
         "name": "Non-stop Attacks, Marika",
@@ -2120,7 +2120,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E077RR.png"
     },
     {
         "name": "Swimsuit Marika",
@@ -2147,7 +2147,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E078.png"
     },
     {
         "name": "Infatuation, Marika",
@@ -2174,7 +2174,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E079.png"
     },
     {
         "name": "First Visit, Kosaki",
@@ -2201,7 +2201,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E080.png"
     },
     {
         "name": "Angel in White, Kosaki",
@@ -2230,7 +2230,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E081.png"
     },
     {
         "name": "Girl in Glasses, Ruri",
@@ -2259,7 +2259,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E082.png"
     },
     {
         "name": "Kosaki's Close Friend, Ruri",
@@ -2286,7 +2286,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E083.png"
     },
     {
         "name": "Two of a Kind, Raku",
@@ -2313,7 +2313,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E084.png"
     },
     {
         "name": "Mischievous Kiss, Marika",
@@ -2340,7 +2340,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E085.png"
     },
     {
         "name": "Their Progress, Kosaki",
@@ -2366,7 +2366,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E086.png"
     },
     {
         "name": "Head Tilt Kosaki",
@@ -2393,7 +2393,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E087.png"
     },
     {
         "name": "Fake Love!? Kosaki",
@@ -2422,7 +2422,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E088.png"
     },
     {
         "name": "Gentle Profile, Kosaki",
@@ -2448,7 +2448,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E089.png"
     },
     {
         "name": "Moodmaker, Shu",
@@ -2474,7 +2474,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E090.png"
     },
     {
         "name": "At the Secret Place, Kosaki",
@@ -2501,7 +2501,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E091.png"
     },
     {
         "name": "Kosaki in Denial",
@@ -2527,7 +2527,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E092.png"
     },
     {
         "name": "Love Triangle? Raku",
@@ -2553,7 +2553,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E093.png"
     },
     {
         "name": "Swimsuit Ruri",
@@ -2579,7 +2579,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E094.png"
     },
     {
         "name": "Modest Personality, Kosaki",
@@ -2607,7 +2607,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E095.png"
     },
     {
         "name": "Marika Tachibana",
@@ -2635,7 +2635,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E096.png"
     },
     {
         "name": "Promised Pendant",
@@ -2661,7 +2661,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E097.png"
     },
     {
         "name": "I told…… a lie……",
@@ -2690,7 +2690,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E098.png"
     },
     {
         "name": "Promise from Long Ago",
@@ -2719,7 +2719,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E099.png"
     },
     {
         "name": "Exchanged Promises",
@@ -2748,7 +2748,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E100.png"
     },
     {
         "name": "Mini Chitoge",
@@ -2906,7 +2906,7 @@
         "set": "NK",
         "release": "30",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_E016PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_E106.png"
     },
     {
         "name": "To the Highest Stage, Chitoge",
@@ -2935,7 +2935,7 @@
         "set": "NK",
         "release": "30",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_PE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_PE04.png"
     },
     {
         "name": "To the Highest Stage, Kosaki",
@@ -2963,7 +2963,7 @@
         "set": "NK",
         "release": "30",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_PE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_PE05.png"
     },
     {
         "name": "Raku Ichijo",
@@ -2989,7 +2989,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE01.png"
     },
     {
         "name": "Transfer Student, Chitoge",
@@ -3015,7 +3015,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE02.png"
     },
     {
         "name": "First Date, Chitoge",
@@ -3041,7 +3041,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE03.png"
     },
     {
         "name": "Seishiro Tsugumi",
@@ -3069,7 +3069,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE04.png"
     },
     {
         "name": "Lovers!? Chitoge",
@@ -3098,7 +3098,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE05.png"
     },
     {
         "name": "Love Triangle? Chitoge",
@@ -3126,7 +3126,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE06.png"
     },
     {
         "name": "Chitoge Kirisaki",
@@ -3155,7 +3155,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE07.png"
     },
     {
         "name": "Promised Pendant",
@@ -3181,7 +3181,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE08.png"
     },
     {
         "name": "Fake Love",
@@ -3211,7 +3211,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE09.png"
     },
     {
         "name": "Gentle Profile, Kosaki",
@@ -3237,7 +3237,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE10.png"
     },
     {
         "name": "Ruri Miyamoto",
@@ -3263,7 +3263,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE11.png"
     },
     {
         "name": "Kosaki in Denial",
@@ -3289,7 +3289,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE12.png"
     },
     {
         "name": "Love Triangle? Kosaki",
@@ -3316,7 +3316,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE13.png"
     },
     {
         "name": "Love Triangle? Raku",
@@ -3342,7 +3342,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE14.png"
     },
     {
         "name": "Head Tilt Kosaki",
@@ -3369,7 +3369,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE15.png"
     },
     {
         "name": "Kosaki Onodera",
@@ -3397,7 +3397,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE16.png"
     },
     {
         "name": "Marika Tachibana",
@@ -3425,7 +3425,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE17.png"
     },
     {
         "name": "Promise from Long Ago",
@@ -3454,7 +3454,7 @@
         "set": "NK",
         "release": "30",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE18.png"
     },
     {
         "name": "I told…… a lie……",
@@ -3483,6 +3483,6 @@
         "set": "NK",
         "release": "30",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NK_W30_TE19.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nk_w30/NK_W30_TE19.png"
     }
 ]

--- a/DB/NM_S24.json
+++ b/DB/NM_S24.json
@@ -25,7 +25,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E001RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E001.png"
     },
     {
         "name": "Master-servant Relationship, Shinobu Oshino",
@@ -54,7 +54,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E002RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E002.png"
     },
     {
         "name": "The Way Back, Shinobu Oshino",
@@ -81,7 +81,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E003R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E003.png"
     },
     {
         "name": "Blessing of the Moon, Shinobu Oshino",
@@ -107,7 +107,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E004R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E004.png"
     },
     {
         "name": "Words of \"Courage\", Mayoi Hachikuji",
@@ -133,7 +133,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E005R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E005.png"
     },
     {
         "name": "Serious Mode, Shinobu Oshino",
@@ -161,7 +161,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E006R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E006.png"
     },
     {
         "name": "Sake of Cooperation, Shinobu Oshino",
@@ -187,7 +187,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E007U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E007.png"
     },
     {
         "name": "Primp and Proper, Nadeko Sengoku",
@@ -213,7 +213,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E008U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E008.png"
     },
     {
         "name": "Vampire's Dignity, Shinobu Oshino",
@@ -239,7 +239,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E009U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E009.png"
     },
     {
         "name": "Resident of the Shadows, Shinobu Oshino",
@@ -267,7 +267,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E010U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E010.png"
     },
     {
         "name": "Flower Garden Shinobu Oshino",
@@ -295,7 +295,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E011U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E011.png"
     },
     {
         "name": "Sudden Attack, Koyomi Araragi",
@@ -321,7 +321,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E012C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E012.png"
     },
     {
         "name": "Shinobu Oshino in the Shadows",
@@ -347,7 +347,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E013C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E013.png"
     },
     {
         "name": "First Visitor, Nadeko Sengoku",
@@ -372,7 +372,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E014C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E014.png"
     },
     {
         "name": "Shinobu Oshino in a Good Mood",
@@ -398,7 +398,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E015C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E015.png"
     },
     {
         "name": "Blond with Gold Eyes, Shinobu Oshino",
@@ -426,7 +426,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E016C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E016.png"
     },
     {
         "name": "Being Bashful, Mayoi Hachikuji",
@@ -454,7 +454,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E017C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E017.png"
     },
     {
         "name": "Ritual One Level Higher",
@@ -479,7 +479,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E018U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E018.png"
     },
     {
         "name": "Encounter in the Ruins",
@@ -507,7 +507,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E019CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E019.png"
     },
     {
         "name": "Welcome",
@@ -536,7 +536,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E020CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E020.png"
     },
     {
         "name": "“Fire Sisters” Karen Araragi",
@@ -562,7 +562,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E021RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E021.png"
     },
     {
         "name": "As Lovers, Hitagi Senjyogahara",
@@ -589,7 +589,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E022RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E022.png"
     },
     {
         "name": "Combat Role, Karen Araragi",
@@ -616,7 +616,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E023R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E023.png"
     },
     {
         "name": "Benefactor's Advice, Tsubasa Hanekawa",
@@ -642,7 +642,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E024R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E024.png"
     },
     {
         "name": "Girl Who Was Given a Bee, Karen Araragi",
@@ -671,7 +671,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E025R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E025.png"
     },
     {
         "name": "Someone to Protect, Hitagi Senjyogahara",
@@ -699,7 +699,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E026R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E026.png"
     },
     {
         "name": "“Wreathe-fire Bee” Karen Araragi",
@@ -728,7 +728,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E027R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E027.png"
     },
     {
         "name": "Bigger of the Sisters, Karen Araragi",
@@ -755,7 +755,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E028U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E028.png"
     },
     {
         "name": "“Fake” Deishu Kaiki",
@@ -781,7 +781,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E029U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E029.png"
     },
     {
         "name": "Sharp Intuition, Hitagi Senjyogahara",
@@ -807,7 +807,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E030U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E030.png"
     },
     {
         "name": "Brushing Teeth, Karen Araragi",
@@ -834,7 +834,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E031U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E031.png"
     },
     {
         "name": "Light-hearted, Karen Araragi",
@@ -860,7 +860,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E032U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E032.png"
     },
     {
         "name": "Playing With Cards, Suruga Kanbaru",
@@ -886,7 +886,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E033U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E033.png"
     },
     {
         "name": "A Morning Sight, Karen Araragi",
@@ -914,7 +914,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E034U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E034.png"
     },
     {
         "name": "Tutor, Tsubasa Hanekawa",
@@ -940,7 +940,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E035C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E035.png"
     },
     {
         "name": "Pride of an Elder Brother, Koyomi Araragi",
@@ -966,7 +966,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E036C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E036.png"
     },
     {
         "name": "Celebrity of Tsuganoki 2nd Middle School, Karen Araragi",
@@ -992,7 +992,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E037C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E037.png"
     },
     {
         "name": "“What is Justice” Karen Araragi",
@@ -1018,7 +1018,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E038C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E038.png"
     },
     {
         "name": "Family Bond, Karen Araragi",
@@ -1044,7 +1044,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E039C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E039.png"
     },
     {
         "name": "Innocence, Suruga Kanbaru",
@@ -1073,7 +1073,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E040C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E040.png"
     },
     {
         "name": "Mischievous Nature, Tsubasa Hanekawa",
@@ -1101,7 +1101,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E041C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E041.png"
     },
     {
         "name": "Teeth Brushing Time",
@@ -1129,7 +1129,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E042CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E042.png"
     },
     {
         "name": "Sandy Beach for Two",
@@ -1157,7 +1157,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E043CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E043.png"
     },
     {
         "name": "Girl Who Knows Anything",
@@ -1185,7 +1185,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E044CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E044.png"
     },
     {
         "name": "KAREN Bee",
@@ -1213,7 +1213,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E045CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E045.png"
     },
     {
         "name": "Cuckoo Girl, Tsukihi Araragi",
@@ -1239,7 +1239,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E046RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E046.png"
     },
     {
         "name": "Immortal Strange, Tsukihi Araragi",
@@ -1267,7 +1267,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E047RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E047.png"
     },
     {
         "name": "Farewell to the Past, Hitagi Senjyogahara",
@@ -1292,7 +1292,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E048R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E048.png"
     },
     {
         "name": "“Phoenix” Tsukihi Araragi",
@@ -1318,7 +1318,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E049R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E049.png"
     },
     {
         "name": "Sense of Liberation, Suruga Kanbaru",
@@ -1345,7 +1345,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E050R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E050.png"
     },
     {
         "name": "Celebrity of Tsuganoki 2nd Middle School, Tsukihi Araragi",
@@ -1374,7 +1374,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E051R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E051.png"
     },
     {
         "name": "Usual Parting, Mayoi Hachikuji",
@@ -1402,7 +1402,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E052R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E052.png"
     },
     {
         "name": "Promise Exchange, Mayoi Hachikuji",
@@ -1428,7 +1428,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E053U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E053.png"
     },
     {
         "name": "Accelerator, Suruga Kanbaru",
@@ -1454,7 +1454,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E054U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E054.png"
     },
     {
         "name": "Matters of Younger Sisters, Koyomi Araragi",
@@ -1481,7 +1481,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E055U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E055.png"
     },
     {
         "name": "“Fire Sisters” Tsukihi Araragi",
@@ -1507,7 +1507,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E056U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E056.png"
     },
     {
         "name": "Advisor Role, Tsukihi Araragi",
@@ -1535,7 +1535,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E057U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E057.png"
     },
     {
         "name": "Passionate Personality, Tsukihi Araragi",
@@ -1564,7 +1564,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E058U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E058.png"
     },
     {
         "name": "Loves Kimono, Tsukihi Araragi",
@@ -1591,7 +1591,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E059C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E059.png"
     },
     {
         "name": "Smaller of the Sisters, Tsukihi Araragi",
@@ -1617,7 +1617,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E060C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E060.png"
     },
     {
         "name": "Tea Ceremony Club, Tsukihi Araragi",
@@ -1643,7 +1643,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E061C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E061.png"
     },
     {
         "name": "A Morning Sight, Tsukihi Araragi",
@@ -1670,7 +1670,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E062C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E062.png"
     },
     {
         "name": "Unexpected Words, Hitagi Senjyogahara",
@@ -1695,7 +1695,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E063C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E063.png"
     },
     {
         "name": "Secret Conversation, Mayoi Hachikuji",
@@ -1721,7 +1721,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E064C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E064.png"
     },
     {
         "name": "“Pervert” Suruga Kanbaru",
@@ -1749,7 +1749,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E065C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E065.png"
     },
     {
         "name": "Usual Occurrence",
@@ -1774,7 +1774,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E066U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E066.png"
     },
     {
         "name": "TSUKIHI Phoenix",
@@ -1802,7 +1802,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E067CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E067.png"
     },
     {
         "name": "I flubbed it!",
@@ -1830,7 +1830,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E068CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E068.png"
     },
     {
         "name": "Handling Memories",
@@ -1858,7 +1858,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E069CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E069.png"
     },
     {
         "name": "Platinum Mad",
@@ -1886,7 +1886,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E070CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E070.png"
     },
     {
         "name": "Koyomi Araragi Heading for Battle",
@@ -1912,7 +1912,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E071RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E071.png"
     },
     {
         "name": "Hairband, Nadeko Sengoku",
@@ -1938,7 +1938,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E072R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E072.png"
     },
     {
         "name": "Sisters' Helper, Tsubasa Hanekawa",
@@ -1964,7 +1964,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E073U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E073.png"
     },
     {
         "name": "Shikigami, Yotsugi Ononoki",
@@ -1990,7 +1990,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E074U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E074.png"
     },
     {
         "name": "Unlimited Rulebook, Yotsugi Ononoki",
@@ -2016,7 +2016,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E075C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E075.png"
     },
     {
         "name": "Way Back, Tsubasa Hanekawa",
@@ -2042,7 +2042,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E076C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E076.png"
     },
     {
         "name": "Playing Together, Nadeko Sengoku",
@@ -2069,7 +2069,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E077C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E077.png"
     },
     {
         "name": "Onmyoji, Yozuru Kagenui",
@@ -2097,7 +2097,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E078C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E078.png"
     },
     {
         "name": "Loser's Bravado",
@@ -2122,7 +2122,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E079U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E079.png"
     },
     {
         "name": "Family Matters",
@@ -2150,7 +2150,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E080CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E080.png"
     },
     {
         "name": "Vanpire's Bond, Shinobu Oshino",
@@ -2176,7 +2176,7 @@
         "set": "NM",
         "release": "24",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_E081PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_E081PR.png"
     },
     {
         "name": "Friendly Sisters, Tsukihi Araragi & Karen Araragi",
@@ -2202,7 +2202,7 @@
         "set": "NM",
         "release": "24",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_PE01PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_PE01.png"
     },
     {
         "name": "Burning Girl, Karen Araragi",
@@ -2230,7 +2230,7 @@
         "set": "NM",
         "release": "24",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_PE03PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_PE03.png"
     },
     {
         "name": "A Sister to Be Proud Of, Karen Araragi",
@@ -2281,7 +2281,7 @@
         "set": "NM",
         "release": "24",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_PE05PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_PE05.png"
     },
     {
         "name": "Celebrity of Tsuganoki 2nd Middle School, Karen Araragi",
@@ -2307,7 +2307,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE01.png"
     },
     {
         "name": "Brushing Teeth, Karen Araragi",
@@ -2334,7 +2334,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE02.png"
     },
     {
         "name": "Light-hearted, Karen Araragi",
@@ -2360,7 +2360,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE03.png"
     },
     {
         "name": "A Morning Sight, Karen Araragi",
@@ -2388,7 +2388,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE04.png"
     },
     {
         "name": "Mischievous Nature, Tsubasa Hanekawa",
@@ -2416,7 +2416,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE05.png"
     },
     {
         "name": "“Wreathe-fire Bee” Karen Araragi",
@@ -2445,7 +2445,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE06.png"
     },
     {
         "name": "Teeth Brushing Time",
@@ -2473,7 +2473,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE07.png"
     },
     {
         "name": "Smaller of the Sisters, Tsukihi Araragi",
@@ -2499,7 +2499,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE08.png"
     },
     {
         "name": "Tea Ceremony Club, Tsukihi Araragi",
@@ -2525,7 +2525,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE09.png"
     },
     {
         "name": "Advisor Role, Tsukihi Araragi",
@@ -2553,7 +2553,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE10.png"
     },
     {
         "name": "“Pervert” Suruga Kanbaru",
@@ -2581,7 +2581,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE11.png"
     },
     {
         "name": "TSUKIHI Phoenix",
@@ -2609,7 +2609,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE12.png"
     },
     {
         "name": "Platinum Mad",
@@ -2637,7 +2637,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE13.png"
     },
     {
         "name": "“Hero of Justice” Karen Araragi",
@@ -2663,7 +2663,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE14.png"
     },
     {
         "name": "Heroes of Justice Game, Karen Araragi & Tsukihi Araragi",
@@ -2689,7 +2689,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE15.png"
     },
     {
         "name": "Noisy Morning, Karen Araragi & Tsukihi Araragi",
@@ -2717,7 +2717,7 @@
         "set": "NM",
         "release": "24",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE16.png"
     },
     {
         "name": "“Hero of Justice” Tsukihi Araragi",
@@ -2745,6 +2745,6 @@
         "set": "NM",
         "release": "24",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_NM_S24_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/n/nm_s24/NM_S24_TE17.png"
     }
 ]

--- a/DB/OVL_S62.json
+++ b/DB/OVL_S62.json
@@ -24,7 +24,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E001.png"
     },
     {
         "name": "Hero of Heroes, Momon",
@@ -51,7 +51,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E002.png"
     },
     {
         "name": "Entomancer, Entoma",
@@ -78,7 +78,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E003.png"
     },
     {
         "name": "Nazarick's Maid Intern, Tuare",
@@ -104,7 +104,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E004.png"
     },
     {
         "name": "Commending Humans, Momon",
@@ -133,7 +133,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E005.png"
     },
     {
         "name": "Tuare's Rescue Operation, Sebas",
@@ -162,7 +162,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E006.png"
     },
     {
         "name": "Nazarick's Values, Nabe",
@@ -192,7 +192,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E007.png"
     },
     {
         "name": "Demon King, Jaldabaoth",
@@ -221,7 +221,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E008.png"
     },
     {
         "name": "Infiltration of the Capital, Shalltear",
@@ -248,7 +248,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E009.png"
     },
     {
         "name": "Undefeated Warrior, Momon",
@@ -275,7 +275,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E010.png"
     },
     {
         "name": "Ingenious Demon, Demiurge",
@@ -302,7 +302,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E011.png"
     },
     {
         "name": "Cold Reaction, Nabe",
@@ -331,7 +331,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E012.png"
     },
     {
         "name": "Details of Operation Gehenna, Demiurge",
@@ -360,7 +360,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E013.png"
     },
     {
         "name": "Where Happiness Is, Tuare",
@@ -386,7 +386,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E014.png"
     },
     {
         "name": "Dissolution Vessel, Solution",
@@ -412,7 +412,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E015.png"
     },
     {
         "name": "Djungarian Hamster? Hamusuke",
@@ -438,7 +438,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E016.png"
     },
     {
         "name": "Bug-Loving Maid, Entoma",
@@ -464,7 +464,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E017.png"
     },
     {
         "name": "Embodiment of Justice, Sebas",
@@ -490,7 +490,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E018.png"
     },
     {
         "name": "Stupefied, Nabe",
@@ -517,7 +517,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E019.png"
     },
     {
         "name": "Subjugation of the Wise King of the Forest, Momon",
@@ -544,7 +544,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E020.png"
     },
     {
         "name": "Kiss of Happiness",
@@ -570,7 +570,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E021.png"
     },
     {
         "name": "Wise King of the Forest",
@@ -596,7 +596,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E022.png"
     },
     {
         "name": "The Curtains Rise on a Legend",
@@ -626,7 +626,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E023.png"
     },
     {
         "name": "Operation Gehenna",
@@ -656,7 +656,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E024.png"
     },
     {
         "name": "Butler of Steel",
@@ -686,7 +686,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E025.png"
     },
     {
         "name": "Master of Great Tomb of Nazarick, Ainz",
@@ -713,7 +713,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E026.png"
     },
     {
         "name": "Unreliable Nature Manipulator, Mare",
@@ -740,7 +740,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E027.png"
     },
     {
         "name": "Boundless Obsessive Love, Albedo",
@@ -767,7 +767,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E028.png"
     },
     {
         "name": "Energetic Beast Tamer, Aura",
@@ -796,7 +796,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E029.png"
     },
     {
         "name": "Emotion Inhibition, Ainz",
@@ -823,7 +823,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E030.png"
     },
     {
         "name": "Protector of the Treasury, Pandora's Actor",
@@ -850,7 +850,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E031.png"
     },
     {
         "name": "Death Knight",
@@ -877,7 +877,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E032.png"
     },
     {
         "name": "A Woman's Battle, Albedo",
@@ -906,7 +906,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E033.png"
     },
     {
         "name": "Remains of a Dark Past, Pandora's Actor",
@@ -932,7 +932,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E034.png"
     },
     {
         "name": "Precious Watch, Aura",
@@ -959,7 +959,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E035.png"
     },
     {
         "name": "A Ring of Reward, Mare",
@@ -988,7 +988,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E036.png"
     },
     {
         "name": "Allure of Position of Uncle, Cocytus",
@@ -1015,7 +1015,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E037.png"
     },
     {
         "name": "Ecstatic Respect and Affection, Albedo",
@@ -1044,7 +1044,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E038.png"
     },
     {
         "name": "Absolute Loyalty, Demiurge",
@@ -1073,7 +1073,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E039.png"
     },
     {
         "name": "Elder Sister of the Battle Maids, Yuri",
@@ -1102,7 +1102,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E040.png"
     },
     {
         "name": "Assault Maid, CZ2128・Δ",
@@ -1128,7 +1128,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E041.png"
     },
     {
         "name": "Command Mantra, Demiurge",
@@ -1155,7 +1155,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E042.png"
     },
     {
         "name": "Sadist with a Smile, Lupusregina",
@@ -1181,7 +1181,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E043.png"
     },
     {
         "name": "Financial Management, Ainz",
@@ -1210,7 +1210,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E044.png"
     },
     {
         "name": "Oval Battle Maid, Narberal",
@@ -1239,7 +1239,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E045.png"
     },
     {
         "name": "As a Warrior, Cocytus",
@@ -1267,7 +1267,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E046.png"
     },
     {
         "name": "Freezing Spell",
@@ -1293,7 +1293,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E047.png"
     },
     {
         "name": "Benevolent Pure White Demon",
@@ -1322,7 +1322,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E048.png"
     },
     {
         "name": "A Woman's Nature",
@@ -1351,7 +1351,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E049.png"
     },
     {
         "name": "Floor Guardian Twins",
@@ -1380,7 +1380,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E050.png"
     },
     {
         "name": "Crimson Red Battle Maiden, Shalltear",
@@ -1407,7 +1407,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E051.png"
     },
     {
         "name": "Infinite Loyalty, Albedo",
@@ -1437,7 +1437,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E052.png"
     },
     {
         "name": "Overlord, Ainz",
@@ -1467,7 +1467,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E053.png"
     },
     {
         "name": "Strongest Magic Caster, Ainz",
@@ -1494,7 +1494,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E054.png"
     },
     {
         "name": "Defender of the Throne, Albedo",
@@ -1521,7 +1521,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E055.png"
     },
     {
         "name": "Cute Blunder, Albedo",
@@ -1551,7 +1551,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E056.png"
     },
     {
         "name": "Ability of a Floor Guardian, Shalltear",
@@ -1580,7 +1580,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E057.png"
     },
     {
         "name": "8th Floor Guardian, Victim",
@@ -1607,7 +1607,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E058.png"
     },
     {
         "name": "Vampire Bride",
@@ -1634,7 +1634,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E059.png"
     },
     {
         "name": "Reason for the Handicap, Ainz",
@@ -1660,7 +1660,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E060.png"
     },
     {
         "name": "A Woman's Battle, Shalltear",
@@ -1686,7 +1686,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E061.png"
     },
     {
         "name": "True Vampire Ancestor, Shalltear",
@@ -1713,7 +1713,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E062.png"
     },
     {
         "name": "4th Floor Guardian, Gargantua",
@@ -1742,7 +1742,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E063.png"
     },
     {
         "name": "Leader of Pleiades, Sebas",
@@ -1769,7 +1769,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E064.png"
     },
     {
         "name": "Assistant Butler, Eclair",
@@ -1796,7 +1796,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E065.png"
     },
     {
         "name": "Nature of a Floor Guardian, Albedo",
@@ -1823,7 +1823,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E066.png"
     },
     {
         "name": "True Power, Ainz",
@@ -1849,7 +1849,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E067.png"
     },
     {
         "name": "Crazed Bloodlust, Shalltear",
@@ -1875,7 +1875,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E068.png"
     },
     {
         "name": "Resurrection Ritual, Ainz",
@@ -1904,7 +1904,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E069.png"
     },
     {
         "name": "Diversionary Tactics, Sebas",
@@ -1933,7 +1933,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E070.png"
     },
     {
         "name": "Shooting Star",
@@ -1962,7 +1962,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E071.png"
     },
     {
         "name": "〈Fallen Down〉",
@@ -1989,7 +1989,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E072.png"
     },
     {
         "name": "〈Grasp Heart〉",
@@ -2018,7 +2018,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E073.png"
     },
     {
         "name": "Shalltear's Resurrection",
@@ -2048,7 +2048,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E074.png"
     },
     {
         "name": "Pipette Lance",
@@ -2077,7 +2077,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E075.png"
     },
     {
         "name": "\"Blue Rose\" Evileye",
@@ -2106,7 +2106,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E076.png"
     },
     {
         "name": "The Golden Princess, Renner",
@@ -2133,7 +2133,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E077.png"
     },
     {
         "name": "A Maiden's Heart, Evileye",
@@ -2160,7 +2160,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E078.png"
     },
     {
         "name": "White-Scaled Beauty, Crusch",
@@ -2187,7 +2187,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E079.png"
     },
     {
         "name": "\"Blue Rose\" Lakyus",
@@ -2214,7 +2214,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E080.png"
     },
     {
         "name": "Honorable Warrior, Cocytus",
@@ -2244,7 +2244,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E081.png"
     },
     {
         "name": "A New Legend, Momon",
@@ -2273,7 +2273,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E082.png"
     },
     {
         "name": "Battle to Protect a Kingdom, Momon",
@@ -2300,7 +2300,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E083.png"
     },
     {
         "name": "Grotesque Hydra, Rororo",
@@ -2327,7 +2327,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E084.png"
     },
     {
         "name": "Strongest Lizardman Warrior, Zaryusu",
@@ -2354,7 +2354,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E085.png"
     },
     {
         "name": "Invisibility Magic, Evileye",
@@ -2383,7 +2383,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E086.png"
     },
     {
         "name": "Kingdom's Head Warrior, Gazef",
@@ -2412,7 +2412,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E087.png"
     },
     {
         "name": "\"Blue Rose\" Tina",
@@ -2439,7 +2439,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E088.png"
     },
     {
         "name": "Extreme Love, Renner",
@@ -2465,7 +2465,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E089.png"
     },
     {
         "name": "\"Blue Rose\" Tia",
@@ -2492,7 +2492,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E090.png"
     },
     {
         "name": "\"Green Claw\" Cheftian Shasuryu",
@@ -2518,7 +2518,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E091.png"
     },
     {
         "name": "Struggles of the Untalented, Climb",
@@ -2544,7 +2544,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E092.png"
     },
     {
         "name": "Brain",
@@ -2571,7 +2571,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E093.png"
     },
     {
         "name": "\"Blue Rose\" Gagaran",
@@ -2599,7 +2599,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E094.png"
     },
     {
         "name": "Berserker with a Giant Fist, Zenberu",
@@ -2627,7 +2627,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E095.png"
     },
     {
         "name": "Frost Pain",
@@ -2653,7 +2653,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E096.png"
     },
     {
         "name": "Adamantite-Class Adventurer",
@@ -2679,7 +2679,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E097.png"
     },
     {
         "name": "5th Tier Magic Caster",
@@ -2709,7 +2709,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E098.png"
     },
     {
         "name": "Raven Black Hero",
@@ -2739,7 +2739,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E099.png"
     },
     {
         "name": "Ruler of the Frozen Lake",
@@ -2768,7 +2768,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E100.png"
     },
     {
         "name": "Nazarick's Loyal Retainer, Demiurge",
@@ -2795,7 +2795,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E101.png"
     },
     {
         "name": "Unique Speech Mannerisms, Shalltear",
@@ -2824,7 +2824,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E102.png"
     },
     {
         "name": "To the Most Beloved One, Albedo",
@@ -2850,7 +2850,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E103.png"
     },
     {
         "name": "Supreme in a Weapons Battle, Cocytus",
@@ -2876,7 +2876,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E104.png"
     },
     {
         "name": "Bashful Effeminate Boy, Mare",
@@ -2903,7 +2903,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E105.png"
     },
     {
         "name": "Breath of Mental Manipulation, Aura",
@@ -2932,7 +2932,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_E106.png"
     },
     {
         "name": "Joyful Exclamation, Albedo",
@@ -2988,7 +2988,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE01.png"
     },
     {
         "name": "6th Floor Guardian, Aura",
@@ -3014,7 +3014,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE02.png"
     },
     {
         "name": "Scheming Demon, Demiurge",
@@ -3041,7 +3041,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE03.png"
     },
     {
         "name": "Lunchtime, Aura",
@@ -3067,7 +3067,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE04.png"
     },
     {
         "name": "Innocent Insult, Mare",
@@ -3095,7 +3095,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE05.png"
     },
     {
         "name": "Butler of Great Tomb of Nazarick, Sebas",
@@ -3121,7 +3121,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE06.png"
     },
     {
         "name": "7th Floor Guardian, Demiurge",
@@ -3150,7 +3150,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE07.png"
     },
     {
         "name": "5th Floor Guardian, Cocytus",
@@ -3179,7 +3179,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE08.png"
     },
     {
         "name": "Endless Devotion, Albedo",
@@ -3208,7 +3208,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE09.png"
     },
     {
         "name": "Loyalty Ritual",
@@ -3237,7 +3237,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE10.png"
     },
     {
         "name": "The End and the Beginning, Momonga",
@@ -3264,7 +3264,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE11.png"
     },
     {
         "name": "Overseer of Floor Guardians, Albedo",
@@ -3290,7 +3290,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE12.png"
     },
     {
         "name": "1st to 3rd Floor Guardian, Shalltear",
@@ -3317,7 +3317,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE13.png"
     },
     {
         "name": "Benevolent Overlord, Ainz",
@@ -3343,7 +3343,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE14.png"
     },
     {
         "name": "The End and the Beginning, Albedo",
@@ -3369,7 +3369,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE15.png"
     },
     {
         "name": "Crimson Red Tyrant, Shalltear",
@@ -3398,7 +3398,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE16.png"
     },
     {
         "name": "Ruler of Death, Ainz",
@@ -3427,7 +3427,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE17.png"
     },
     {
         "name": "Ring of Ainz Ooal Gown",
@@ -3453,7 +3453,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE18.png"
     },
     {
         "name": "The Curtain Closes",
@@ -3482,7 +3482,7 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE19.png"
     },
     {
         "name": "Staff of Ainz Ooal Gown",
@@ -3511,6 +3511,6 @@
         "set": "OVL",
         "release": "62",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/OVL_S62_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/o/ovl_s62/OVL_S62_TE20.png"
     }
 ]

--- a/DB/P4_S01.json
+++ b/DB/P4_S01.json
@@ -27,7 +27,7 @@
         "set": "P4",
         "release": "01",
         "sid": "001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_001.png"
     },
     {
         "name": "Yosuke in Yukata",
@@ -53,7 +53,7 @@
         "set": "P4",
         "release": "01",
         "sid": "002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_002.png"
     },
     {
         "name": "Protagonist & Izanagi-no-Okami",
@@ -82,7 +82,7 @@
         "set": "P4",
         "release": "01",
         "sid": "003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_003.png"
     },
     {
         "name": "Loves Junes! Nanako",
@@ -111,7 +111,7 @@
         "set": "P4",
         "release": "01",
         "sid": "004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_004.png"
     },
     {
         "name": "Store Manager's Son, Yosuke",
@@ -139,7 +139,7 @@
         "set": "P4",
         "release": "01",
         "sid": "005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_005.png"
     },
     {
         "name": "Nanako Dojima",
@@ -166,7 +166,7 @@
         "set": "P4",
         "release": "01",
         "sid": "006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_006.png"
     },
     {
         "name": "Liquor Store's Daughter, Saki Konishi",
@@ -195,7 +195,7 @@
         "set": "P4",
         "release": "01",
         "sid": "007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_007.png"
     },
     {
         "name": "Friendly Siblings, Protagonist & Nanako",
@@ -224,7 +224,7 @@
         "set": "P4",
         "release": "01",
         "sid": "008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_008.png"
     },
     {
         "name": "Leader, Protagonist",
@@ -252,7 +252,7 @@
         "set": "P4",
         "release": "01",
         "sid": "009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_009.png"
     },
     {
         "name": "Signs of a Family, Dojima",
@@ -279,7 +279,7 @@
         "set": "P4",
         "release": "01",
         "sid": "010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_010.png"
     },
     {
         "name": "Declaration of Marriage, Nanako",
@@ -306,7 +306,7 @@
         "set": "P4",
         "release": "01",
         "sid": "011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_011.png"
     },
     {
         "name": "WILD Power, Protagonist",
@@ -333,7 +333,7 @@
         "set": "P4",
         "release": "01",
         "sid": "012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_012.png"
     },
     {
         "name": "Prince of Disappointment, Yosuke",
@@ -359,7 +359,7 @@
         "set": "P4",
         "release": "01",
         "sid": "013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_013.png"
     },
     {
         "name": "Ryotaro Dojima",
@@ -388,7 +388,7 @@
         "set": "P4",
         "release": "01",
         "sid": "014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_014.png"
     },
     {
         "name": "Junes",
@@ -414,7 +414,7 @@
         "set": "P4",
         "release": "01",
         "sid": "015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_015.png"
     },
     {
         "name": "Midnight Channel",
@@ -440,7 +440,7 @@
         "set": "P4",
         "release": "01",
         "sid": "016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_016.png"
     },
     {
         "name": "Myriad Truths",
@@ -469,7 +469,7 @@
         "set": "P4",
         "release": "01",
         "sid": "017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_017.png"
     },
     {
         "name": "Emerged Izanagi",
@@ -498,7 +498,7 @@
         "set": "P4",
         "release": "01",
         "sid": "018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_018.png"
     },
     {
         "name": "Never More",
@@ -527,7 +527,7 @@
         "set": "P4",
         "release": "01",
         "sid": "019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_019.png"
     },
     {
         "name": "\"Yasogami's Steel Council President!\" Labrys",
@@ -554,7 +554,7 @@
         "set": "P4",
         "release": "01",
         "sid": "020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_020.png"
     },
     {
         "name": "Kung Fu Club, Chie",
@@ -583,7 +583,7 @@
         "set": "P4",
         "release": "01",
         "sid": "021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_021.png"
     },
     {
         "name": "\"The Raging Bull of Destruction\" Shadow Labrys",
@@ -612,7 +612,7 @@
         "set": "P4",
         "release": "01",
         "sid": "022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_022.png"
     },
     {
         "name": "Show Biz People, Rise",
@@ -639,7 +639,7 @@
         "set": "P4",
         "release": "01",
         "sid": "023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_023.png"
     },
     {
         "name": "\"The Heartless Armed Angel\" Aigis",
@@ -666,7 +666,7 @@
         "set": "P4",
         "release": "01",
         "sid": "024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_024.png"
     },
     {
         "name": "Rise & Himiko",
@@ -693,7 +693,7 @@
         "set": "P4",
         "release": "01",
         "sid": "025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_025.png"
     },
     {
         "name": "Fox of Tatsuhime Shrine",
@@ -722,7 +722,7 @@
         "set": "P4",
         "release": "01",
         "sid": "026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_026R.png"
     },
     {
         "name": "Destined Confrontation, Labrys",
@@ -750,7 +750,7 @@
         "set": "P4",
         "release": "01",
         "sid": "027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_027.png"
     },
     {
         "name": "Chie & Suzuka Gongen",
@@ -779,7 +779,7 @@
         "set": "P4",
         "release": "01",
         "sid": "028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_028.png"
     },
     {
         "name": "Reliable Prince, Chie",
@@ -806,7 +806,7 @@
         "set": "P4",
         "release": "01",
         "sid": "029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_029.png"
     },
     {
         "name": "P-1 Grand Prix Host! General Teddie",
@@ -832,7 +832,7 @@
         "set": "P4",
         "release": "01",
         "sid": "030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_030.png"
     },
     {
         "name": "Chie in Yukata",
@@ -858,7 +858,7 @@
         "set": "P4",
         "release": "01",
         "sid": "031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_031.png"
     },
     {
         "name": "Rise Kujikawa",
@@ -887,7 +887,7 @@
         "set": "P4",
         "release": "01",
         "sid": "032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_032.png"
     },
     {
         "name": "Future Policewoman, Chie",
@@ -913,7 +913,7 @@
         "set": "P4",
         "release": "01",
         "sid": "033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_033.png"
     },
     {
         "name": "Special Friends, Chie & Yukiko",
@@ -941,7 +941,7 @@
         "set": "P4",
         "release": "01",
         "sid": "034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_034.png"
     },
     {
         "name": "Unit #024",
@@ -967,7 +967,7 @@
         "set": "P4",
         "release": "01",
         "sid": "035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_035.png"
     },
     {
         "name": "Chie Satonaka",
@@ -993,7 +993,7 @@
         "set": "P4",
         "release": "01",
         "sid": "036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_036.png"
     },
     {
         "name": "P-1 Grand Prix Exclusive Commentator! Rise",
@@ -1019,7 +1019,7 @@
         "set": "P4",
         "release": "01",
         "sid": "037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_037.png"
     },
     {
         "name": "Golden Right Leg, Chie",
@@ -1048,7 +1048,7 @@
         "set": "P4",
         "release": "01",
         "sid": "038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_038.png"
     },
     {
         "name": "Rise's True Self",
@@ -1077,7 +1077,7 @@
         "set": "P4",
         "release": "01",
         "sid": "039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_039.png"
     },
     {
         "name": "Sisters' Reunion, Aigis",
@@ -1105,7 +1105,7 @@
         "set": "P4",
         "release": "01",
         "sid": "040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_040.png"
     },
     {
         "name": "Rise & Kanzeon",
@@ -1134,7 +1134,7 @@
         "set": "P4",
         "release": "01",
         "sid": "041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_041.png"
     },
     {
         "name": "Chie & Tomoe",
@@ -1161,7 +1161,7 @@
         "set": "P4",
         "release": "01",
         "sid": "042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_042.png"
     },
     {
         "name": "King's Game",
@@ -1188,7 +1188,7 @@
         "set": "P4",
         "release": "01",
         "sid": "043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_043.png"
     },
     {
         "name": "Fishing for the River Guardian",
@@ -1214,7 +1214,7 @@
         "set": "P4",
         "release": "01",
         "sid": "044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_044.png"
     },
     {
         "name": "Labrys's Wrath",
@@ -1243,7 +1243,7 @@
         "set": "P4",
         "release": "01",
         "sid": "045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_045.png"
     },
     {
         "name": "Arrival of Asterius",
@@ -1272,7 +1272,7 @@
         "set": "P4",
         "release": "01",
         "sid": "046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_046.png"
     },
     {
         "name": "God's Hand",
@@ -1301,7 +1301,7 @@
         "set": "P4",
         "release": "01",
         "sid": "047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_047.png"
     },
     {
         "name": "Full Analysis",
@@ -1330,7 +1330,7 @@
         "set": "P4",
         "release": "01",
         "sid": "048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_048.png"
     },
     {
         "name": "Chie's Pursuit",
@@ -1359,7 +1359,7 @@
         "set": "P4",
         "release": "01",
         "sid": "049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_049.png"
     },
     {
         "name": "Active Teen Idol",
@@ -1388,7 +1388,7 @@
         "set": "P4",
         "release": "01",
         "sid": "050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_050.png"
     },
     {
         "name": "Yukiko in Yukata",
@@ -1418,7 +1418,7 @@
         "set": "P4",
         "release": "01",
         "sid": "051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_051.png"
     },
     {
         "name": "Young Okami, Yukiko",
@@ -1447,7 +1447,7 @@
         "set": "P4",
         "release": "01",
         "sid": "052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_052.png"
     },
     {
         "name": "Promise with Allies, Yukiko",
@@ -1473,7 +1473,7 @@
         "set": "P4",
         "release": "01",
         "sid": "053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_053.png"
     },
     {
         "name": "\"The Bloodcurdling Beefcake Emperor\" Kanji Tatsumi",
@@ -1499,7 +1499,7 @@
         "set": "P4",
         "release": "01",
         "sid": "054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_054.png"
     },
     {
         "name": "“The Unconquerable Snow Black” Yukiko Amagi",
@@ -1525,7 +1525,7 @@
         "set": "P4",
         "release": "01",
         "sid": "055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_055.png"
     },
     {
         "name": "Yukiko & Konohana Sakuya",
@@ -1555,7 +1555,7 @@
         "set": "P4",
         "release": "01",
         "sid": "056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_056.png"
     },
     {
         "name": "Yukiko's Laughing Fits",
@@ -1583,7 +1583,7 @@
         "set": "P4",
         "release": "01",
         "sid": "057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_057.png"
     },
     {
         "name": "Brains of the Station, Adachi",
@@ -1611,7 +1611,7 @@
         "set": "P4",
         "release": "01",
         "sid": "058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_058.png"
     },
     {
         "name": "Totally Wrong, Miss Kanji",
@@ -1640,7 +1640,7 @@
         "set": "P4",
         "release": "01",
         "sid": "059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_059.png"
     },
     {
         "name": "Reliable Princess, Yukiko",
@@ -1667,7 +1667,7 @@
         "set": "P4",
         "release": "01",
         "sid": "060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_060.png"
     },
     {
         "name": "Yukiko Amagi",
@@ -1694,7 +1694,7 @@
         "set": "P4",
         "release": "01",
         "sid": "061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_061.png"
     },
     {
         "name": "Gas Station Attendant",
@@ -1720,7 +1720,7 @@
         "set": "P4",
         "release": "01",
         "sid": "062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_062.png"
     },
     {
         "name": "Finish with a Single Blow, Yukiko",
@@ -1747,7 +1747,7 @@
         "set": "P4",
         "release": "01",
         "sid": "063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_063.png"
     },
     {
         "name": "Like a Game, Adachi",
@@ -1775,7 +1775,7 @@
         "set": "P4",
         "release": "01",
         "sid": "064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_064.png"
     },
     {
         "name": "\"The Two-Fisted Protein Junkie\" Akihiko Sanada",
@@ -1803,7 +1803,7 @@
         "set": "P4",
         "release": "01",
         "sid": "065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_065.png"
     },
     {
         "name": "Inedible Curry",
@@ -1830,7 +1830,7 @@
         "set": "P4",
         "release": "01",
         "sid": "066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_066.png"
     },
     {
         "name": "One Strike",
@@ -1856,7 +1856,7 @@
         "set": "P4",
         "release": "01",
         "sid": "067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_067.png"
     },
     {
         "name": "It's my turn!",
@@ -1882,7 +1882,7 @@
         "set": "P4",
         "release": "01",
         "sid": "068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_068.png"
     },
     {
         "name": "Scoring a Hot Stud",
@@ -1911,7 +1911,7 @@
         "set": "P4",
         "release": "01",
         "sid": "069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_069.png"
     },
     {
         "name": "Will of the World",
@@ -1940,7 +1940,7 @@
         "set": "P4",
         "release": "01",
         "sid": "070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_070.png"
     },
     {
         "name": "Bond with Fists",
@@ -1969,7 +1969,7 @@
         "set": "P4",
         "release": "01",
         "sid": "071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_071.png"
     },
     {
         "name": "Naoto & Yamato Takeru",
@@ -1997,7 +1997,7 @@
         "set": "P4",
         "release": "01",
         "sid": "072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_072.png"
     },
     {
         "name": "\"The 2000-IQ Killjoy Detective\" Naoto Shirogane",
@@ -2026,7 +2026,7 @@
         "set": "P4",
         "release": "01",
         "sid": "073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_073.png"
     },
     {
         "name": "Full Power Follow Up, Naoto",
@@ -2052,7 +2052,7 @@
         "set": "P4",
         "release": "01",
         "sid": "074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_074.png"
     },
     {
         "name": "Middle of a Long Journey, Elizabeth",
@@ -2079,7 +2079,7 @@
         "set": "P4",
         "release": "01",
         "sid": "075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_075.png"
     },
     {
         "name": "Infinite Possibilities, Naoto",
@@ -2106,7 +2106,7 @@
         "set": "P4",
         "release": "01",
         "sid": "076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_076.png"
     },
     {
         "name": "Paper Thin Teddie",
@@ -2132,7 +2132,7 @@
         "set": "P4",
         "release": "01",
         "sid": "077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_077.png"
     },
     {
         "name": "Naoto Shirogane",
@@ -2161,7 +2161,7 @@
         "set": "P4",
         "release": "01",
         "sid": "078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_078.png"
     },
     {
         "name": "One who Wields Power, Margaret",
@@ -2189,7 +2189,7 @@
         "set": "P4",
         "release": "01",
         "sid": "079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_079.png"
     },
     {
         "name": "Detective Prince, Naoto",
@@ -2216,7 +2216,7 @@
         "set": "P4",
         "release": "01",
         "sid": "080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_080.png"
     },
     {
         "name": "Teddie in Yukata",
@@ -2243,7 +2243,7 @@
         "set": "P4",
         "release": "01",
         "sid": "081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_081.png"
     },
     {
         "name": "\"The Beast in Heat\" Teddie",
@@ -2269,7 +2269,7 @@
         "set": "P4",
         "release": "01",
         "sid": "082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_082.png"
     },
     {
         "name": "\"Assertion of Youth\" Teddie",
@@ -2295,7 +2295,7 @@
         "set": "P4",
         "release": "01",
         "sid": "083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_083.png"
     },
     {
         "name": "Companion on a Journey, Margaret",
@@ -2324,7 +2324,7 @@
         "set": "P4",
         "release": "01",
         "sid": "084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_084.png"
     },
     {
         "name": "Undercover Investigation, Naoto",
@@ -2353,7 +2353,7 @@
         "set": "P4",
         "release": "01",
         "sid": "085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_085.png"
     },
     {
         "name": "Teddie",
@@ -2380,7 +2380,7 @@
         "set": "P4",
         "release": "01",
         "sid": "086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_086.png"
     },
     {
         "name": "Teddie & Kintoki-Douji",
@@ -2407,7 +2407,7 @@
         "set": "P4",
         "release": "01",
         "sid": "087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_087.png"
     },
     {
         "name": "Naoto & Sukuna-Hikona",
@@ -2433,7 +2433,7 @@
         "set": "P4",
         "release": "01",
         "sid": "088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_088.png"
     },
     {
         "name": "Miss \"Teddie\"",
@@ -2459,7 +2459,7 @@
         "set": "P4",
         "release": "01",
         "sid": "089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_089.png"
     },
     {
         "name": "Investigation Team, Teddie",
@@ -2488,7 +2488,7 @@
         "set": "P4",
         "release": "01",
         "sid": "090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_090.png"
     },
     {
         "name": "New Legend of Teddie",
@@ -2517,7 +2517,7 @@
         "set": "P4",
         "release": "01",
         "sid": "091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_091.png"
     },
     {
         "name": "Sailor Uniform Naoto",
@@ -2546,7 +2546,7 @@
         "set": "P4",
         "release": "01",
         "sid": "092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_092.png"
     },
     {
         "name": "Teddie & Kamui",
@@ -2575,7 +2575,7 @@
         "set": "P4",
         "release": "01",
         "sid": "093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_093.png"
     },
     {
         "name": "\"The Imperious Queen of Executions\" Mitsuru Kirijo",
@@ -2604,7 +2604,7 @@
         "set": "P4",
         "release": "01",
         "sid": "094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_094.png"
     },
     {
         "name": "Aria of the Soul",
@@ -2630,7 +2630,7 @@
         "set": "P4",
         "release": "01",
         "sid": "095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_095.png"
     },
     {
         "name": "Maggie's Tarot Reading",
@@ -2656,7 +2656,7 @@
         "set": "P4",
         "release": "01",
         "sid": "096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_096.png"
     },
     {
         "name": "Megidolaon",
@@ -2685,7 +2685,7 @@
         "set": "P4",
         "release": "01",
         "sid": "097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_097.png"
     },
     {
         "name": "Mabufudyne",
@@ -2714,7 +2714,7 @@
         "set": "P4",
         "release": "01",
         "sid": "098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_098.png"
     },
     {
         "name": "Charging into the Announcement Room!",
@@ -2743,7 +2743,7 @@
         "set": "P4",
         "release": "01",
         "sid": "099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_099.png"
     },
     {
         "name": "My Christmas Eve",
@@ -2772,7 +2772,7 @@
         "set": "P4",
         "release": "01",
         "sid": "100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_100.png"
     },
     {
         "name": "\"Contract Key\" Protagonist",
@@ -2800,7 +2800,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T01.png"
     },
     {
         "name": "Investigation Team, Yosuke",
@@ -2827,7 +2827,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T02.png"
     },
     {
         "name": "Yosuke Hanamura",
@@ -2853,7 +2853,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T03.png"
     },
     {
         "name": "Nanako Helping Out",
@@ -2879,7 +2879,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T04.png"
     },
     {
         "name": "Beauty Pageant? Miss Protagonist",
@@ -2905,7 +2905,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T05.png"
     },
     {
         "name": "Protagonist's Partner, Yosuke",
@@ -2932,7 +2932,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T06.png"
     },
     {
         "name": "Investigation Team, Yu",
@@ -2961,7 +2961,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T07.png"
     },
     {
         "name": "Yosuke & Jiraiya",
@@ -2990,7 +2990,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T08.png"
     },
     {
         "name": "Yosuke & Susano-O",
@@ -3019,7 +3019,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T09.png"
     },
     {
         "name": "\"Sister-Complex Kingpin of Steel\" Yu Narukami",
@@ -3049,7 +3049,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T10.png"
     },
     {
         "name": "P-1 Grand Prix Begins!",
@@ -3078,7 +3078,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T11.png"
     },
     {
         "name": "Brave Blade",
@@ -3108,7 +3108,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T12.png"
     },
     {
         "name": "Kanji Tatsumi",
@@ -3134,7 +3134,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T13.png"
     },
     {
         "name": "Real Strength, Kanji",
@@ -3161,7 +3161,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T14.png"
     },
     {
         "name": "Kanji & Take-Mikazuchi",
@@ -3188,7 +3188,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T15.png"
     },
     {
         "name": "Kanji & Rokuten Maou",
@@ -3217,7 +3217,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T16.png"
     },
     {
         "name": "Yukiko & Amaterasu",
@@ -3246,7 +3246,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T17.png"
     },
     {
         "name": "Musha Training",
@@ -3272,7 +3272,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T18.png"
     },
     {
         "name": "Mighty Swing",
@@ -3301,7 +3301,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T19.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T19.png"
     },
     {
         "name": "Salvation",
@@ -3330,7 +3330,7 @@
         "set": "P4",
         "release": "01",
         "sid": "T20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4EN_S01_T20.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S01_T20.png"
     },
     {
         "name": "\"Another Self\" Protagonist & Izanagi",
@@ -3358,7 +3358,7 @@
         "set": "P4",
         "release": "08",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4_S08_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_S08_E103.png"
     },
     {
         "name": "Idol on a Break, Risette",
@@ -3386,7 +3386,7 @@
         "set": "P4",
         "release": "08",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4_S08_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/WS_P4_S08_E105.jpg"
     },
     {
         "name": "Final Break! Aigis",
@@ -3414,6 +3414,6 @@
         "set": "P4",
         "release": "E15",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_P4_SE15_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p4_en_s01/P4_EN_SE15_PE01.png"
     }
 ]

--- a/DB/P5_S45.json
+++ b/DB/P5_S45.json
@@ -27,7 +27,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E001.png"
     },
     {
         "name": "Ryuji as SKULL: All-out Attack",
@@ -56,7 +56,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E002.png"
     },
     {
         "name": "Protagonist: The Will of Rebellion",
@@ -83,7 +83,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E003.png"
     },
     {
         "name": "Ryuji as SKULL: The Phantom Vanguard",
@@ -110,7 +110,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E004.png"
     },
     {
         "name": "Ryuji Sakamoto",
@@ -136,7 +136,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E005.png"
     },
     {
         "name": "Protagonist as JOKER: All-out Attack",
@@ -165,7 +165,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E006.png"
     },
     {
         "name": "Ryuji as SKULL & Captain Kidd",
@@ -194,7 +194,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E007.png"
     },
     {
         "name": "Ryuji as SKULL: A Big Smile",
@@ -221,7 +221,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E008.png"
     },
     {
         "name": "Protagonist: Leblanc's Troublesome Guest",
@@ -248,7 +248,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E009.png"
     },
     {
         "name": "Akechi: The New Detective Prince",
@@ -274,7 +274,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E010.png"
     },
     {
         "name": "Ryuji: It's a Deal",
@@ -300,7 +300,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E011.png"
     },
     {
         "name": "Protagonist: Prisoner of Fate",
@@ -329,7 +329,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E012.png"
     },
     {
         "name": "Swimsuit Ryuji",
@@ -355,7 +355,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E013.png"
     },
     {
         "name": "Goro Akechi",
@@ -382,7 +382,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E014.png"
     },
     {
         "name": "Swimsuit Protagonist",
@@ -408,7 +408,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E015.png"
     },
     {
         "name": "Protagonist as JOKER: Thief Clad in Black",
@@ -436,7 +436,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E016.png"
     },
     {
         "name": "Protagonist as JOKER: Lurking in the Dark",
@@ -464,7 +464,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E017.png"
     },
     {
         "name": "Ryuji as SKULL: The Fight Is On",
@@ -491,7 +491,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E018.png"
     },
     {
         "name": "Yuuki Mishima",
@@ -519,7 +519,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E019.png"
     },
     {
         "name": "Akechi: The High-School Detective",
@@ -548,7 +548,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E020.png"
     },
     {
         "name": "Calling Card",
@@ -576,7 +576,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E021.png"
     },
     {
         "name": "Wild Talk",
@@ -606,7 +606,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E022.png"
     },
     {
         "name": "THE SHOW'S OVER",
@@ -636,7 +636,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E023.png"
     },
     {
         "name": "FREAKiN' BoRiNG",
@@ -665,7 +665,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E024.png"
     },
     {
         "name": "Yo, I'm Ready...",
@@ -695,7 +695,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E025.png"
     },
     {
         "name": "Makoto as QUEEN & Johanna",
@@ -724,7 +724,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E026.png"
     },
     {
         "name": "Haru as NOIR & Milady",
@@ -753,7 +753,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E027.png"
     },
     {
         "name": "Makoto as QUEEN: The Phantom Tactician",
@@ -780,7 +780,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E028.png"
     },
     {
         "name": "Haru Okumura",
@@ -807,7 +807,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E029.png"
     },
     {
         "name": "Swimsuit Makoto",
@@ -833,7 +833,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E030.png"
     },
     {
         "name": "Makoto Niijima",
@@ -859,7 +859,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E031.png"
     },
     {
         "name": "Haru as NOIR: All-out Attack",
@@ -888,7 +888,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E032.png"
     },
     {
         "name": "Sadayo Kawakami",
@@ -914,7 +914,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E033.png"
     },
     {
         "name": "Toranosuke Yoshida",
@@ -941,7 +941,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E034.png"
     },
     {
         "name": "Haru as NOIR: The Mysterious Beauty Thief",
@@ -968,7 +968,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E035.png"
     },
     {
         "name": "Makoto as QUEEN: All-out Attack",
@@ -995,7 +995,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E036.png"
     },
     {
         "name": "Haru as NOIR: The Phantom Lady",
@@ -1022,7 +1022,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E037.png"
     },
     {
         "name": "Makoto as QUEEN: Miss Post-Apocalyptic Raider",
@@ -1051,7 +1051,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E038.png"
     },
     {
         "name": "Sae Niijima",
@@ -1078,7 +1078,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E039.png"
     },
     {
         "name": "Prosecutor Sae",
@@ -1105,7 +1105,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E040.png"
     },
     {
         "name": "Haru: It's a Deal",
@@ -1132,7 +1132,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E041.png"
     },
     {
         "name": "Makoto: It's a Deal",
@@ -1159,7 +1159,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E042.png"
     },
     {
         "name": "Haru: A Life on Rails",
@@ -1185,7 +1185,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E043.png"
     },
     {
         "name": "Chihaya Mifune",
@@ -1212,7 +1212,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E044.png"
     },
     {
         "name": "Ichiko Ohya",
@@ -1240,7 +1240,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E045.png"
     },
     {
         "name": "Calling Card",
@@ -1267,7 +1267,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E046.png"
     },
     {
         "name": "Metaverse Navigator",
@@ -1293,7 +1293,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E047.png"
     },
     {
         "name": "Tanaka's Shady Commodities",
@@ -1323,7 +1323,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E048.png"
     },
     {
         "name": "Adieu.",
@@ -1352,7 +1352,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E049.png"
     },
     {
         "name": "JUSTICE HAS PREVAILED.",
@@ -1381,7 +1381,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E050.png"
     },
     {
         "name": "Morgana as MONA & Zorro",
@@ -1411,7 +1411,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E051.png"
     },
     {
         "name": "Ann as PANTHER: All-out Attack",
@@ -1440,7 +1440,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E052.png"
     },
     {
         "name": "Ann as PANTHER: The Talented(?) Phantom Actress",
@@ -1467,7 +1467,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E053.png"
     },
     {
         "name": "Morgana as MONA: The Phantom Guide",
@@ -1493,7 +1493,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E054.png"
     },
     {
         "name": "Ann as PANTHER & Carmen",
@@ -1520,7 +1520,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E055.png"
     },
     {
         "name": "Morgana as MONA: All-out Attack",
@@ -1547,7 +1547,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E056.png"
     },
     {
         "name": "Ann Takamaki",
@@ -1576,7 +1576,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E057.png"
     },
     {
         "name": "Shinya Oda",
@@ -1602,7 +1602,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E058.png"
     },
     {
         "name": "Ann as PANTHER: Quiet Rage",
@@ -1629,7 +1629,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E059.png"
     },
     {
         "name": "Ann: It's a Deal",
@@ -1655,7 +1655,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E060.png"
     },
     {
         "name": "Morgana as MONA: It's a Deal",
@@ -1682,7 +1682,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E061.png"
     },
     {
         "name": "Ann as PANTHER: Determination",
@@ -1709,7 +1709,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E062.png"
     },
     {
         "name": "Morgana Car",
@@ -1737,7 +1737,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E063.png"
     },
     {
         "name": "Hifumi Togo",
@@ -1764,7 +1764,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E064.png"
     },
     {
         "name": "Morgana as MONA: Earnest Affection",
@@ -1791,7 +1791,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E065.png"
     },
     {
         "name": "Munehisa Iwai",
@@ -1817,7 +1817,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E066.png"
     },
     {
         "name": "Swimsuit Ann",
@@ -1843,7 +1843,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E067.png"
     },
     {
         "name": "Morgana as MONA: Identity Unknown",
@@ -1871,7 +1871,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E068.png"
     },
     {
         "name": "Morgana as MONA: For the Sake of the Team",
@@ -1900,7 +1900,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E069.png"
     },
     {
         "name": "Calling Card",
@@ -1927,7 +1927,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E070.png"
     },
     {
         "name": "Mementos",
@@ -1954,7 +1954,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E071.png"
     },
     {
         "name": "omg!! We are SO awesome",
@@ -1983,7 +1983,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E072.png"
     },
     {
         "name": "For My Best Friend",
@@ -2012,7 +2012,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E073.png"
     },
     {
         "name": "MISSION ACCOMPLISHED",
@@ -2041,7 +2041,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E074.png"
     },
     {
         "name": "Where I Belong",
@@ -2070,7 +2070,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E075.png"
     },
     {
         "name": "Futaba as ORACLE: Navigation Duty",
@@ -2100,7 +2100,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E076.png"
     },
     {
         "name": "Yusuke as FOX & Goemon",
@@ -2129,7 +2129,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E077.png"
     },
     {
         "name": "Caroline",
@@ -2157,7 +2157,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E078.png"
     },
     {
         "name": "Futaba Sakura",
@@ -2184,7 +2184,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E079.png"
     },
     {
         "name": "Yusuke as FOX: The Phantom Artist",
@@ -2211,7 +2211,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E080.png"
     },
     {
         "name": "Futaba as ORACLE & Necronomicon",
@@ -2237,7 +2237,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E081.png"
     },
     {
         "name": "Yusuke Kitagawa",
@@ -2266,7 +2266,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E082.png"
     },
     {
         "name": "Justine",
@@ -2293,7 +2293,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E083.png"
     },
     {
         "name": "Swimsuit Futaba",
@@ -2320,7 +2320,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E084.png"
     },
     {
         "name": "Igor: Imposer of Rehabilitation",
@@ -2346,7 +2346,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E085.png"
     },
     {
         "name": "Futaba as ORACLE: The Phantom Hacker",
@@ -2375,7 +2375,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E086.png"
     },
     {
         "name": "Tae Takemi",
@@ -2404,7 +2404,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E087.png"
     },
     {
         "name": "Sojiro Sakura",
@@ -2431,7 +2431,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E088.png"
     },
     {
         "name": "Yusuke: First Encounter",
@@ -2458,7 +2458,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E089.png"
     },
     {
         "name": "Yusuke: It's a Deal",
@@ -2484,7 +2484,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E090.png"
     },
     {
         "name": "Futaba: It's a Deal",
@@ -2510,7 +2510,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E091.png"
     },
     {
         "name": "Futaba: Hacking in Session",
@@ -2536,7 +2536,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E092.png"
     },
     {
         "name": "Yusuke: Card Duplication",
@@ -2565,7 +2565,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E093.png"
     },
     {
         "name": "Igor: Master of the Velvet Room",
@@ -2592,7 +2592,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E094.png"
     },
     {
         "name": "Yusuke as FOX: All-out Attack",
@@ -2619,7 +2619,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E095.png"
     },
     {
         "name": "Calling Card",
@@ -2646,7 +2646,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E096.png"
     },
     {
         "name": "Execution",
@@ -2672,7 +2672,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E097.png"
     },
     {
         "name": "Velvet Room",
@@ -2698,7 +2698,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E098.png"
     },
     {
         "name": "IT WAS FUN WHILE IT LASTED, GOODBYE.",
@@ -2727,7 +2727,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E099.png"
     },
     {
         "name": "I'll Never Forgive Them!",
@@ -2757,7 +2757,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E100.png"
     },
     {
         "name": "Protagonist as JOKER: Phantom Thief of Hearts",
@@ -2786,7 +2786,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E101.png"
     },
     {
         "name": "Ryuji: Phantom Thief of Hearts",
@@ -2813,7 +2813,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E102.png"
     },
     {
         "name": "Ann: Phantom Thief of Hearts",
@@ -2839,7 +2839,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E103.png"
     },
     {
         "name": "Morgana as MONA: Phantom Thief of Hearts",
@@ -2865,7 +2865,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E104.png"
     },
     {
         "name": "Yusuke: Phantom Thief of Hearts",
@@ -2892,7 +2892,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E105.png"
     },
     {
         "name": "Makoto: Phantom Thief of Hearts",
@@ -2918,7 +2918,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E106.png"
     },
     {
         "name": "Futaba: Phantom Thief of Hearts",
@@ -2945,7 +2945,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E107.png"
     },
     {
         "name": "Haru: Phantom Thief of Hearts",
@@ -2971,7 +2971,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E108.png"
     },
     {
         "name": "Protagonist as JOKER: Destiny Awaits",
@@ -2998,7 +2998,7 @@
         "set": "P5",
         "release": "45",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_E109.png"
     },
     {
         "name": "Protagonist & Ryuji & Ann",
@@ -3076,7 +3076,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE01.png"
     },
     {
         "name": "Mishima: Volleyball Team Member",
@@ -3102,7 +3102,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE02.png"
     },
     {
         "name": "Protagonist (P5)",
@@ -3128,7 +3128,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE03.png"
     },
     {
         "name": "Ryuji: Spirit of Defiance",
@@ -3154,7 +3154,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE04.png"
     },
     {
         "name": "Protagonist: Imprisonment",
@@ -3183,7 +3183,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE05.png"
     },
     {
         "name": "Ryuji as SKULL: The Skull of Rebellion",
@@ -3209,7 +3209,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE06.png"
     },
     {
         "name": "Protagonist as JOKER",
@@ -3238,7 +3238,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE07.png"
     },
     {
         "name": "The Unforgettable Memory",
@@ -3264,7 +3264,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE08.png"
     },
     {
         "name": "The Will of Rebellion",
@@ -3294,7 +3294,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE09.png"
     },
     {
         "name": "Power Awakens",
@@ -3323,7 +3323,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE10.png"
     },
     {
         "name": "Ann: Concerned for Her Friend",
@@ -3349,7 +3349,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE11.png"
     },
     {
         "name": "Morgana as MONA: The Elusive Phantom Thief",
@@ -3376,7 +3376,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE12.png"
     },
     {
         "name": "Shiho Suzui",
@@ -3402,7 +3402,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE13.png"
     },
     {
         "name": "Morgana as MONA: The Plan Fails",
@@ -3428,7 +3428,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE14.png"
     },
     {
         "name": "Ann as PANTHER: First Infiltration",
@@ -3454,7 +3454,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE15.png"
     },
     {
         "name": "Morgana as MONA: That's the Treasure!",
@@ -3480,7 +3480,7 @@
         "set": "P5",
         "release": "45",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE16.png"
     },
     {
         "name": "We Will Promptly Shut Them Up!",
@@ -3509,6 +3509,6 @@
         "set": "P5",
         "release": "45",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/P5_S45_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/p5_s45/P5_S45_TE17.png"
     }
 ]

--- a/DB/PD1_S22.json
+++ b/DB/PD1_S22.json
@@ -26,7 +26,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E001.png"
     },
     {
         "name": "Kagamine Len\"Original\"",
@@ -55,7 +55,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E002.png"
     },
     {
         "name": "Kagamine Rin\"Ni-no-Sakura Butterfly\"",
@@ -84,7 +84,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E003.png"
     },
     {
         "name": "Kagamine Rin\"Striped Bikini\"",
@@ -110,7 +110,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E004.png"
     },
     {
         "name": "Kagamine Len\"Starmine\"",
@@ -139,7 +139,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E005.png"
     },
     {
         "name": "Kagamine Rin\"Sakura Moon\"",
@@ -168,7 +168,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E006.png"
     },
     {
         "name": "Kagamine Rin\"Original\"",
@@ -198,7 +198,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E007.png"
     },
     {
         "name": "Kagamine Rin\"Melancholy\"",
@@ -225,7 +225,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E008.png"
     },
     {
         "name": "Kagamine Len\"Swimshorts\"",
@@ -252,7 +252,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E009.png"
     },
     {
         "name": "Kagamine Len\"Ni-no-Sakura Fan Dance\"",
@@ -278,7 +278,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E010.png"
     },
     {
         "name": "Kagamine Len\"Receiver\"",
@@ -304,7 +304,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E011.png"
     },
     {
         "name": "Kagamine Rin\"Transmitter\"",
@@ -330,7 +330,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E012.png"
     },
     {
         "name": "Akita Neru\"Original\"",
@@ -356,7 +356,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E013.png"
     },
     {
         "name": "Kagamine Rin\"Append\"",
@@ -384,7 +384,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E014.png"
     },
     {
         "name": "Kagamine Len\"Crane\"",
@@ -410,7 +410,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E015.png"
     },
     {
         "name": "Kagamine Len\"Append\"",
@@ -436,7 +436,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E016.png"
     },
     {
         "name": "Kagamine Len\"Trickster\"",
@@ -462,7 +462,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E017.png"
     },
     {
         "name": "Kagamine Rin\"Future Style\"",
@@ -488,7 +488,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E018.png"
     },
     {
         "name": "\"Continuing Dream\"Kagamine Rin",
@@ -514,7 +514,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E019.png"
     },
     {
         "name": "\"Continuing Dream\"Kagamine Len",
@@ -542,7 +542,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E020.png"
     },
     {
         "name": "Melancholic",
@@ -568,7 +568,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E021.png"
     },
     {
         "name": "Tengaku",
@@ -597,7 +597,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E022.png"
     },
     {
         "name": "Fire◎Flower",
@@ -624,7 +624,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E023.png"
     },
     {
         "name": "Tokyo Teddy Bear",
@@ -654,7 +654,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E024.png"
     },
     {
         "name": "Remote Controller",
@@ -683,7 +683,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E025.png"
     },
     {
         "name": "\"Electron Diva\"Hatsune Miku",
@@ -712,7 +712,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E026.png"
     },
     {
         "name": "Hatsune Miku\"Factory Tyrant\"",
@@ -741,7 +741,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E027.png"
     },
     {
         "name": "Hatsune Miku\"Linkage\"",
@@ -767,7 +767,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E028.png"
     },
     {
         "name": "Hatsune Miku\"Summer Memories\"",
@@ -793,7 +793,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E029.png"
     },
     {
         "name": "Hatsune Miku\"Ichi-no-Sakura Blossom\"",
@@ -819,7 +819,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E030.png"
     },
     {
         "name": "\"Together with You\"Hatsune Miku",
@@ -848,7 +848,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E031.png"
     },
     {
         "name": "\"My Song for You\"Hatsune Miku",
@@ -876,7 +876,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E032.png"
     },
     {
         "name": "Hatsune Miku\"Divine Goddess\"",
@@ -902,7 +902,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E033.png"
     },
     {
         "name": "Hatsune Miku\"Pierretta\"",
@@ -928,7 +928,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E034.png"
     },
     {
         "name": "Hatsune Miku\"Kitty Cape\"",
@@ -954,7 +954,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E035.png"
     },
     {
         "name": "\"Continuing Dream\"Hatsune Miku",
@@ -983,7 +983,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E036.png"
     },
     {
         "name": "Hatsune Miku\"FOnewearl Style\"",
@@ -1009,7 +1009,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E037.png"
     },
     {
         "name": "Hatsune Miku\"Append\"",
@@ -1037,7 +1037,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E038.png"
     },
     {
         "name": "\"39 Get!\"Hatsune Miku",
@@ -1064,7 +1064,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E039.png"
     },
     {
         "name": "Hatsune Miku\"Pansy\"",
@@ -1091,7 +1091,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E040.png"
     },
     {
         "name": "Hatsune Miku\"Deep Sky\"",
@@ -1117,7 +1117,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E041.png"
     },
     {
         "name": "Hatsune Miku\"Swimsuit\"",
@@ -1143,7 +1143,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E042.png"
     },
     {
         "name": "Hatsune Miku\"Honey Whip\"",
@@ -1169,7 +1169,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E043.png"
     },
     {
         "name": "\"Full Power Mikku Miku\"Hatsune Miku",
@@ -1197,7 +1197,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E044.png"
     },
     {
         "name": "Hatsune Miku\"Hello, Good Night.\"",
@@ -1225,7 +1225,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E045.png"
     },
     {
         "name": "Weekender Girl",
@@ -1252,7 +1252,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E046.png"
     },
     {
         "name": "Senbonzakura",
@@ -1281,7 +1281,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E047a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e047a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E047a.png"
     },
     {
         "name": "Senbonzakura",
@@ -1310,7 +1310,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E047b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e047b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E047b.png"
     },
     {
         "name": "Senbonzakura",
@@ -1339,7 +1339,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E047c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e047c.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E047c.png"
     },
     {
         "name": "Sadistic.Music∞Factory",
@@ -1368,7 +1368,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E048.png"
     },
     {
         "name": "Time Machine",
@@ -1397,7 +1397,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E049.png"
     },
     {
         "name": "Continuing Dream",
@@ -1426,7 +1426,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E050.png"
     },
     {
         "name": "Hatsune Miku\"Emerald\"",
@@ -1454,7 +1454,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E051.png"
     },
     {
         "name": "Megurine Luka\"Ruby\"",
@@ -1482,7 +1482,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E052.png"
     },
     {
         "name": "Megurine Luka\"Resort Bikini\"",
@@ -1509,7 +1509,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E053.png"
     },
     {
         "name": "Megurine Luka\"Eternal White\"",
@@ -1535,7 +1535,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E054.png"
     },
     {
         "name": "MEIKO\"Long Pareo\"",
@@ -1561,7 +1561,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E055.png"
     },
     {
         "name": "MEIKO\"Blue Crystal\"",
@@ -1587,7 +1587,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E056.png"
     },
     {
         "name": "Megurine Luka\"Original\"",
@@ -1617,7 +1617,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E057.png"
     },
     {
         "name": "Hatsune Miku\"Rin-chan's #1 Fan\"",
@@ -1644,7 +1644,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E058.png"
     },
     {
         "name": "Megurine Luka\"Rin-chan's #2 Fan\"",
@@ -1671,7 +1671,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E059.png"
     },
     {
         "name": "Megurine Luka\"Racing Swimsuit\"",
@@ -1697,7 +1697,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E060.png"
     },
     {
         "name": "Kasane Teto\"Original\"",
@@ -1724,7 +1724,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E061.png"
     },
     {
         "name": "MEIKO\"Noel Rouge\"",
@@ -1753,7 +1753,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E062.png"
     },
     {
         "name": "Megurine Luka\"Light & Casual\"",
@@ -1780,7 +1780,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E063.png"
     },
     {
         "name": "Megurine Luka\"Amour\"",
@@ -1808,7 +1808,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E064.png"
     },
     {
         "name": "MEIKO\"Water Polo\"",
@@ -1834,7 +1834,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E065.png"
     },
     {
         "name": "\"Continuing Dream\"Megurine Luka",
@@ -1860,7 +1860,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E066.png"
     },
     {
         "name": "Hatsune Miku\"Dark Angel\"",
@@ -1886,7 +1886,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E067.png"
     },
     {
         "name": "Hatsune Miku\"Lab Girl\"",
@@ -1912,7 +1912,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E068.png"
     },
     {
         "name": "Megurine Luka\"San-no-Sakura Maple\"",
@@ -1940,7 +1940,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E069.png"
     },
     {
         "name": "MEIKO\"Rei-no-Sakura Camellia\"",
@@ -1968,7 +1968,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E070.png"
     },
     {
         "name": "Glasses",
@@ -1994,7 +1994,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E071.png"
     },
     {
         "name": "DYE",
@@ -2023,7 +2023,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E072.png"
     },
     {
         "name": "Nostalogic",
@@ -2052,7 +2052,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E073.png"
     },
     {
         "name": "World's End Dance Hall",
@@ -2081,7 +2081,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E074a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e074a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E074a.png"
     },
     {
         "name": "World's End Dance Hall",
@@ -2110,7 +2110,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E074b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e074b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E074b.png"
     },
     {
         "name": "Rin-chan Now!",
@@ -2139,7 +2139,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E075a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e075a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E075a.png"
     },
     {
         "name": "Rin-chan Now!",
@@ -2168,7 +2168,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E075b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e075b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E075b.png"
     },
     {
         "name": "Kagamine Rin\"Ame\"",
@@ -2196,7 +2196,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E076.png"
     },
     {
         "name": "KAITO & MEIKO\"Original\"",
@@ -2225,7 +2225,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E077.png"
     },
     {
         "name": "KAITO\"General\"",
@@ -2252,7 +2252,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E078.png"
     },
     {
         "name": "\"Never Ending Song\"Hatsune Miku",
@@ -2279,7 +2279,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E079.png"
     },
     {
         "name": "Hatsune Miku\"Agitation\"",
@@ -2305,7 +2305,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E080.png"
     },
     {
         "name": "Kagamine Len\"Phoenix Moon\"",
@@ -2331,7 +2331,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E081.png"
     },
     {
         "name": "Hatsune Miku\"Polka Dot Bikini\"",
@@ -2360,7 +2360,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E082.png"
     },
     {
         "name": "Hatsune Miku\"Memoria\"",
@@ -2386,7 +2386,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E083.png"
     },
     {
         "name": "Kagamine Len\"Bad Boy\"",
@@ -2413,7 +2413,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E084a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e084a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E084a.png"
     },
     {
         "name": "Kagamine Len\"Bad Boy\"",
@@ -2440,7 +2440,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E084b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e084b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E084b.png"
     },
     {
         "name": "Yowane Haku\"Original\"",
@@ -2466,7 +2466,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E085.png"
     },
     {
         "name": "KAITO\"Guilty\"",
@@ -2492,7 +2492,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E086.png"
     },
     {
         "name": "Kagamine Rin\"School Swimwear\"",
@@ -2518,7 +2518,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E087.png"
     },
     {
         "name": "Hatsune Miku\"Star Vocalist\"",
@@ -2546,7 +2546,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E088.png"
     },
     {
         "name": "Hatsune Miku\"Innocent\"",
@@ -2574,7 +2574,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E089.png"
     },
     {
         "name": "Hatsune Miku\"Solitude\"",
@@ -2600,7 +2600,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E090.png"
     },
     {
         "name": "KAITO\"Requiem\"",
@@ -2626,7 +2626,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E091.png"
     },
     {
         "name": "KAITO\"Half Tights\"",
@@ -2652,7 +2652,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E092.png"
     },
     {
         "name": "KAITO\"Rei-no-Sakura Azure Snow\"",
@@ -2680,7 +2680,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E093.png"
     },
     {
         "name": "Hatsune Miku\"Violet Butterfly\"",
@@ -2708,7 +2708,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E094.png"
     },
     {
         "name": "Unfortunately, it was a SAFE",
@@ -2734,7 +2734,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E095.png"
     },
     {
         "name": "Ashes to Ashes",
@@ -2760,7 +2760,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E096.png"
     },
     {
         "name": "Freely Tomorrow",
@@ -2789,7 +2789,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E097.png"
     },
     {
         "name": "ACUTE",
@@ -2818,7 +2818,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E098a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e098a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E098a.png"
     },
     {
         "name": "ACUTE",
@@ -2847,7 +2847,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E098b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e098b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E098b.png"
     },
     {
         "name": "Kagamine HachiHachi Flower Fight",
@@ -2876,7 +2876,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E099.png"
     },
     {
         "name": "Unhappy Refrain",
@@ -2905,7 +2905,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_pd_s22_e100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E100.png"
     },
     {
         "name": "\"Close to You\"Hatsune Miku",
@@ -2932,7 +2932,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e101.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E101.png"
     },
     {
         "name": "\"To the Highest Stage\"Hatsune Miku",
@@ -2960,7 +2960,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e102.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E102.png"
     },
     {
         "name": "\"Black★Rock Shooter\"Hatsune Miku",
@@ -2986,7 +2986,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E103.png"
     },
     {
         "name": "Hatsune Miku\"Heartbeat\"",
@@ -3014,7 +3014,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E104a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e104a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E104a.png"
     },
     {
         "name": "Hatsune Miku\"Heartbeat\"",
@@ -3042,7 +3042,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E104b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e104b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E104b.png"
     },
     {
         "name": "Hatsune Miku\"Original\"",
@@ -3071,7 +3071,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e105.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E105.png"
     },
     {
         "name": "Black★Rock Shooter",
@@ -3100,7 +3100,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e106.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E106.png"
     },
     {
         "name": "Odds & Ends",
@@ -3129,7 +3129,7 @@
         "set": "PD",
         "release": "22",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_e107.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_E107.png"
     },
     {
         "name": "Summer Idol",
@@ -3620,7 +3620,7 @@
         "set": "PD",
         "release": "22",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S22_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_PE01.png"
     },
     {
         "name": "\"Time Machine\"Hatsune Miku",
@@ -3646,7 +3646,7 @@
         "set": "PD",
         "release": "22",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S22_PE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_PE05.png"
     },
     {
         "name": "Kagamine Len\"Append\"",
@@ -3672,7 +3672,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE01.png"
     },
     {
         "name": "Kagamine Len\"Trickster\"",
@@ -3698,7 +3698,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE02.png"
     },
     {
         "name": "Kagamine Rin\"Future Style\"",
@@ -3724,7 +3724,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE03.png"
     },
     {
         "name": "\"Continuing Dream\"Kagamine Rin",
@@ -3750,7 +3750,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE04.png"
     },
     {
         "name": "\"Continuing Dream\"Kagamine Len",
@@ -3778,7 +3778,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE05.png"
     },
     {
         "name": "Melancholic",
@@ -3804,7 +3804,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE06.png"
     },
     {
         "name": "Tengaku",
@@ -3833,7 +3833,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE07.png"
     },
     {
         "name": "Hatsune Miku\"Pansy\"",
@@ -3860,7 +3860,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE08.png"
     },
     {
         "name": "Hatsune Miku\"Deep Sky\"",
@@ -3886,7 +3886,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE09.png"
     },
     {
         "name": "Hatsune Miku\"Honey Whip\"",
@@ -3912,7 +3912,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE10.png"
     },
     {
         "name": "Hatsune Miku\"FOnewearl Style\"",
@@ -3938,7 +3938,7 @@
         "set": "PD",
         "release": "22",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE11.png"
     },
     {
         "name": "\"Full Power Mikku Miku\"Hatsune Miku",
@@ -3966,6 +3966,6 @@
         "set": "PD",
         "release": "22",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/pd_s22_te12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s22/PD_S22_TE12.png"
     }
 ]

--- a/DB/PD2_S29.json
+++ b/DB/PD2_S29.json
@@ -2,7 +2,7 @@
     {
         "name": "Kagamine Rin \"Original\"(F 2nd)",
         "code": "PD/S29-E001",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Hatsune Miku: Project DIVA F 2nd",
         "side": "S",
         "type": "Character",
@@ -746,7 +746,7 @@
     {
         "name": "Resonating \"DIVA\" Hatsune Miku",
         "code": "PD/S29-E026",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Hatsune Miku: Project DIVA F 2nd",
         "side": "S",
         "type": "Character",
@@ -776,7 +776,7 @@
     {
         "name": "\"Eternal Sounds\" Hatsune Miku",
         "code": "PD/S29-E027",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Hatsune Miku: Project DIVA F 2nd",
         "side": "S",
         "type": "Character",
@@ -1599,7 +1599,7 @@
     {
         "name": "Megurine Luka \"Original\"(F 2nd)",
         "code": "PD/S29-E057",
-        "rarity": "RR",
+        "rarity": "RR+",
         "expansion": "Hatsune Miku: Project DIVA F 2nd",
         "side": "S",
         "type": "Character",

--- a/DB/PD2_S29.json
+++ b/DB/PD2_S29.json
@@ -27,7 +27,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E001.png"
     },
     {
         "name": "Kagamine Rin \"Reactor\"",
@@ -56,7 +56,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E002.png"
     },
     {
         "name": "Kagamine Len \"Original\"(F 2nd)",
@@ -85,7 +85,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E003.png"
     },
     {
         "name": "Kagamine Rin \"Heat Haze\"",
@@ -112,7 +112,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E004.png"
     },
     {
         "name": "Kagamine Len \"Punkish\"",
@@ -138,7 +138,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E005.png"
     },
     {
         "name": "Kagamine Len \"Strangely Dark\"",
@@ -166,7 +166,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E006.png"
     },
     {
         "name": "Kagamine Rin \"Dreaming Panda\"",
@@ -194,7 +194,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E007.png"
     },
     {
         "name": "Kagamine Len \"Polar Bear in Love\"",
@@ -220,7 +220,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E008.png"
     },
     {
         "name": "Kagamine Rin \"Fairy Dress\"",
@@ -247,7 +247,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E009.png"
     },
     {
         "name": "Kagamine Rin \"Faker\"",
@@ -273,7 +273,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E010.png"
     },
     {
         "name": "Hatsune Miku \"Liar\"",
@@ -299,7 +299,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E011.png"
     },
     {
         "name": "Kagamine Len \"White Edge\"",
@@ -328,7 +328,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E012.png"
     },
     {
         "name": "Hatsune Miku \"Chat Noir\"",
@@ -354,7 +354,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E013a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E013a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E013a.png"
     },
     {
         "name": "Hatsune Miku \"Chat Noir\"",
@@ -380,7 +380,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E013b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E013b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E013b.png"
     },
     {
         "name": "Kagamine Len \"School Jersey\"",
@@ -406,7 +406,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E014.png"
     },
     {
         "name": "Hatsune Miku \"Urban Pop\"",
@@ -432,7 +432,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E015.png"
     },
     {
         "name": "Kagamine Rin \"Soleil\"",
@@ -459,7 +459,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E016.png"
     },
     {
         "name": "Kagamine Len \"Ciel\"",
@@ -486,7 +486,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E017.png"
     },
     {
         "name": "Kagamine Rin \"Cheerful Candy\"",
@@ -515,7 +515,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E018.png"
     },
     {
         "name": "Hatsune Miku \"Colorful Gumdrop\"",
@@ -544,7 +544,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E019.png"
     },
     {
         "name": "Colorful x Melody",
@@ -571,7 +571,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E020a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E020a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E020a.png"
     },
     {
         "name": "Colorful x Melody",
@@ -598,7 +598,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E020b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E020b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E020b.png"
     },
     {
         "name": "Envy Cat Walk",
@@ -624,7 +624,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E021.png"
     },
     {
         "name": "Kokoro",
@@ -654,7 +654,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E022.png"
     },
     {
         "name": "Soundless Voice",
@@ -683,7 +683,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E023.png"
     },
     {
         "name": "Roshin Yukai",
@@ -712,7 +712,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E024.png"
     },
     {
         "name": "Paradichlorobenzene",
@@ -741,7 +741,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E025.png"
     },
     {
         "name": "Resonating \"DIVA\" Hatsune Miku",
@@ -771,7 +771,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E026.png"
     },
     {
         "name": "\"Eternal Sounds\" Hatsune Miku",
@@ -800,7 +800,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E027.png"
     },
     {
         "name": "Hatsune Miku \"Magician\"",
@@ -827,7 +827,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E028.png"
     },
     {
         "name": "Hatsune Miku \"V3\"",
@@ -856,7 +856,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E029.png"
     },
     {
         "name": "Hatsune Miku \"White Dress\"",
@@ -883,7 +883,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E030.png"
     },
     {
         "name": "Hatsune Miku \"School\"",
@@ -909,7 +909,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E031.png"
     },
     {
         "name": "Hatsune Miku \"Orange Blossom\"",
@@ -936,7 +936,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E032.png"
     },
     {
         "name": "Hatsune Miku \"Orbit\"",
@@ -965,7 +965,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E033.png"
     },
     {
         "name": "Hatsune Miku \"Siren\"",
@@ -993,7 +993,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E034.png"
     },
     {
         "name": "Hatsune Miku \"Rainbow Lines\"",
@@ -1019,7 +1019,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E035.png"
     },
     {
         "name": "Hatsune Miku \"Puffy Pastels\"",
@@ -1045,7 +1045,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E036.png"
     },
     {
         "name": "Hatsune Miku \"∞\"",
@@ -1071,7 +1071,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E037.png"
     },
     {
         "name": "Hatsune Miku \"Meteorite\"",
@@ -1100,7 +1100,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E038.png"
     },
     {
         "name": "I'll Miku-Miku You♪ (For Reals)",
@@ -1126,7 +1126,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E039.png"
     },
     {
         "name": "Hatsune Miku \"Kitty Cat\"",
@@ -1152,7 +1152,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E040.png"
     },
     {
         "name": "Hatsune Miku \"Noble\"",
@@ -1178,7 +1178,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E041.png"
     },
     {
         "name": "Hatsune Miku \"Dimensional\"",
@@ -1204,7 +1204,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E042.png"
     },
     {
         "name": "Hatsune Miku \"Gothic\"",
@@ -1233,7 +1233,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E043.png"
     },
     {
         "name": "Hatsune Miku \"Natural\"",
@@ -1259,7 +1259,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E044.png"
     },
     {
         "name": "Hatsune Miku \"Heart Hunter\"",
@@ -1285,7 +1285,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E045.png"
     },
     {
         "name": "Hatsune Miku \"Conflicted\"",
@@ -1316,7 +1316,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E046.png"
     },
     {
         "name": "Hatsune Miku \"Out and About\"",
@@ -1344,7 +1344,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E047.png"
     },
     {
         "name": "The Intense Voice of Hatsune Miku",
@@ -1370,7 +1370,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E048.png"
     },
     {
         "name": "2D Dream Fever",
@@ -1396,7 +1396,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E049.png"
     },
     {
         "name": "Melt",
@@ -1423,7 +1423,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E050.png"
     },
     {
         "name": "Miracle Paint",
@@ -1449,7 +1449,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E051.png"
     },
     {
         "name": "Packaged",
@@ -1478,7 +1478,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E052.png"
     },
     {
         "name": "Two-Sided Lovers",
@@ -1507,7 +1507,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E053.png"
     },
     {
         "name": "SPiCa -39's Giving Day Edition-",
@@ -1536,7 +1536,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E054.png"
     },
     {
         "name": "Decorator",
@@ -1565,7 +1565,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E055.png"
     },
     {
         "name": "Glory 3usi9",
@@ -1594,7 +1594,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E056.png"
     },
     {
         "name": "Megurine Luka \"Original\"(F 2nd)",
@@ -1623,7 +1623,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E057.png"
     },
     {
         "name": "Megurine Luka \"Cybernation\"",
@@ -1649,7 +1649,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E058.png"
     },
     {
         "name": "MEIKO \"Original\"(F 2nd)",
@@ -1679,7 +1679,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E059.png"
     },
     {
         "name": "Megurine Luka \"Witch Girl Style\"",
@@ -1706,7 +1706,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E060.png"
     },
     {
         "name": "Hatsune Miku \"Breathe With You\"",
@@ -1733,7 +1733,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E061.png"
     },
     {
         "name": "Sakine Meiko \"Original\"",
@@ -1760,7 +1760,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E062.png"
     },
     {
         "name": "MEIKO \"Momiji\"",
@@ -1787,7 +1787,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E063.png"
     },
     {
         "name": "Megurine Luka \"Temptation\"",
@@ -1816,7 +1816,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E064a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E064a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E064a.png"
     },
     {
         "name": "Megurine Luka \"Temptation\"",
@@ -1845,7 +1845,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E064b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E064b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E064b.png"
     },
     {
         "name": "Megurine Luka \"Floral\"",
@@ -1872,7 +1872,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E065.png"
     },
     {
         "name": "Megurine Luka \"Fr?ulein\"",
@@ -1899,7 +1899,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E066.png"
     },
     {
         "name": "MEIKO \"Scarlet\"",
@@ -1925,7 +1925,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E067.png"
     },
     {
         "name": "Hatsune Miku \"Supreme\"",
@@ -1951,7 +1951,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E068.png"
     },
     {
         "name": "MEIKO \"Taisho Nostalgia\"",
@@ -1980,7 +1980,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E069.png"
     },
     {
         "name": "MEIKO \"Blazing\"",
@@ -2009,7 +2009,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E070.png"
     },
     {
         "name": "Megurine Luka \"Hard Rock\"",
@@ -2037,7 +2037,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E071.png"
     },
     {
         "name": "MEIKO \"Marine Ribbons\"",
@@ -2064,7 +2064,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E072.png"
     },
     {
         "name": "Hatsune Miku \"Butterfly\"",
@@ -2091,7 +2091,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E073.png"
     },
     {
         "name": "Megurine Luka \"Blossom\"",
@@ -2117,7 +2117,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E074.png"
     },
     {
         "name": "Hatsune Miku \"Little Red\"",
@@ -2143,7 +2143,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E075.png"
     },
     {
         "name": "MEIKO \"Fluffy Coat\"",
@@ -2169,7 +2169,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E076.png"
     },
     {
         "name": "Megurine Luka \"VF Suit\"",
@@ -2195,7 +2195,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E077.png"
     },
     {
         "name": "Megurine Luka \"Recruiter\"",
@@ -2221,7 +2221,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E078.png"
     },
     {
         "name": "MEIKO \"Lorelei\"",
@@ -2249,7 +2249,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E079.png"
     },
     {
         "name": "Hatsune Miku \"Avant-garde\"",
@@ -2278,7 +2278,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E080.png"
     },
     {
         "name": "Megurine Luka \"Successor\"",
@@ -2308,7 +2308,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E081.png"
     },
     {
         "name": "Blackjack",
@@ -2334,7 +2334,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E082.png"
     },
     {
         "name": "The World is Mine",
@@ -2360,7 +2360,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E083.png"
     },
     {
         "name": "Double Lariat",
@@ -2389,7 +2389,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E084.png"
     },
     {
         "name": "Break It, Break It!",
@@ -2418,7 +2418,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E085.png"
     },
     {
         "name": "Luka Luka ★ Night Fever",
@@ -2447,7 +2447,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E086.png"
     },
     {
         "name": "Akatsuki Arrival",
@@ -2476,7 +2476,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E087a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E087a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E087a.png"
     },
     {
         "name": "Akatsuki Arrival",
@@ -2505,7 +2505,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E087b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E087b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E087b.png"
     },
     {
         "name": "\"To Wherever You May Be\" Hatsune Miku",
@@ -2532,7 +2532,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E088.png"
     },
     {
         "name": "KAITO \"V3\"",
@@ -2561,7 +2561,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E089.png"
     },
     {
         "name": "Hatsune Miku \"Rosa Bianca\"",
@@ -2588,7 +2588,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E090a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E090a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E090a.png"
     },
     {
         "name": "Hatsune Miku \"Rosa Bianca\"",
@@ -2615,7 +2615,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E090b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E090b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E090b.png"
     },
     {
         "name": "KAITO \"Rosa Blue\"",
@@ -2642,7 +2642,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E091a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E091a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E091a.png"
     },
     {
         "name": "KAITO \"Rosa Blue\"",
@@ -2669,7 +2669,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E091b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E091b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E091b.png"
     },
     {
         "name": "KAITO \"Original\"(F 2nd)",
@@ -2697,7 +2697,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E092.png"
     },
     {
         "name": "KAITO \"Shigure\"",
@@ -2725,7 +2725,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E093.png"
     },
     {
         "name": "KAITO \"Holiday\"",
@@ -2751,7 +2751,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E094.png"
     },
     {
         "name": "Kagamine Rin \"Raspberry\"",
@@ -2777,7 +2777,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E095a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E095a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E095a.png"
     },
     {
         "name": "Kagamine Rin \"Raspberry Fox\"",
@@ -2803,7 +2803,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E095b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E095b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E095b.png"
     },
     {
         "name": "Kagamine Len \"Indigo\"",
@@ -2830,7 +2830,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E096a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E096a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E096a.png"
     },
     {
         "name": "Kagamine Len \"Indigo Fox\"",
@@ -2857,7 +2857,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E096b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E096b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E096b.png"
     },
     {
         "name": "Hatsune Miku \"Vintage Dress\"",
@@ -2883,7 +2883,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E097.png"
     },
     {
         "name": "KAITO \"Originator\"",
@@ -2910,7 +2910,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E098.png"
     },
     {
         "name": "Kagamine Len \"Eraser\"",
@@ -2939,7 +2939,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E099.png"
     },
     {
         "name": "KAITO \"Violet\"",
@@ -2967,7 +2967,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E100.png"
     },
     {
         "name": "Hatsune Miku \"Demons and the Dead\"",
@@ -2995,7 +2995,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E101.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E101.png"
     },
     {
         "name": "KAITO \"White Blazer\"",
@@ -3022,7 +3022,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E102.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E102.png"
     },
     {
         "name": "Hatsune Miku \"Hana-Kotoba\"",
@@ -3049,7 +3049,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E103.png"
     },
     {
         "name": "Hatsune Miku \"Kasha\"",
@@ -3076,7 +3076,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E104.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E104.png"
     },
     {
         "name": "Hatsune Miku \"Regret\"",
@@ -3103,7 +3103,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E105.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E105.png"
     },
     {
         "name": "Hatsune Miku \"Marionette\"",
@@ -3130,7 +3130,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E106a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E106a.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E106a.png"
     },
     {
         "name": "Hatsune Miku \"Marionette\"",
@@ -3157,7 +3157,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E106b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E106b.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E106b.png"
     },
     {
         "name": "Hatsune Miku \"Moonlight Butterfly\"",
@@ -3184,7 +3184,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E107.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E107.png"
     },
     {
         "name": "Kagamine Rin \"Sunflower\"",
@@ -3210,7 +3210,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E108.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E108.png"
     },
     {
         "name": "Kagamine Len \"Thorned Rose\"",
@@ -3236,7 +3236,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E109.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E109.png"
     },
     {
         "name": "KAITO \"Cyber Cat\"",
@@ -3262,7 +3262,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E110.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E110.png"
     },
     {
         "name": "Wintry Winds",
@@ -3288,7 +3288,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E111.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E111.png"
     },
     {
         "name": "Knife",
@@ -3314,7 +3314,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E112.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E112.png"
     },
     {
         "name": "Cantarella ～Grace Edition～",
@@ -3344,7 +3344,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E113.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E113.png"
     },
     {
         "name": "Romeo and Cinderella",
@@ -3371,7 +3371,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E114.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E114.png"
     },
     {
         "name": "Thousand Year Solo (DIVA Edit)",
@@ -3400,7 +3400,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E115.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E115.png"
     },
     {
         "name": "Erase or Zero",
@@ -3429,7 +3429,7 @@
         "set": "PD",
         "release": "29",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PD_S29_E116.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pd_s29/PD_S29_E116.png"
     },
     {
         "name": "Love-Hate",

--- a/DB/PIDX_S04.json
+++ b/DB/PIDX_S04.json
@@ -26,7 +26,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E001.png"
     },
     {
         "name": "Wish You Want to Fulfill, Kuro",
@@ -56,7 +56,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E002.png"
     },
     {
         "name": "Sweets Battle Outbreak! Kuro",
@@ -83,7 +83,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E003.png"
     },
     {
         "name": "Temporary Retreat, Kuro",
@@ -109,7 +109,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E004.png"
     },
     {
         "name": "Another “Illya”, Kuro",
@@ -135,7 +135,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E005.png"
     },
     {
         "name": "“Flame Burst, seven-fold” Luvia",
@@ -163,7 +163,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E006.png"
     },
     {
         "name": "“Miracle”? Kuro",
@@ -191,7 +191,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E007.png"
     },
     {
         "name": "“Gale Burst, five-fold” Rin",
@@ -220,7 +220,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E008.png"
     },
     {
         "name": "Kaleido Ruby, Rin",
@@ -247,7 +247,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E009.png"
     },
     {
         "name": "Luvia in Regular Clothes",
@@ -274,7 +274,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E010.png"
     },
     {
         "name": "Kuro All Ready for Gym",
@@ -301,7 +301,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E011.png"
     },
     {
         "name": "A Maid's Job, Rin",
@@ -327,7 +327,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E012.png"
     },
     {
         "name": "In a Pinch! Kuro",
@@ -353,7 +353,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E013.png"
     },
     {
         "name": "Rin in Uniform",
@@ -380,7 +380,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E014.png"
     },
     {
         "name": "Former Master, Rin",
@@ -406,7 +406,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E015.png"
     },
     {
         "name": "Former Master, Luvia",
@@ -432,7 +432,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E016.png"
     },
     {
         "name": "“Shared Pain” Kuro",
@@ -458,7 +458,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E017.png"
     },
     {
         "name": "Homurabara Academy Student, Kuro",
@@ -484,7 +484,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E018.png"
     },
     {
         "name": "Domineering Princess, Luvia",
@@ -510,7 +510,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E019.png"
     },
     {
         "name": "School Nursing, Karen",
@@ -536,7 +536,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E020.png"
     },
     {
         "name": "Kaleido Sapphire, Luvia",
@@ -562,7 +562,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E021.png"
     },
     {
         "name": "Top Candidate of Clock Tower, Rin",
@@ -589,7 +589,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E022.png"
     },
     {
         "name": "Sealing Designation Enforcer, Bazett",
@@ -617,7 +617,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E023.png"
     },
     {
         "name": "Luvia in Uniform",
@@ -646,7 +646,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E024.png"
     },
     {
         "name": "Mana Resupply",
@@ -675,7 +675,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E025.png"
     },
     {
         "name": "Behind the Lies and Strong Front",
@@ -704,7 +704,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E026.png"
     },
     {
         "name": "“Necessity”? Illya",
@@ -731,7 +731,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E027.png"
     },
     {
         "name": "Ties That Bind, Miyu",
@@ -758,7 +758,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E028.png"
     },
     {
         "name": "Something to Protect, Miyu",
@@ -788,7 +788,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E029.png"
     },
     {
         "name": "“Kaleidoscope” Illya",
@@ -817,7 +817,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E030.png"
     },
     {
         "name": "“Kaleidoscope” Miyu",
@@ -846,7 +846,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E031.png"
     },
     {
         "name": "Usual Scenery, Illya",
@@ -875,7 +875,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E032.png"
     },
     {
         "name": "In a Pinch! Illya",
@@ -902,7 +902,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E033.png"
     },
     {
         "name": "Magical Stick, Ruby",
@@ -928,7 +928,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E034.png"
     },
     {
         "name": "A Maid's Job, Miyu",
@@ -954,7 +954,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E035.png"
     },
     {
         "name": "“Coincidence”? Miyu",
@@ -981,7 +981,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E036.png"
     },
     {
         "name": "Kaleido Magical Girl, Illya",
@@ -1007,7 +1007,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E037.png"
     },
     {
         "name": "Perfect Super-human? Miyu",
@@ -1033,7 +1033,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E038.png"
     },
     {
         "name": "Maid Outfit Miyu",
@@ -1062,7 +1062,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E039.png"
     },
     {
         "name": "Swimsuit Illya & Miyu",
@@ -1091,7 +1091,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E040.png"
     },
     {
         "name": "Dreamy Girl, Illya",
@@ -1121,7 +1121,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E041.png"
     },
     {
         "name": "Big Bath at Luvia's Mansion, Miyu",
@@ -1150,7 +1150,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E042.png"
     },
     {
         "name": "To Protect Daily Life, Illya",
@@ -1179,7 +1179,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E043.png"
     },
     {
         "name": "Practicing Magic, Illya",
@@ -1206,7 +1206,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E044.png"
     },
     {
         "name": "Worst Luck!? Illya",
@@ -1232,7 +1232,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E045.png"
     },
     {
         "name": "“Big Bro” Shirou",
@@ -1260,7 +1260,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E046.png"
     },
     {
         "name": "Kaleido Magical Girl, Miyu",
@@ -1287,7 +1287,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E047.png"
     },
     {
         "name": "“Promise” Illya",
@@ -1313,7 +1313,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E048.png"
     },
     {
         "name": "Sudden Transfer Student, Miyu",
@@ -1339,7 +1339,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E049.png"
     },
     {
         "name": "Normal Girl, Illya",
@@ -1365,7 +1365,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E050.png"
     },
     {
         "name": "Homurabara Academy Student, Miyu",
@@ -1391,7 +1391,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E051.png"
     },
     {
         "name": "Mission Failed!? Miyu",
@@ -1417,7 +1417,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E052.png"
     },
     {
         "name": "Cooking is Love, Illya",
@@ -1443,7 +1443,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E053.png"
     },
     {
         "name": "Illya Being Toyed Around With",
@@ -1469,7 +1469,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E054.png"
     },
     {
         "name": "Sign of Closeness, Leys",
@@ -1495,7 +1495,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E055.png"
     },
     {
         "name": "“Mama” Irisviel",
@@ -1524,7 +1524,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E056.png"
     },
     {
         "name": "Magical Stick, Sapphire",
@@ -1552,7 +1552,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E057.png"
     },
     {
         "name": "Trainer, Sella",
@@ -1580,7 +1580,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E058.png"
     },
     {
         "name": "At the End of the Night, Illya",
@@ -1608,7 +1608,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E059.png"
     },
     {
         "name": "Realistic Miyu",
@@ -1637,7 +1637,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E060.png"
     },
     {
         "name": "“Friend” Illya & Miyu",
@@ -1666,7 +1666,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E061.png"
     },
     {
         "name": "Magical Sapphire",
@@ -1694,7 +1694,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E062.png"
     },
     {
         "name": "Einzbern Family, Sella & Leys",
@@ -1720,7 +1720,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E063.png"
     },
     {
         "name": "Classmate, Mimi",
@@ -1746,7 +1746,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E064.png"
     },
     {
         "name": "“Mama's Intuition” Irisviel",
@@ -1772,7 +1772,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E065.png"
     },
     {
         "name": "Miyu in Regular Clothes",
@@ -1798,7 +1798,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E066.png"
     },
     {
         "name": "Classmate, Suzuka",
@@ -1824,7 +1824,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E067.png"
     },
     {
         "name": "Magical Ruby",
@@ -1851,7 +1851,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E068.png"
     },
     {
         "name": "“Belief” Miyu",
@@ -1878,7 +1878,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E069.png"
     },
     {
         "name": "After School with Friends, Illya",
@@ -1904,7 +1904,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E070.png"
     },
     {
         "name": "After School with Friends, Miyu",
@@ -1930,7 +1930,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E071.png"
     },
     {
         "name": "Guided Fate, Illya",
@@ -1956,7 +1956,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E072.png"
     },
     {
         "name": "Homeroom Teacher, Taiga",
@@ -1982,7 +1982,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E073.png"
     },
     {
         "name": "“Saber” Install, Miyu",
@@ -2009,7 +2009,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E074.png"
     },
     {
         "name": "Illya in Pajamas",
@@ -2036,7 +2036,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E075.png"
     },
     {
         "name": "Classmate, Tatsuko",
@@ -2062,7 +2062,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E076.png"
     },
     {
         "name": "Lovestruck Miyu",
@@ -2090,7 +2090,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E077.png"
     },
     {
         "name": "Big Bath at Luvia's Mansion, Illya",
@@ -2118,7 +2118,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E078.png"
     },
     {
         "name": "Classmate, Nanaki",
@@ -2146,7 +2146,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E079.png"
     },
     {
         "name": "Another Magical Girl, Miyu",
@@ -2174,7 +2174,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E080.png"
     },
     {
         "name": "Class Card, Saber",
@@ -2204,7 +2204,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E081.png"
     },
     {
         "name": "Another Me",
@@ -2234,7 +2234,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E082.png"
     },
     {
         "name": "Birth of A Magical Girl!!",
@@ -2263,7 +2263,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E083.png"
     },
     {
         "name": "Class Card, Archer",
@@ -2292,7 +2292,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E084.png"
     },
     {
         "name": "Class Card, Lancer",
@@ -2321,7 +2321,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E085.png"
     },
     {
         "name": "Class Card, Rider",
@@ -2350,7 +2350,7 @@
         "set": "PI",
         "release": "04",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_E086.png"
     },
     {
         "name": "Holiday Together with Friends, Illya",
@@ -2376,7 +2376,7 @@
         "set": "PI",
         "release": "04",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_PIEN_S04_PE01PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/p/pi_en_s04/PI_EN_S04_PE01.png"
     },
     {
         "name": "Yearning for Summer Vacation",

--- a/DB/RSL_S56.json
+++ b/DB/RSL_S56.json
@@ -24,7 +24,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E001.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E001.png",
         "price": "8.00"
     },
     {
@@ -56,7 +56,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E002.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E002.png",
         "price": "5.00"
     },
     {
@@ -86,7 +86,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E003.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E003.png",
         "price": "12.00"
     },
     {
@@ -114,7 +114,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E004.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E004.png",
         "price": "3.00"
     },
     {
@@ -141,7 +141,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E005.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E005.png",
         "price": "3.00"
     },
     {
@@ -169,7 +169,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E006.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E006.png",
         "price": "5.00"
     },
     {
@@ -197,7 +197,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E007.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E007.png",
         "price": "1.00"
     },
     {
@@ -225,7 +225,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E008.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E008.png",
         "price": "2.00"
     },
     {
@@ -255,7 +255,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E009.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E009.png",
         "price": "1.00"
     },
     {
@@ -285,7 +285,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E010.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E010.png",
         "price": "2.00"
     },
     {
@@ -313,7 +313,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E011.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E011.png",
         "price": "0.50"
     },
     {
@@ -341,7 +341,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E012.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E012.png",
         "price": "0.50"
     },
     {
@@ -369,7 +369,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E013.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E013.png",
         "price": "0.50"
     },
     {
@@ -397,7 +397,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E014.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E014.png",
         "price": "0.50"
     },
     {
@@ -425,7 +425,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E015.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E015.png",
         "price": "0.50"
     },
     {
@@ -455,7 +455,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E016.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E016.png",
         "price": "0.50"
     },
     {
@@ -485,7 +485,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E017.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E017.png",
         "price": "0.50"
     },
     {
@@ -513,7 +513,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E018.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E018.png",
         "price": "0.25"
     },
     {
@@ -541,7 +541,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E019.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E019.png",
         "price": "0.25"
     },
     {
@@ -569,7 +569,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E020.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E020.png",
         "price": "0.25"
     },
     {
@@ -597,7 +597,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E021.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E021.png",
         "price": "0.25"
     },
     {
@@ -624,7 +624,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E022.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E022.png",
         "price": "0.25"
     },
     {
@@ -651,7 +651,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E023.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E023.png",
         "price": "0.25"
     },
     {
@@ -678,7 +678,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E024.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E024.png",
         "price": "0.25"
     },
     {
@@ -705,7 +705,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E025.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E025.png",
         "price": "0.25"
     },
     {
@@ -736,7 +736,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E026.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E026.png",
         "price": "0.25"
     },
     {
@@ -765,7 +765,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E027.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E027.png",
         "price": "0.25"
     },
     {
@@ -795,7 +795,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E028.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E028.png",
         "price": "0.25"
     },
     {
@@ -822,7 +822,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E029.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E029.png",
         "price": "0.50"
     },
     {
@@ -850,7 +850,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E030.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E030.png",
         "price": "0.50"
     },
     {
@@ -881,7 +881,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E031.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E031.png",
         "price": "2.00"
     },
     {
@@ -912,7 +912,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E032.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E032.png",
         "price": "0.50"
     },
     {
@@ -943,7 +943,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E033.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E033.png",
         "price": "0.25"
     },
     {
@@ -971,7 +971,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E034.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E034.png",
         "price": "10.00"
     },
     {
@@ -999,7 +999,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E035.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E035.png",
         "price": "15.00"
     },
     {
@@ -1029,7 +1029,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E036.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E036.png",
         "price": "8.00"
     },
     {
@@ -1059,7 +1059,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E037.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E037.png",
         "price": "5.00"
     },
     {
@@ -1087,7 +1087,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E038.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E038.png",
         "price": "1.00"
     },
     {
@@ -1115,7 +1115,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E039.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E039.png",
         "price": "1.00"
     },
     {
@@ -1143,7 +1143,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E040.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E040.png",
         "price": "1.00"
     },
     {
@@ -1170,7 +1170,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E041.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E041.png",
         "price": "1.00"
     },
     {
@@ -1198,7 +1198,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E042.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E042.png",
         "price": "1.50"
     },
     {
@@ -1226,7 +1226,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E043.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E043.png",
         "price": "1.00"
     },
     {
@@ -1254,7 +1254,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E044.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E044.png",
         "price": "2.00"
     },
     {
@@ -1284,7 +1284,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E045.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E045.png",
         "price": "1.00"
     },
     {
@@ -1314,7 +1314,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E046.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E046.png",
         "price": "1.00"
     },
     {
@@ -1342,7 +1342,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E047.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E047.png",
         "price": "0.50"
     },
     {
@@ -1369,7 +1369,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E048.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E048.png",
         "price": "1.00"
     },
     {
@@ -1397,7 +1397,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E049.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E049.png",
         "price": "0.50"
     },
     {
@@ -1425,7 +1425,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E050.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E050.png",
         "price": "0.75"
     },
     {
@@ -1453,7 +1453,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E051.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E051.png",
         "price": "0.50"
     },
     {
@@ -1484,7 +1484,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E052.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E052.png",
         "price": "0.50"
     },
     {
@@ -1514,7 +1514,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E053.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E053.png",
         "price": "0.50"
     },
     {
@@ -1544,7 +1544,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E054.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E054.png",
         "price": "0.50"
     },
     {
@@ -1571,7 +1571,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E055.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E055.png",
         "price": "0.25"
     },
     {
@@ -1598,7 +1598,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E056.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E056.png",
         "price": "0.25"
     },
     {
@@ -1626,7 +1626,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E057.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E057.png",
         "price": "0.25"
     },
     {
@@ -1655,7 +1655,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E058.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E058.png",
         "price": "0.25"
     },
     {
@@ -1682,7 +1682,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E059.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E059.png",
         "price": "0.25"
     },
     {
@@ -1712,7 +1712,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E060.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E060.png",
         "price": "0.25"
     },
     {
@@ -1741,7 +1741,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E061.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E061.png",
         "price": "0.25"
     },
     {
@@ -1768,7 +1768,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E062.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E062.png",
         "price": "0.50"
     },
     {
@@ -1798,7 +1798,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E063.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E063.png",
         "price": "1.00"
     },
     {
@@ -1828,7 +1828,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E064.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E064.png",
         "price": "1.50"
     },
     {
@@ -1859,7 +1859,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E065.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E065.png",
         "price": "1.00"
     },
     {
@@ -1887,7 +1887,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E066.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E066.png",
         "price": "8.00"
     },
     {
@@ -1918,7 +1918,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E067.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E067.png",
         "price": "5.00"
     },
     {
@@ -1948,7 +1948,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E068.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E068.png",
         "price": "7.00"
     },
     {
@@ -1976,7 +1976,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E069.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E069.png",
         "price": "1.00"
     },
     {
@@ -2003,7 +2003,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E070.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E070.png",
         "price": "1.00"
     },
     {
@@ -2031,7 +2031,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E071.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E071.png",
         "price": "1.50"
     },
     {
@@ -2059,7 +2059,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E072.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E072.png",
         "price": "1.00"
     },
     {
@@ -2087,7 +2087,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E073.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E073.png",
         "price": "2.00"
     },
     {
@@ -2118,7 +2118,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E074.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E074.png",
         "price": "1.50"
     },
     {
@@ -2146,7 +2146,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E075.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E075.png",
         "price": "0.50"
     },
     {
@@ -2174,7 +2174,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E076.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E076.png",
         "price": "2.00"
     },
     {
@@ -2202,7 +2202,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E077.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E077.png",
         "price": "0.50"
     },
     {
@@ -2229,7 +2229,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E078.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E078.png",
         "price": "0.50"
     },
     {
@@ -2260,7 +2260,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E079.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E079.png",
         "price": "0.50"
     },
     {
@@ -2290,7 +2290,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E080.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E080.png",
         "price": "0.50"
     },
     {
@@ -2320,7 +2320,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E081.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E081.png",
         "price": "0.50"
     },
     {
@@ -2350,7 +2350,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E082.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E082.png",
         "price": "0.50"
     },
     {
@@ -2378,7 +2378,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E083.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E083.png",
         "price": "0.25"
     },
     {
@@ -2406,7 +2406,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E084.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E084.png",
         "price": "0.25"
     },
     {
@@ -2435,7 +2435,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E085.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E085.png",
         "price": "0.25"
     },
     {
@@ -2462,7 +2462,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E086.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E086.png",
         "price": "0.25"
     },
     {
@@ -2489,7 +2489,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E087.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E087.png",
         "price": "0.25"
     },
     {
@@ -2516,7 +2516,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E088.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E088.png",
         "price": "0.25"
     },
     {
@@ -2546,7 +2546,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E089.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E089.png",
         "price": "0.25"
     },
     {
@@ -2576,7 +2576,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E090.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E090.png",
         "price": "0.25"
     },
     {
@@ -2606,7 +2606,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E091.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E091.png",
         "price": "0.25"
     },
     {
@@ -2636,7 +2636,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E092.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E092.png",
         "price": "0.25"
     },
     {
@@ -2663,7 +2663,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E093.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E093.png",
         "price": "0.50"
     },
     {
@@ -2690,7 +2690,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E094.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E094.png",
         "price": "0.50"
     },
     {
@@ -2721,7 +2721,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E095.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E095.png",
         "price": "1.50"
     },
     {
@@ -2751,7 +2751,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E096.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E096.png",
         "price": "0.50"
     },
     {
@@ -2781,7 +2781,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E097.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E097.png",
         "price": "0.25"
     },
     {
@@ -2811,7 +2811,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E098.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E098.png",
         "price": "0.25"
     },
     {
@@ -2841,7 +2841,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E099.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E099.png",
         "price": "0.25"
     },
     {
@@ -2871,7 +2871,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E100.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E100.png",
         "price": "0.25"
     },
     {
@@ -2899,7 +2899,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E101.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E101.png",
         "price": "3.00"
     },
     {
@@ -2927,7 +2927,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E102.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E102.png",
         "price": "3.00"
     },
     {
@@ -2955,7 +2955,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E103.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E103.png",
         "price": "3.00"
     },
     {
@@ -2982,7 +2982,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E104.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E104.png",
         "price": "5.00"
     },
     {
@@ -3012,7 +3012,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E105.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E105.png",
         "price": "3.00"
     },
     {
@@ -3039,7 +3039,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_E106.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_E106.png",
         "price": "3.00"
     },
     {
@@ -3067,7 +3067,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_PE05.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_PE05.png",
         "price": "2.00"
     },
     {
@@ -3095,7 +3095,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE01.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE01.png",
         "price": "2.00"
     },
     {
@@ -3122,7 +3122,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE02.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE02.png",
         "price": "2.00"
     },
     {
@@ -3149,7 +3149,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE03.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE03.png",
         "price": "0.50"
     },
     {
@@ -3176,7 +3176,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE04.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE04.png",
         "price": "0.50"
     },
     {
@@ -3205,7 +3205,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE05.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE05.png",
         "price": "0.50"
     },
     {
@@ -3235,7 +3235,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE06.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE06.png",
         "price": "1.00"
     },
     {
@@ -3266,7 +3266,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE07.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE07.png",
         "price": "0.50"
     },
     {
@@ -3294,7 +3294,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE08.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE08.png",
         "price": "2.00"
     },
     {
@@ -3322,7 +3322,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE09.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE09.png",
         "price": "0.50"
     },
     {
@@ -3350,7 +3350,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE10.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE10.png",
         "price": "0.50"
     },
     {
@@ -3377,7 +3377,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE11.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE11.png",
         "price": "0.25"
     },
     {
@@ -3404,7 +3404,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE12.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE12.png",
         "price": "0.50"
     },
     {
@@ -3434,7 +3434,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE13.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE13.png",
         "price": "3.00"
     },
     {
@@ -3461,7 +3461,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE14.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE14.png",
         "price": "0.50"
     },
     {
@@ -3491,7 +3491,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE15.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE15.png",
         "price": "0.25"
     },
     {
@@ -3519,7 +3519,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE16.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE16.png",
         "price": "0.50"
     },
     {
@@ -3546,7 +3546,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE17.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE17.png",
         "price": "0.50"
     },
     {
@@ -3574,7 +3574,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE18.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE18.png",
         "price": "0.50"
     },
     {
@@ -3604,7 +3604,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE19.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE19.png",
         "price": "0.50"
     },
     {
@@ -3633,7 +3633,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE20.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE20.png",
         "price": "0.50"
     },
     {
@@ -3662,7 +3662,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE21.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE21.png",
         "price": "0.50"
     },
     {
@@ -3692,7 +3692,7 @@
         "set": "RSL",
         "release": "56",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RSL_S56_TE22.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rsl_s56/RSL_S56_TE22.png",
         "price": "0.50"
     }
 ]

--- a/DB/RZ2_S55.json
+++ b/DB/RZ2_S55.json
@@ -27,7 +27,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E001.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E001.png",
         "price": "2.00"
     },
     {
@@ -57,7 +57,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E002.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E002.png",
         "price": "4.00"
     },
     {
@@ -85,7 +85,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E003.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E003.png",
         "price": "1.00"
     },
     {
@@ -113,7 +113,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E004.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E004.png",
         "price": "1.00"
     },
     {
@@ -140,7 +140,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E005.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E005.png",
         "price": "2.00"
     },
     {
@@ -170,7 +170,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E006.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E006.png",
         "price": "1.00"
     },
     {
@@ -198,7 +198,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E007.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E007.png",
         "price": "0.50"
     },
     {
@@ -227,7 +227,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E008.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E008.png",
         "price": "1.50"
     },
     {
@@ -254,7 +254,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E009.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E009.png",
         "price": "0.50"
     },
     {
@@ -282,7 +282,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E010.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E010.png",
         "price": "0.50"
     },
     {
@@ -310,7 +310,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E011.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E011.png",
         "price": "0.50"
     },
     {
@@ -340,7 +340,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E012.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E012.png",
         "price": "0.50"
     },
     {
@@ -369,7 +369,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E013.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E013.png",
         "price": "0.50"
     },
     {
@@ -396,7 +396,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E014.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E014.png",
         "price": "0.25"
     },
     {
@@ -424,7 +424,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E015.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E015.png",
         "price": "0.50"
     },
     {
@@ -451,7 +451,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E016.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E016.png",
         "price": "0.25"
     },
     {
@@ -479,7 +479,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E017.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E017.png",
         "price": "0.25"
     },
     {
@@ -507,7 +507,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E018.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E018.png",
         "price": "0.25"
     },
     {
@@ -535,7 +535,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E019.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E019.png",
         "price": "0.25"
     },
     {
@@ -565,7 +565,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E020.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E020.png",
         "price": "0.25"
     },
     {
@@ -594,7 +594,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E021.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E021.png",
         "price": "0.25"
     },
     {
@@ -621,7 +621,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E022.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E022.png",
         "price": "0.50"
     },
     {
@@ -652,7 +652,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E023.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E023.png",
         "price": "1.00"
     },
     {
@@ -683,7 +683,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E024.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E024.png",
         "price": "0.50"
     },
     {
@@ -713,7 +713,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E025.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E025.png",
         "price": "0.50"
     },
     {
@@ -741,7 +741,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E026.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E026.png",
         "price": "10.00"
     },
     {
@@ -769,7 +769,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E027.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E027.png",
         "price": "5.00"
     },
     {
@@ -800,7 +800,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E028.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E028.png",
         "price": "2.00"
     },
     {
@@ -828,7 +828,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E029.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E029.png",
         "price": "1.00"
     },
     {
@@ -856,7 +856,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E030.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E030.png",
         "price": "1.00"
     },
     {
@@ -883,7 +883,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E031.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E031.png",
         "price": "1.00"
     },
     {
@@ -911,7 +911,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E032.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E032.png",
         "price": "1.00"
     },
     {
@@ -939,7 +939,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E033.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E033.png",
         "price": "1.00"
     },
     {
@@ -969,7 +969,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E034.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E034.png",
         "price": "1.00"
     },
     {
@@ -1000,7 +1000,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E035.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E035.png",
         "price": "2.00"
     },
     {
@@ -1028,7 +1028,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E036.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E036.png",
         "price": "0.50"
     },
     {
@@ -1056,7 +1056,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E037.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E037.png",
         "price": "0.50"
     },
     {
@@ -1084,7 +1084,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E038.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E038.png",
         "price": "0.50"
     },
     {
@@ -1112,7 +1112,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E039.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E039.png",
         "price": "0.50"
     },
     {
@@ -1142,7 +1142,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E040.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E040.png",
         "price": "0.50"
     },
     {
@@ -1172,7 +1172,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E041.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E041.png",
         "price": "0.50"
     },
     {
@@ -1200,7 +1200,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E042.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E042.png",
         "price": "0.25"
     },
     {
@@ -1228,7 +1228,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E043.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E043.png",
         "price": "0.25"
     },
     {
@@ -1255,7 +1255,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E044.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E044.png",
         "price": "0.25"
     },
     {
@@ -1282,7 +1282,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E045.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E045.png",
         "price": "0.25"
     },
     {
@@ -1309,7 +1309,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E046.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E046.png",
         "price": "0.25"
     },
     {
@@ -1336,7 +1336,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E047.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E047.png",
         "price": "0.25"
     },
     {
@@ -1366,7 +1366,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E048.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E048.png",
         "price": "0.25"
     },
     {
@@ -1395,7 +1395,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E049.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E049.png",
         "price": "0.25"
     },
     {
@@ -1423,7 +1423,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E050.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E050.png",
         "price": "0.50"
     },
     {
@@ -1450,7 +1450,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E051.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E051.png",
         "price": "0.50"
     },
     {
@@ -1480,7 +1480,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E052.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E052.png",
         "price": "1.00"
     },
     {
@@ -1510,7 +1510,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E053.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E053.png",
         "price": "0.50"
     },
     {
@@ -1540,7 +1540,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E054.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E054.png",
         "price": "0.50"
     },
     {
@@ -1570,7 +1570,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E055.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E055.png",
         "price": "0.50"
     },
     {
@@ -1598,7 +1598,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E056.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E056.png",
         "price": "15.00"
     },
     {
@@ -1626,7 +1626,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E057.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E057.png",
         "price": "25.00"
     },
     {
@@ -1654,7 +1654,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E058.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E058.png",
         "price": "8.00"
     },
     {
@@ -1685,7 +1685,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E059.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E059.png",
         "price": "10.00"
     },
     {
@@ -1716,7 +1716,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E060.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E060.png",
         "price": "6.00"
     },
     {
@@ -1744,7 +1744,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E061.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E061.png",
         "price": "1.00"
     },
     {
@@ -1772,7 +1772,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E062.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E062.png",
         "price": "3.00"
     },
     {
@@ -1800,7 +1800,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E063.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E063.png",
         "price": "1.00"
     },
     {
@@ -1828,7 +1828,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E064.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E064.png",
         "price": "2.00"
     },
     {
@@ -1856,7 +1856,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E065.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E065.png",
         "price": "2.00"
     },
     {
@@ -1884,7 +1884,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E066.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E066.png",
         "price": "1.00"
     },
     {
@@ -1912,7 +1912,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E067.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E067.png",
         "price": "2.00"
     },
     {
@@ -1941,7 +1941,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E068.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E068.png",
         "price": "1.00"
     },
     {
@@ -1968,7 +1968,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E069.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E069.png",
         "price": "1.00"
     },
     {
@@ -1998,7 +1998,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E070.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E070.png",
         "price": "1.00"
     },
     {
@@ -2029,7 +2029,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E071.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E071.png",
         "price": "1.00"
     },
     {
@@ -2058,7 +2058,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E072.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E072.png",
         "price": "0.50"
     },
     {
@@ -2086,7 +2086,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E073.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E073.png",
         "price": "0.50"
     },
     {
@@ -2114,7 +2114,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E074.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E074.png",
         "price": "1.00"
     },
     {
@@ -2142,7 +2142,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E075.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E075.png",
         "price": "0.50"
     },
     {
@@ -2170,7 +2170,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E076.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E076.png",
         "price": "0.50"
     },
     {
@@ -2198,7 +2198,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E077.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E077.png",
         "price": "0.50"
     },
     {
@@ -2228,7 +2228,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E078.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E078.png",
         "price": "0.50"
     },
     {
@@ -2258,7 +2258,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E079.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E079.png",
         "price": "0.50"
     },
     {
@@ -2288,7 +2288,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E080.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E080.png",
         "price": "0.50"
     },
     {
@@ -2318,7 +2318,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E081.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E081.png",
         "price": "0.50"
     },
     {
@@ -2346,7 +2346,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E082.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E082.png",
         "price": "0.25"
     },
     {
@@ -2374,7 +2374,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E083.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E083.png",
         "price": "0.25"
     },
     {
@@ -2402,7 +2402,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E084.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E084.png",
         "price": "0.25"
     },
     {
@@ -2430,7 +2430,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E085.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E085.png",
         "price": "0.25"
     },
     {
@@ -2457,7 +2457,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E086.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E086.png",
         "price": "0.25"
     },
     {
@@ -2484,7 +2484,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E087.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E087.png",
         "price": "0.25"
     },
     {
@@ -2511,7 +2511,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E088.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E088.png",
         "price": "0.25"
     },
     {
@@ -2541,7 +2541,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E089.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E089.png",
         "price": "0.25"
     },
     {
@@ -2571,7 +2571,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E090.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E090.png",
         "price": "0.25"
     },
     {
@@ -2601,7 +2601,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E091.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E091.png",
         "price": "0.25"
     },
     {
@@ -2631,7 +2631,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E092.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E092.png",
         "price": "0.25"
     },
     {
@@ -2661,7 +2661,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E093.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E093.png",
         "price": "0.25"
     },
     {
@@ -2688,7 +2688,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E094.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E094.png",
         "price": "0.50"
     },
     {
@@ -2715,7 +2715,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E095.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E095.png",
         "price": "0.50"
     },
     {
@@ -2745,7 +2745,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E096.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E096.png",
         "price": "1.00"
     },
     {
@@ -2776,7 +2776,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E097.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E097.png",
         "price": "1.00"
     },
     {
@@ -2807,7 +2807,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E098.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E098.png",
         "price": "0.50"
     },
     {
@@ -2837,7 +2837,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E099.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E099.png",
         "price": "0.50"
     },
     {
@@ -2867,7 +2867,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E100.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E100.png",
         "price": "0.50"
     },
     {
@@ -2894,7 +2894,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E101.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E101.png",
         "price": "4.00"
     },
     {
@@ -2921,7 +2921,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E102.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E102.png",
         "price": "3.00"
     },
     {
@@ -2951,7 +2951,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E103.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E103.png",
         "price": "3.00"
     },
     {
@@ -2979,7 +2979,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E104.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E104.png",
         "price": "3.00"
     },
     {
@@ -3006,7 +3006,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_E105.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_E105.png",
         "price": "3.00"
     },
     {
@@ -3035,7 +3035,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_PE04.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_PE04.png",
         "price": "2.00"
     },
     {
@@ -3065,7 +3065,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "PE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_PE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_PE05.png"
     },
     {
         "name": "Morning Chores, Rem",
@@ -3092,7 +3092,7 @@
         "set": "RZ",
         "release": "55",
         "sid": "PE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S55_PE08.png",
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s55/RZ_S55_PE08.png",
         "price": "5.00"
     }
 ]

--- a/DB/RZ_S46.json
+++ b/DB/RZ_S46.json
@@ -27,7 +27,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E001.png"
     },
     {
         "name": "Former Sword Saint, Theresia",
@@ -54,7 +54,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E002.png"
     },
     {
         "name": "Head of House Karsten, Crusch",
@@ -82,7 +82,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E003.png"
     },
     {
         "name": "Young Swordsman, Wilhelm",
@@ -109,7 +109,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E004.png"
     },
     {
         "name": "Declaration of War, Felt",
@@ -135,7 +135,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E005.png"
     },
     {
         "name": "The Greatest Knight, Julius",
@@ -162,7 +162,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E006.png"
     },
     {
         "name": "Sword Saint, Reinhard",
@@ -191,7 +191,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E007.png"
     },
     {
         "name": "Expert Negotiator, Anastasia",
@@ -217,7 +217,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E008.png"
     },
     {
         "name": "Healer, Felix",
@@ -245,7 +245,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E009.png"
     },
     {
         "name": "White Whale Hunt, Crusch",
@@ -273,7 +273,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E010.png"
     },
     {
         "name": "Felt's Knight, Reinhard",
@@ -300,7 +300,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E011.png"
     },
     {
         "name": "Old Man Rom",
@@ -328,7 +328,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E012.png"
     },
     {
         "name": "Pride of the Slums, Felt",
@@ -356,7 +356,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E013.png"
     },
     {
         "name": "Wilhelm van Astrea",
@@ -386,7 +386,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E014.png"
     },
     {
         "name": "Unseen Hand, Petelgeuse",
@@ -416,7 +416,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E015.png"
     },
     {
         "name": "Sloth Sin Archbishop, Petelgeuse",
@@ -445,7 +445,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E016.png"
     },
     {
         "name": "Thankful Feelings, Felt",
@@ -471,7 +471,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E017.png"
     },
     {
         "name": "Fang of Iron Vice-Captain, Mimi",
@@ -499,7 +499,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E018.png"
     },
     {
         "name": "Fang of Iron Vice-Captain, Hetaro",
@@ -527,7 +527,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E019.png"
     },
     {
         "name": "Priscilla's Knight, Aldebaran",
@@ -554,7 +554,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E020.png"
     },
     {
         "name": "Royal Election Candidate, Anastasia",
@@ -580,7 +580,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E021.png"
     },
     {
         "name": "Royal Election Candidate, Priscilla",
@@ -607,7 +607,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E022.png"
     },
     {
         "name": "Negotiating An Alliance, Crusch",
@@ -634,7 +634,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E023.png"
     },
     {
         "name": "Airs of a Queen, Priscilla",
@@ -663,7 +663,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E024.png"
     },
     {
         "name": "Bowel Hunter, Elsa",
@@ -692,7 +692,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E025.png"
     },
     {
         "name": "Fang of Iron Captain, Ricardo",
@@ -720,7 +720,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E026.png"
     },
     {
         "name": "Royal Election",
@@ -753,7 +753,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E027a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E027a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E027a.png"
     },
     {
         "name": "Royal Election",
@@ -786,7 +786,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E027b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E027b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E027b.png"
     },
     {
         "name": "Royal Election",
@@ -819,7 +819,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E027c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E027c.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E027c.png"
     },
     {
         "name": "Royal Election",
@@ -852,7 +852,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E027d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E027d.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E027d.png"
     },
     {
         "name": "Royal Election",
@@ -885,7 +885,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E027e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E027e.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E027e.png"
     },
     {
         "name": "Mistral Maiden",
@@ -914,7 +914,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E028.png"
     },
     {
         "name": "Hundred Man Sword Strike",
@@ -944,7 +944,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E029.png"
     },
     {
         "name": "Pink-Haired Maid, Ram",
@@ -974,7 +974,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E030.png"
     },
     {
         "name": "Cute Girl, Beatrice",
@@ -1004,7 +1004,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E031.png"
     },
     {
         "name": "Roswaal Mansion Maid, Ram",
@@ -1031,7 +1031,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E032.png"
     },
     {
         "name": "Clairvoyance, Ram",
@@ -1059,7 +1059,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E033.png"
     },
     {
         "name": "The Maid Saw! Ram",
@@ -1087,7 +1087,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E034.png"
     },
     {
         "name": "Canopy-Piercing Sunlight, Rem & Ram",
@@ -1114,7 +1114,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E035.png"
     },
     {
         "name": "Sunset Knoll, Beatrice",
@@ -1141,7 +1141,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E036.png"
     },
     {
         "name": "Forbidden Library Warden, Beatrice",
@@ -1167,7 +1167,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E037.png"
     },
     {
         "name": "Bathtime! Rem & Ram",
@@ -1197,7 +1197,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E038.png"
     },
     {
         "name": "With Puck, Subaru",
@@ -1224,7 +1224,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E039.png"
     },
     {
         "name": "Court Sorcerer, Roswaal",
@@ -1257,7 +1257,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E040.png"
     },
     {
         "name": "Forbidden Library Librarian, Beatrice",
@@ -1284,7 +1284,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E041.png"
     },
     {
         "name": "Oni Prodigy, Ram",
@@ -1311,7 +1311,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E042.png"
     },
     {
         "name": "With Puck, Beatrice",
@@ -1340,7 +1340,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E043.png"
     },
     {
         "name": "Self-Praise, Ram",
@@ -1369,7 +1369,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E044.png"
     },
     {
         "name": "Sticking with Bubby, Beatrice",
@@ -1396,7 +1396,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E045.png"
     },
     {
         "name": "Innocent Child, Petra",
@@ -1423,7 +1423,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E046.png"
     },
     {
         "name": "Door Crossing, Beatrice",
@@ -1449,7 +1449,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E047.png"
     },
     {
         "name": "Sulking Beatrice",
@@ -1475,7 +1475,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E048.png"
     },
     {
         "name": "A Flower in Each Arm, Ram",
@@ -1503,7 +1503,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E049.png"
     },
     {
         "name": "Challenging Another World, Subaru",
@@ -1529,7 +1529,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E050.png"
     },
     {
         "name": "Sister's Avenger, Ram",
@@ -1558,7 +1558,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E051.png"
     },
     {
         "name": "Margrave Roswaal",
@@ -1586,7 +1586,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E052.png"
     },
     {
         "name": "Forbidden Library",
@@ -1612,7 +1612,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E053.png"
     },
     {
         "name": "Subaru Natsuki's Decoy Tactic",
@@ -1641,7 +1641,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E054.png"
     },
     {
         "name": "As the Older Sister",
@@ -1670,7 +1670,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E055.png"
     },
     {
         "name": "Mana Drain",
@@ -1699,7 +1699,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E056.png"
     },
     {
         "name": "Breaking the Curse",
@@ -1728,7 +1728,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E057.png"
     },
     {
         "name": "Peaceful Life, Rem",
@@ -1755,7 +1755,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E058.png"
     },
     {
         "name": "Silver-Haired Beauty, Emilia",
@@ -1781,7 +1781,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E059.png"
     },
     {
         "name": "Blue-Haired Maid, Rem",
@@ -1812,7 +1812,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E060.png"
     },
     {
         "name": "Half-Elf Maiden, Emilia",
@@ -1841,7 +1841,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E061.png"
     },
     {
         "name": "Angel's Smile, Emilia",
@@ -1868,7 +1868,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E062.png"
     },
     {
         "name": "Happy Daydream, Rem",
@@ -1896,7 +1896,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E063.png"
     },
     {
         "name": "Pure Maiden, Emilia",
@@ -1923,7 +1923,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E064.png"
     },
     {
         "name": "Unconditional Trust, Rem",
@@ -1949,7 +1949,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E065.png"
     },
     {
         "name": "Bathtime! Emilia",
@@ -1979,7 +1979,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E066.png"
     },
     {
         "name": "Demon's Demeanor, Rem",
@@ -2010,7 +2010,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E067.png"
     },
     {
         "name": "Subaru Natsuki",
@@ -2040,7 +2040,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E068.png"
     },
     {
         "name": "Modest Request, Rem",
@@ -2070,7 +2070,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E069.png"
     },
     {
         "name": "In Uniforms, Rem & Ram",
@@ -2097,7 +2097,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E070.png"
     },
     {
         "name": "Stunned, Emilia",
@@ -2124,7 +2124,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E071.png"
     },
     {
         "name": "Talking About the Future Smiling, Rem",
@@ -2151,7 +2151,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E072.png"
     },
     {
         "name": "Talking About the Future Smiling, Subaru",
@@ -2178,7 +2178,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E073.png"
     },
     {
         "name": "Gaze of Admiration, Rem",
@@ -2204,7 +2204,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E074.png"
     },
     {
         "name": "Great Spirit, Puck",
@@ -2231,7 +2231,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E075.png"
     },
     {
         "name": "Midnight Visit, Rem",
@@ -2260,7 +2260,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E076.png"
     },
     {
         "name": "Peaceful Life, Emilia",
@@ -2286,7 +2286,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E077.png"
     },
     {
         "name": "Smug Look, Emilia",
@@ -2315,7 +2315,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E078.png"
     },
     {
         "name": "Dim Light Seen With Those Eyes, Rem",
@@ -2344,7 +2344,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E079.png"
     },
     {
         "name": "Intense Ire, Puck",
@@ -2374,7 +2374,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E080.png"
     },
     {
         "name": "Capital's Fruit Seller, Kadomon",
@@ -2401,7 +2401,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E081.png"
     },
     {
         "name": "Fated Encounter, Subaru",
@@ -2428,7 +2428,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E082.png"
     },
     {
         "name": "Ground Dragon, Patrasche",
@@ -2455,7 +2455,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E083.png"
     },
     {
         "name": "In My Hero's Arms, Rem",
@@ -2481,7 +2481,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E084.png"
     },
     {
         "name": "In a Corner of This Dark World, Emilia",
@@ -2508,7 +2508,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E085.png"
     },
     {
         "name": "Fire Spirit, Puck",
@@ -2535,7 +2535,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E086.png"
     },
     {
         "name": "A Morning Moment, Emilia",
@@ -2562,7 +2562,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E087.png"
     },
     {
         "name": "A Flower in Each Arm, Rem",
@@ -2590,7 +2590,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E088.png"
     },
     {
         "name": "Masterly Maid, Rem",
@@ -2617,7 +2617,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E089.png"
     },
     {
         "name": "Two Riding A Ground Dragon, Rem",
@@ -2643,7 +2643,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E090.png"
     },
     {
         "name": "Merchant, Otto",
@@ -2669,7 +2669,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E091.png"
     },
     {
         "name": "Gentle Disparagement, Emilia",
@@ -2698,7 +2698,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E092.png"
     },
     {
         "name": "Anxious Emilia",
@@ -2726,7 +2726,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E093.png"
     },
     {
         "name": "Return by Death",
@@ -2753,7 +2753,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E094.png"
     },
     {
         "name": "Oni's Smile",
@@ -2783,7 +2783,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E095.png"
     },
     {
         "name": "Starting Life in Another World",
@@ -2812,7 +2812,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E096.png"
     },
     {
         "name": "A Boy's Fantasy",
@@ -2841,7 +2841,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E097.png"
     },
     {
         "name": "Demon's True Form",
@@ -2870,7 +2870,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E098.png"
     },
     {
         "name": "Wishing",
@@ -2899,7 +2899,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E099.png"
     },
     {
         "name": "Like A Demon",
@@ -2929,7 +2929,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E100.png"
     },
     {
         "name": "Petit Felt",
@@ -2956,7 +2956,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E101.png"
     },
     {
         "name": "Petit Beatrice",
@@ -2983,7 +2983,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E102.png"
     },
     {
         "name": "Petit Ram",
@@ -3012,7 +3012,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E103.png"
     },
     {
         "name": "Petit Emilia",
@@ -3041,7 +3041,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E104.png"
     },
     {
         "name": "Petit Rem",
@@ -3070,7 +3070,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_E105.png"
     },
     {
         "name": "Roscchi's Library Librarian, Beatrice",
@@ -3099,7 +3099,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_PE02.png"
     },
     {
         "name": "Reciprocative Feelings, Emilia",
@@ -3126,7 +3126,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_PE03.png"
     },
     {
         "name": "Sweetly Smiling Ram",
@@ -3153,7 +3153,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE23.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE23.png"
     },
     {
         "name": "Sharp-Tongued Maid, Ram",
@@ -3179,7 +3179,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE24.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE24.png"
     },
     {
         "name": "Determined Look Beatrice",
@@ -3205,7 +3205,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE25.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE25.png"
     },
     {
         "name": "Dumbfounded Subaru",
@@ -3231,7 +3231,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE26.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE26.png"
     },
     {
         "name": "Obstinate, Beatrice",
@@ -3257,7 +3257,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE27.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE27.png"
     },
     {
         "name": "The Older Twin, Ram",
@@ -3283,7 +3283,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE28.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE28.png"
     },
     {
         "name": "High, High, So Very High",
@@ -3312,7 +3312,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE29.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE29.png"
     },
     {
         "name": "Morning Greeting, Puck",
@@ -3339,7 +3339,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE30.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE30.png"
     },
     {
         "name": "Roswaal Mansion Maid, Rem",
@@ -3366,7 +3366,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE31.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE31.png"
     },
     {
         "name": "Bride in Pure White, Rem",
@@ -3393,7 +3393,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE32.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE32.png"
     },
     {
         "name": "Lap Pillow Emilia",
@@ -3420,7 +3420,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE33.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE33.png"
     },
     {
         "name": "The Younger Twin, Rem",
@@ -3446,7 +3446,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE34.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE34.png"
     },
     {
         "name": "Welcome to This World! Emilia & Rem",
@@ -3475,7 +3475,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE35.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE35.png"
     },
     {
         "name": "Death Stare, Rem",
@@ -3504,7 +3504,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE36a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE36a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE36a.png"
     },
     {
         "name": "Death Stare, Rem",
@@ -3533,7 +3533,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE36b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE36b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE36b.png"
     },
     {
         "name": "Refreshing Smile, Subaru",
@@ -3562,7 +3562,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE37",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE37.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE37.png"
     },
     {
         "name": "Spirit User, Emilia",
@@ -3591,7 +3591,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE38",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE38.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE38.png"
     },
     {
         "name": "Subaru's Choice",
@@ -3617,7 +3617,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE39a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE39a.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE39a.png"
     },
     {
         "name": "Subaru's Choice",
@@ -3643,7 +3643,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE39b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE39b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE39b.png"
     },
     {
         "name": "Speaking to the Spirit",
@@ -3673,7 +3673,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE40",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE40.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE40.png"
     },
     {
         "name": "Parting Passions",
@@ -3702,7 +3702,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE41",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE41.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE41.png"
     },
     {
         "name": "A Short Snooze, Emilia",
@@ -3729,7 +3729,7 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE42",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE42.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE42.png"
     },
     {
         "name": "Light of Love, Rem",
@@ -3758,6 +3758,6 @@
         "set": "RZ",
         "release": "46",
         "sid": "TE43",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ-S46-TE43.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s46/RZ_S46_TE43.png"
     }
 ]

--- a/DB/RZ_S68.json
+++ b/DB/RZ_S68.json
@@ -23,7 +23,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E001.png"
     },
     {
         "name": "Aim for New York? Petra",
@@ -50,7 +50,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E002.png"
     },
     {
         "name": "Snow Bunny and Petra",
@@ -77,7 +77,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E003.png"
     },
     {
         "name": "\"Memory Snow\" Subaru",
@@ -107,7 +107,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E004.png"
     },
     {
         "name": "Aim for New York? Dine",
@@ -133,7 +133,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E005.png"
     },
     {
         "name": "Aim for New York? Lucas",
@@ -161,7 +161,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E006.png"
     },
     {
         "name": "Girl from Village Irlam, Petra",
@@ -190,7 +190,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E007.png"
     },
     {
         "name": "Delicious Reward, Petra",
@@ -217,7 +217,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E008.png"
     },
     {
         "name": "Aim for New York? Mildo",
@@ -244,7 +244,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E009.png"
     },
     {
         "name": "Another World-Style? Incitement, Subaru",
@@ -272,7 +272,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E010.png"
     },
     {
         "name": "Flying Assault Form of the Ultra-Firepower Weapon S-N0 BUN-E",
@@ -299,7 +299,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E011.png"
     },
     {
         "name": "First Wild and Crazy Snow Festival",
@@ -329,7 +329,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E012.png"
     },
     {
         "name": "Out-of-Season Snow Festival",
@@ -359,7 +359,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E013.png"
     },
     {
         "name": "\"Memory Snow\" Ram & Rem",
@@ -385,7 +385,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E014.png"
     },
     {
         "name": "God's Vantage Point, Ram",
@@ -412,7 +412,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E015.png"
     },
     {
         "name": "\"Memory Snow\" Beatrice",
@@ -442,7 +442,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E016.png"
     },
     {
         "name": "Heavy Drinker, Ram",
@@ -471,7 +471,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E017.png"
     },
     {
         "name": "Beatrice Trying Her Best Alone",
@@ -497,7 +497,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E018.png"
     },
     {
         "name": "Ram With a Weakness to Cold",
@@ -523,7 +523,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E019.png"
     },
     {
         "name": "Ram Holding Her Breath",
@@ -549,7 +549,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E020.png"
     },
     {
         "name": "Unexpectedly Low Rating, Ram",
@@ -575,7 +575,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E021.png"
     },
     {
         "name": "Delightful Banquet, Ram",
@@ -604,7 +604,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E022.png"
     },
     {
         "name": "Subaru Shining Under the Night Sky",
@@ -633,7 +633,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E023.png"
     },
     {
         "name": "Actually Having Fun? Beatrice",
@@ -662,7 +662,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E024.png"
     },
     {
         "name": "Super Artist, Ram",
@@ -692,7 +692,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E025.png"
     },
     {
         "name": "Magnificent Subawaal Sculpture",
@@ -723,7 +723,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E026.png"
     },
     {
         "name": "Cold Surprise Attack, Beatrice",
@@ -750,7 +750,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E027.png"
     },
     {
         "name": "Magic-Release Season Strategy Meeting, Beatrice",
@@ -777,7 +777,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E028.png"
     },
     {
         "name": "Slight Omen, Roswaal",
@@ -804,7 +804,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E029.png"
     },
     {
         "name": "Presented by Me! Subaru",
@@ -831,7 +831,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E030.png"
     },
     {
         "name": "Scornful Gaze, Ram",
@@ -858,7 +858,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E031.png"
     },
     {
         "name": "Expectedly Cold, Beatrice",
@@ -885,7 +885,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E032.png"
     },
     {
         "name": "Harsher Than Usual, Ram",
@@ -912,7 +912,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E033.png"
     },
     {
         "name": "Dinner Drink, Roswaal",
@@ -939,7 +939,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E034.png"
     },
     {
         "name": "A Day to Remember, Ram",
@@ -966,7 +966,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E035.png"
     },
     {
         "name": "\"Memory Snow\" Roswaal",
@@ -995,7 +995,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E036.png"
     },
     {
         "name": "Ram Being a Wet Blanket",
@@ -1024,7 +1024,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E037.png"
     },
     {
         "name": "Taking Care of the Drunkards, Ram",
@@ -1051,7 +1051,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E038.png"
     },
     {
         "name": "Busy, Beatrice",
@@ -1078,7 +1078,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E039.png"
     },
     {
         "name": "Abnormal Weather? Subaru",
@@ -1104,7 +1104,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E040.png"
     },
     {
         "name": "Banquet's Corner, Beatrice",
@@ -1131,7 +1131,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E041.png"
     },
     {
         "name": "Judge, Roswaal",
@@ -1157,7 +1157,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E042.png"
     },
     {
         "name": "Slight Change, Ram",
@@ -1183,7 +1183,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E043.png"
     },
     {
         "name": "Precious Alcohol, Ram",
@@ -1212,7 +1212,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E044.png"
     },
     {
         "name": "Bored Spectator, Beatrice",
@@ -1238,7 +1238,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E045.png"
     },
     {
         "name": "Madly in Love With Bubby, Beatrice",
@@ -1267,7 +1267,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E046.png"
     },
     {
         "name": "Strong Enemy, Roswaal",
@@ -1296,7 +1296,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E047.png"
     },
     {
         "name": "Tranquil Reception",
@@ -1322,7 +1322,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E048.png"
     },
     {
         "name": "Daily Duties",
@@ -1351,7 +1351,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E049.png"
     },
     {
         "name": "Participating in the Snow Festival!",
@@ -1380,7 +1380,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E050.png"
     },
     {
         "name": "Expectant Gazes",
@@ -1409,7 +1409,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E051.png"
     },
     {
         "name": "Not a Bad Day",
@@ -1438,7 +1438,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E052.png"
     },
     {
         "name": "Secret Flower Garden, Emilia",
@@ -1465,7 +1465,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E053.png"
     },
     {
         "name": "Leave Everything to Me, Rem",
@@ -1492,7 +1492,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E054.png"
     },
     {
         "name": "That's Not It, Rem",
@@ -1519,7 +1519,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E055.png"
     },
     {
         "name": "The World Reflected in Her Eyes, Emilia",
@@ -1549,7 +1549,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E056.png"
     },
     {
         "name": "\"Memory Snow\" Emilia",
@@ -1578,7 +1578,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E057.png"
     },
     {
         "name": "Delightful Banquet, Rem",
@@ -1607,7 +1607,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E058.png"
     },
     {
         "name": "Dream-Like Scenery, Rem & Emilia",
@@ -1634,7 +1634,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E059.png"
     },
     {
         "name": "I Worked Hard! Rem",
@@ -1661,7 +1661,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E060.png"
     },
     {
         "name": "About the Future, Puck",
@@ -1688,7 +1688,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E061.png"
     },
     {
         "name": "No Cheating, Emilia",
@@ -1715,7 +1715,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E062.png"
     },
     {
         "name": "Unsettling Declaration, Rem",
@@ -1741,7 +1741,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E063.png"
     },
     {
         "name": "Recognition-Hindering Robe, Emilia",
@@ -1770,7 +1770,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E064.png"
     },
     {
         "name": "Magic-Release Season Strategy Meeting, Emilia",
@@ -1800,7 +1800,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E065.png"
     },
     {
         "name": "Date-Day Morning, Emilia",
@@ -1829,7 +1829,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E066.png"
     },
     {
         "name": "Combination of Ideals, Rem",
@@ -1858,7 +1858,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E067.png"
     },
     {
         "name": "Satisfying Conclusion, Puck",
@@ -1885,7 +1885,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E068.png"
     },
     {
         "name": "Delightful Banquet, Emilia",
@@ -1912,7 +1912,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E069.png"
     },
     {
         "name": "Great Spirit Attack, Puck",
@@ -1938,7 +1938,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E070.png"
     },
     {
         "name": "Internet Literacy? Emilia",
@@ -1964,7 +1964,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E071.png"
     },
     {
         "name": "Concaved Puck",
@@ -1991,7 +1991,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E072.png"
     },
     {
         "name": "Earnest Admiration, Rem",
@@ -2018,7 +2018,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E073.png"
     },
     {
         "name": "Madly in Love With Puck, Emilia",
@@ -2045,7 +2045,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E074.png"
     },
     {
         "name": "Hot Springs Operation, Subaru",
@@ -2071,7 +2071,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E075.png"
     },
     {
         "name": "Magic-Release Season Strategy Meeting, Puck",
@@ -2100,7 +2100,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E076.png"
     },
     {
         "name": "Aloof Emilia",
@@ -2127,7 +2127,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E077.png"
     },
     {
         "name": "Speaking in Riddles, Puck",
@@ -2156,7 +2156,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E078.png"
     },
     {
         "name": "Drunk Emilia",
@@ -2183,7 +2183,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E079.png"
     },
     {
         "name": "Secret Mission, Subaru",
@@ -2209,7 +2209,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E080.png"
     },
     {
         "name": "Highly Considerate, Puck",
@@ -2236,7 +2236,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E081.png"
     },
     {
         "name": "Slight Change, Rem",
@@ -2263,7 +2263,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E082.png"
     },
     {
         "name": "Can't Get Enough of This, Subaru",
@@ -2289,7 +2289,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E083.png"
     },
     {
         "name": "Emilia Working Hard",
@@ -2316,7 +2316,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E084.png"
     },
     {
         "name": "Magic-Release Season Strategy Meeting, Rem",
@@ -2343,7 +2343,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E085.png"
     },
     {
         "name": "Winter Clothing, Rem",
@@ -2369,7 +2369,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E086.png"
     },
     {
         "name": "Unsatisfied With the Grading, Emilia",
@@ -2395,7 +2395,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E087.png"
     },
     {
         "name": "Releasing Mana, Puck",
@@ -2421,7 +2421,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E088.png"
     },
     {
         "name": "The One Who Did the Work, Rem",
@@ -2450,7 +2450,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E089.png"
     },
     {
         "name": "Secret Flower Garden, Subaru",
@@ -2479,7 +2479,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E090.png"
     },
     {
         "name": "Imploring Gaze, Rem",
@@ -2508,7 +2508,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E091.png"
     },
     {
         "name": "Drunk Rem",
@@ -2536,7 +2536,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E092.png"
     },
     {
         "name": "Horrific Mayonnaise Human",
@@ -2563,7 +2563,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E093.png"
     },
     {
         "name": "Avant-Garde Sculpture",
@@ -2592,7 +2592,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E094.png"
     },
     {
         "name": "Peaceful Moment",
@@ -2622,7 +2622,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E095.png"
     },
     {
         "name": "It's All Subaru's Fault",
@@ -2652,7 +2652,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E096 copy.png"
     },
     {
         "name": "Praise me! Praise me! Aura",
@@ -2681,7 +2681,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E097.png"
     },
     {
         "name": "It's Magic-Release Season!",
@@ -2710,7 +2710,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E098.png"
     },
     {
         "name": "First Experience With Alcohol",
@@ -2739,7 +2739,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E099.png"
     },
     {
         "name": "Arrival of the Next Morning",
@@ -2768,7 +2768,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E100.png"
     },
     {
         "name": "Dot Ram [Memory Snow]",
@@ -2795,7 +2795,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E101.png"
     },
     {
         "name": "Dot Beatrice [Memory Snow]",
@@ -2821,7 +2821,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E102.png"
     },
     {
         "name": "Dot Rem [Memory Snow]",
@@ -2850,7 +2850,7 @@
         "set": "RZ",
         "release": "68",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E103.png"
     },
     {
         "name": "Dot Emilia & Puck [Memory Snow]",
@@ -2878,6 +2878,6 @@
         "set": "RZ",
         "release": "68",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/RZ_S68_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/r/rz_s68/RZ_S68_E104.png"
     }
 ]

--- a/DB/SAO1_S20.json
+++ b/DB/SAO1_S20.json
@@ -24,7 +24,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e001.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E001.png"
     },
     {
         "name": "<<Lightning Flash>> Asuna",
@@ -53,7 +53,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e002.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E002.png"
     },
     {
         "name": "Asuna Lays on the Sofa",
@@ -79,7 +79,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e003.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E003.png"
     },
     {
         "name": "Imprisoned Queen, Asuna",
@@ -105,7 +105,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e004.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E004.png"
     },
     {
         "name": "Asuna Changes Clothes",
@@ -133,7 +133,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e005.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E005.png"
     },
     {
         "name": "Asuna Dozed Off",
@@ -162,7 +162,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e006.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E006.png"
     },
     {
         "name": "Asuna's Commanding Strength",
@@ -191,7 +191,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e007.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E007.png"
     },
     {
         "name": "Asuna's Married Life",
@@ -218,7 +218,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e008.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E008.png"
     },
     {
         "name": "Asuna's True Expression",
@@ -244,7 +244,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e009.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E009.png"
     },
     {
         "name": "Vice Commander, Asuna",
@@ -271,7 +271,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e010.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E010.png"
     },
     {
         "name": "Asuna Takes Shelter",
@@ -298,7 +298,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e011.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E011.png"
     },
     {
         "name": "Asuna Replies to a Proposal",
@@ -327,7 +327,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e012.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E012.png"
     },
     {
         "name": "Guild Commander, Heathcliff",
@@ -355,7 +355,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e013.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E013.png"
     },
     {
         "name": "Asuna's Strong Bond",
@@ -382,7 +382,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e014.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E014.png"
     },
     {
         "name": "Asuna Jumps to Conclusions",
@@ -408,7 +408,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e015.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E015.png"
     },
     {
         "name": "Observer, Kuradeel",
@@ -434,7 +434,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e016.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E016.png"
     },
     {
         "name": "Asuna - Start of the Battle",
@@ -460,7 +460,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e017.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E017.png"
     },
     {
         "name": "Laughing Coffin",
@@ -486,7 +486,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e018.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E018.png"
     },
     {
         "name": "Heathcliff's Hidden Identity",
@@ -512,7 +512,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e019.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E019.png"
     },
     {
         "name": "Asuna's Veteran Cooking Skill",
@@ -540,7 +540,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e020.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E020.png"
     },
     {
         "name": "Returning to the Front Lines",
@@ -565,7 +565,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e021.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E021.png"
     },
     {
         "name": "Self-sacrifice",
@@ -590,7 +590,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e022.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E022.png"
     },
     {
         "name": "A Sworn Promise",
@@ -618,7 +618,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e023.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E023.png"
     },
     {
         "name": "<<Star Splash>>",
@@ -647,7 +647,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e024.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E024.png"
     },
     {
         "name": "Duel in the Arena",
@@ -676,7 +676,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e025.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E025.png"
     },
     {
         "name": "Magic Swordsman, Leafa",
@@ -704,7 +704,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e026.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E026.png"
     },
     {
         "name": "Leafa's Pure Wish",
@@ -734,7 +734,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e027.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E027.png"
     },
     {
         "name": "Reliable Guide, Leafa",
@@ -760,7 +760,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e028.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E028.png"
     },
     {
         "name": "Suguha's Shaken Feelings",
@@ -787,7 +787,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e029.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E029.png"
     },
     {
         "name": "<<Sylph>> Girl, Leafa",
@@ -814,7 +814,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e030.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E030.png"
     },
     {
         "name": "Suguha in Uniform",
@@ -843,7 +843,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e031.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E031.png"
     },
     {
         "name": "Suguha Persuading Herself",
@@ -870,7 +870,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e032.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E032.png"
     },
     {
         "name": "Gentle Ally, Recon",
@@ -896,7 +896,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e033.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E033.png"
     },
     {
         "name": "Kendo Girl, Suguha",
@@ -922,7 +922,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e034.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E034.png"
     },
     {
         "name": "Leafa's Bashful Expression",
@@ -948,7 +948,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e035.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E035.png"
     },
     {
         "name": "Leafa Gets Her Hand Bit",
@@ -976,7 +976,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e036.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E036.png"
     },
     {
         "name": "Leafa's Sharp Observation",
@@ -1002,7 +1002,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e037.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E037.png"
     },
     {
         "name": "Suguha Out of the Bath",
@@ -1028,7 +1028,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e038.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E038.png"
     },
     {
         "name": "Leafa's in a Panic",
@@ -1054,7 +1054,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e039.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E039.png"
     },
     {
         "name": "Suguha's Mixed Emotions",
@@ -1082,7 +1082,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e040.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E040.png"
     },
     {
         "name": "Fairy King, Oberon",
@@ -1110,7 +1110,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e041.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E041.png"
     },
     {
         "name": "Healing Magic",
@@ -1135,7 +1135,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e042.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E042.png"
     },
     {
         "name": "Recon's Courage",
@@ -1160,7 +1160,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e043.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E043.png"
     },
     {
         "name": "Spell Chanting",
@@ -1188,7 +1188,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e044.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E044.png"
     },
     {
         "name": "Repressed Feelings",
@@ -1216,7 +1216,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e045.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E045.png"
     },
     {
         "name": "Searching Lisbeth",
@@ -1244,7 +1244,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e046.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E046.png"
     },
     {
         "name": "Like a Younger Sister, Silica",
@@ -1273,7 +1273,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e047.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E047.png"
     },
     {
         "name": "Lisbeth's Blessings",
@@ -1300,7 +1300,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e048.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E048.png"
     },
     {
         "name": "Silica in the <<Flower Garden>>",
@@ -1326,7 +1326,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e049.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E049.png"
     },
     {
         "name": "Lisbeth's Professional Pride",
@@ -1353,7 +1353,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e050.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E050.png"
     },
     {
         "name": "Silica's Unyielding Trust",
@@ -1379,7 +1379,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e051.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E051.png"
     },
     {
         "name": "Lisbeth Changes Clothes",
@@ -1405,7 +1405,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e052.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E052.png"
     },
     {
         "name": "Lisbeth's Determined Confession",
@@ -1434,7 +1434,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e053.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E053.png"
     },
     {
         "name": "Familiar, Pina",
@@ -1461,7 +1461,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e054.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E054.png"
     },
     {
         "name": "Silica - Like a Date",
@@ -1487,7 +1487,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e055.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E055.png"
     },
     {
         "name": "Mace User, Lisbeth",
@@ -1513,7 +1513,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e056.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E056.png"
     },
     {
         "name": "Silica - Start of the Adventure",
@@ -1539,7 +1539,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e057.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E057.png"
     },
     {
         "name": "Dagger User, Silica",
@@ -1565,7 +1565,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e058.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E058.png"
     },
     {
         "name": "Cute Mischief, Silica",
@@ -1593,7 +1593,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e059.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E059.png"
     },
     {
         "name": "Lisbeth's Positive Smile",
@@ -1621,7 +1621,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e060.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E060.png"
     },
     {
         "name": "Lisbeth the Blacksmith",
@@ -1648,7 +1648,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e061.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E061.png"
     },
     {
         "name": "<<Beast Tamer>> Silica",
@@ -1674,7 +1674,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e062.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E062.png"
     },
     {
         "name": "Like an Idol, Silica",
@@ -1700,7 +1700,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e063.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E063.png"
     },
     {
         "name": "Silica Leaves the Party",
@@ -1726,7 +1726,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e064.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E064.png"
     },
     {
         "name": "《Pina's Heart》",
@@ -1753,7 +1753,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e065.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E065.png"
     },
     {
         "name": "Cornered Silica",
@@ -1779,7 +1779,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e066.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E066.png"
     },
     {
         "name": "Encouraging Lisbeth",
@@ -1805,7 +1805,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e067.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E067.png"
     },
     {
         "name": "Happening! Silica",
@@ -1833,7 +1833,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e068.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E068.png"
     },
     {
         "name": "Silica's Gratitude",
@@ -1861,7 +1861,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e069.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E069.png"
     },
     {
         "name": "《Pneuma Flower》",
@@ -1887,7 +1887,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e070.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E070.png"
     },
     {
         "name": "White Dragon's Lair",
@@ -1913,7 +1913,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e071.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E071.png"
     },
     {
         "name": "Seeking Warmth",
@@ -1941,7 +1941,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e072.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E072.png"
     },
     {
         "name": "First Adventure",
@@ -1969,7 +1969,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e073.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E073.png"
     },
     {
         "name": "Pina's Resurrection",
@@ -1997,7 +1997,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e074.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E074.png"
     },
     {
         "name": "Awakened Feelings",
@@ -2025,7 +2025,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e075.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E075.png"
     },
     {
         "name": "Mysterious Girl, Yui",
@@ -2052,7 +2052,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e076.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E076.png"
     },
     {
         "name": "《Black Swordsman》 Kirito",
@@ -2081,7 +2081,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e077.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E077.png"
     },
     {
         "name": "Blade User, Klein",
@@ -2108,7 +2108,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e078.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E078.png"
     },
     {
         "name": "Kirito in the Battlefield",
@@ -2134,7 +2134,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e079.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E079.png"
     },
     {
         "name": "Kirito - For Someone Special",
@@ -2161,7 +2161,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e080.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E080.png"
     },
     {
         "name": "Artificial Intelligence, Yui",
@@ -2189,7 +2189,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e081.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E081.png"
     },
     {
         "name": "Kirito Discovers a Unique Skill",
@@ -2219,7 +2219,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e082.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E082.png"
     },
     {
         "name": "Solo Player, Kirito",
@@ -2245,7 +2245,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e083.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E083.png"
     },
     {
         "name": "Moonlit Black Cats, Sachi",
@@ -2271,7 +2271,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e084.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E084.png"
     },
     {
         "name": "Kirito's Strong Bond",
@@ -2298,7 +2298,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e085.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E085.png"
     },
     {
         "name": "Kirito Appraises Items",
@@ -2324,7 +2324,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e086.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E086.png"
     },
     {
         "name": "Kirito's Natural Gentleness",
@@ -2350,7 +2350,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e087.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E087.png"
     },
     {
         "name": "Their Child, Yui",
@@ -2377,7 +2377,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e088.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E088.png"
     },
     {
         "name": "Kirito's Quiet Days",
@@ -2403,7 +2403,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e089.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E089.png"
     },
     {
         "name": "Kirito - Start of the Battle",
@@ -2429,7 +2429,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e090.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E090.png"
     },
     {
         "name": "Sachi's Bloomed Admiration",
@@ -2455,7 +2455,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e091.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E091.png"
     },
     {
         "name": "Lovely Girl, Yui",
@@ -2481,7 +2481,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e092.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E092.png"
     },
     {
         "name": "Kirito - Snow Mountain on Floor 55",
@@ -2509,7 +2509,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e093.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E093.png"
     },
     {
         "name": "Kirito Joins the Knights of the Blood Oath",
@@ -2537,7 +2537,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e094.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E094.png"
     },
     {
         "name": "Axe Warrior, Agil",
@@ -2565,7 +2565,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e095.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E095.png"
     },
     {
         "name": "Marriage Proposal",
@@ -2590,7 +2590,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e096.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E096.png"
     },
     {
         "name": "Thank you, goodbye",
@@ -2615,7 +2615,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e097.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E097.png"
     },
     {
         "name": "<<Dual-wielding>> User",
@@ -2643,7 +2643,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e098.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E098.png"
     },
     {
         "name": "End of the World",
@@ -2671,7 +2671,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e099.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E099.png"
     },
     {
         "name": "Sudden Farewell",
@@ -2699,7 +2699,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s20_e100.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E100.png"
     },
     {
         "name": "<<Lead Group>> Asuna",
@@ -2725,7 +2725,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_E101.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E101.png"
     },
     {
         "name": "<<Lead Group>> Kirito",
@@ -2754,7 +2754,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_E102.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E102.png"
     },
     {
         "name": "<<Beater>> Kirito",
@@ -2780,7 +2780,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_E103.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E103.png"
     },
     {
         "name": "Kirito & Asuna",
@@ -2810,7 +2810,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_E104.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E104.png"
     },
     {
         "name": "Asuna Enters the Underground Dungeon",
@@ -2836,7 +2836,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_E105.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_E105.png"
     },
     {
         "name": "SD Asuna",
@@ -2967,7 +2967,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_PE01.png"
     },
     {
         "name": "Asuna in the Bath",
@@ -2994,7 +2994,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_PE02.png"
     },
     {
         "name": "A Happy Moment, Asuna & Yui",
@@ -3020,7 +3020,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_PE03.png"
     },
     {
         "name": "Asuna - Two Worlds",
@@ -3046,7 +3046,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_PE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_PE04.png"
     },
     {
         "name": "Asuna Conveying Her Feelings",
@@ -3127,7 +3127,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE01.png"
     },
     {
         "name": "Asuna - Start of the Battle",
@@ -3153,7 +3153,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE02.png"
     },
     {
         "name": "Heathcliff's Hidden Identity",
@@ -3179,7 +3179,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE03.png"
     },
     {
         "name": "Asuna Replies to a Proposal",
@@ -3208,7 +3208,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE04.png"
     },
     {
         "name": "Asuna's Veteran Cooking Skill",
@@ -3236,7 +3236,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE05.png"
     },
     {
         "name": "<<Star Splash>>",
@@ -3265,7 +3265,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE06.png"
     },
     {
         "name": "Kirito - Start of the Battle",
@@ -3291,7 +3291,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE07.png"
     },
     {
         "name": "Their Child, Yui",
@@ -3318,7 +3318,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE08.png"
     },
     {
         "name": "Lovely Girl, Yui",
@@ -3344,7 +3344,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE09.png"
     },
     {
         "name": "Kirito Joins the Knights of the Blood Oath",
@@ -3372,7 +3372,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE10.png"
     },
     {
         "name": "Axe Warrior, Agil",
@@ -3400,7 +3400,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE11.png"
     },
     {
         "name": "Kirito - Snow Mountain on Floor 55",
@@ -3428,7 +3428,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE12.png"
     },
     {
         "name": "End of the World",
@@ -3456,7 +3456,7 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE13.png"
     },
     {
         "name": "<<Dual-wielding>> User",
@@ -3484,6 +3484,6 @@
         "set": "SAO",
         "release": "20",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S20_TE14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s20/SAO_S20_TE14.png"
     }
 ]

--- a/DB/SAO2_S26.json
+++ b/DB/SAO2_S26.json
@@ -24,7 +24,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E001.png"
     },
     {
         "name": "Beacon of Hope, Asuna",
@@ -53,7 +53,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E002.png"
     },
     {
         "name": "Asuna's Special Moment",
@@ -80,7 +80,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E003.png"
     },
     {
         "name": "Asuna's Handmade Cooking",
@@ -107,7 +107,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E004.png"
     },
     {
         "name": "Asuna In a Birdcage",
@@ -135,7 +135,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E005.png"
     },
     {
         "name": "Asuna Yuuki",
@@ -164,7 +164,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E006.png"
     },
     {
         "name": "Bride of the Fairy King, Asuna",
@@ -190,7 +190,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E007.png"
     },
     {
         "name": "\"Living Legend\" Heathcliff",
@@ -216,7 +216,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E008.png"
     },
     {
         "name": "Asuna's Domestic Side",
@@ -245,7 +245,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E009.png"
     },
     {
         "name": "Asuna's Gentle Appearance",
@@ -272,7 +272,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E010.png"
     },
     {
         "name": "Asuna's Coy Smile",
@@ -301,7 +301,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E011.png"
     },
     {
         "name": "《Undine》 Girl, Asuna",
@@ -327,7 +327,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E012.png"
     },
     {
         "name": "《Lead Group》 Holiday, Asuna",
@@ -353,7 +353,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E013.png"
     },
     {
         "name": "Akihiko Kayaba",
@@ -379,7 +379,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E014.png"
     },
     {
         "name": "Asuna Spending Her Vacation",
@@ -405,7 +405,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E015.png"
     },
     {
         "name": "Asuna Putting Herself in the Front Lines",
@@ -433,7 +433,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E016.png"
     },
     {
         "name": "Territory Leader of 《Cait Sith》, Alicia Lu",
@@ -461,7 +461,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E017.png"
     },
     {
         "name": "Asuna's Gift",
@@ -488,7 +488,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E018.png"
     },
     {
         "name": "On Top of the 《World Tree》",
@@ -518,7 +518,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E019.png"
     },
     {
         "name": "Identity of the \"Wife\"",
@@ -547,7 +547,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E020.png"
     },
     {
         "name": "Skilled 《Sylph》, Leafa",
@@ -576,7 +576,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E021.png"
     },
     {
         "name": "Virtual and Reality, Leafa & Suguha",
@@ -605,7 +605,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E022.png"
     },
     {
         "name": "Unyielding Girl, Leafa",
@@ -632,7 +632,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E023.png"
     },
     {
         "name": "Suguha Cheering On Her Brother",
@@ -659,7 +659,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E024.png"
     },
     {
         "name": "Virtual World Girl, Leafa",
@@ -685,7 +685,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E025.png"
     },
     {
         "name": "Suguha Changes Clothes",
@@ -714,7 +714,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E026.png"
     },
     {
         "name": "\"Speedholic\" Leafa",
@@ -741,7 +741,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E027.png"
     },
     {
         "name": "\"Veteran Player\" Leafa",
@@ -767,7 +767,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E028.png"
     },
     {
         "name": "Kirito's Younger Sister, Suguha",
@@ -793,7 +793,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E029.png"
     },
     {
         "name": "Wondering Girl, Leafa",
@@ -821,7 +821,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E030.png"
     },
     {
         "name": "Tutor, Suguha",
@@ -849,7 +849,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E031.png"
     },
     {
         "name": "Worrisome Recon",
@@ -875,7 +875,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E032.png"
     },
     {
         "name": "Leafa's Journey from Her Territory",
@@ -901,7 +901,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E033.png"
     },
     {
         "name": "Suguha Cooking",
@@ -927,7 +927,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E034.png"
     },
     {
         "name": "Game Master, Oberon",
@@ -953,7 +953,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E035.png"
     },
     {
         "name": "Childhood Suguha",
@@ -979,7 +979,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E036.png"
     },
     {
         "name": "Territory Leader of 《Sylph》, Sakuya",
@@ -1007,7 +1007,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E037.png"
     },
     {
         "name": "Specialty of Sylvein",
@@ -1033,7 +1033,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E038.png"
     },
     {
         "name": "Fairy Dance",
@@ -1062,7 +1062,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E039C.png"
     },
     {
         "name": "Memories from Last Night",
@@ -1091,7 +1091,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E040C.png"
     },
     {
         "name": "《Cait Sith》 Girl, Silica",
@@ -1117,7 +1117,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E041R.png"
     },
     {
         "name": "Silica's Relieved Smile",
@@ -1146,7 +1146,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E042.png"
     },
     {
         "name": "Silica Looking Up At the Sky",
@@ -1198,7 +1198,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E044.png"
     },
     {
         "name": "Silica's Bashful Troubled Look",
@@ -1227,7 +1227,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E045.png"
     },
     {
         "name": "Lisbeth's Shining Smile",
@@ -1257,7 +1257,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E046.png"
     },
     {
         "name": "Rika Shinozaki",
@@ -1283,7 +1283,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E047.png"
     },
     {
         "name": "Realization of Love, Lisbeth",
@@ -1309,7 +1309,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E048.png"
     },
     {
         "name": "Ceasefire Agreement, Keiko",
@@ -1335,7 +1335,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E049.png"
     },
     {
         "name": "Keiko Ayano",
@@ -1364,7 +1364,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E050.png"
     },
     {
         "name": "Ceasefire Agreement, Rika",
@@ -1392,7 +1392,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E051.png"
     },
     {
         "name": "Keiko in Uniform",
@@ -1418,7 +1418,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E052.png"
     },
     {
         "name": "Lisbeth's Material Gathering Adventure",
@@ -1444,7 +1444,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E053.png"
     },
     {
         "name": "Caution Towards Kindness, Silica",
@@ -1470,7 +1470,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E054.png"
     },
     {
         "name": "Lisbeth Being Mean",
@@ -1498,7 +1498,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E055.png"
     },
     {
         "name": "Lisbeth's Gentle Warmth",
@@ -1526,7 +1526,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E056.png"
     },
     {
         "name": "Commander Eugene",
@@ -1554,7 +1554,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E057.png"
     },
     {
         "name": "《Demonic Sword Gram》",
@@ -1581,7 +1581,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E058.png"
     },
     {
         "name": "Happening During Battle",
@@ -1610,7 +1610,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E059.png"
     },
     {
         "name": "Back to Her Cheerful Self",
@@ -1639,7 +1639,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E060.png"
     },
     {
         "name": "Yui's Adventure to Search for Mommy",
@@ -1668,7 +1668,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E061.png"
     },
     {
         "name": "Demon of 《Dual-wielding》, Kirito",
@@ -1697,7 +1697,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E062.png"
     },
     {
         "name": "Kirito Takes Shelter",
@@ -1723,7 +1723,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E063.png"
     },
     {
         "name": "Kirito Takes on 《ALO》",
@@ -1749,7 +1749,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E064.png"
     },
     {
         "name": "《Spriggan》 Boy, Kirito",
@@ -1776,7 +1776,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E065.png"
     },
     {
         "name": "Kirito's Unshakable Belief",
@@ -1803,7 +1803,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E066.png"
     },
     {
         "name": "Kirito's Married Life",
@@ -1830,7 +1830,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E067.png"
     },
     {
         "name": "Recovered Memories, Yui",
@@ -1857,7 +1857,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E068.png"
     },
     {
         "name": "Kirito - Two Worlds",
@@ -1886,7 +1886,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E069.png"
     },
     {
         "name": "Encounter with an MMO, Kazuto",
@@ -1914,7 +1914,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E070.png"
     },
     {
         "name": "《Navigation Pixie》, Yui",
@@ -1943,7 +1943,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E071.png"
     },
     {
         "name": "Dressed Up Yui",
@@ -1969,7 +1969,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E072.png"
     },
     {
         "name": "Kirito in the 《Flower Garden》",
@@ -1995,7 +1995,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E073.png"
     },
     {
         "name": "Yui's Simple Answer",
@@ -2021,7 +2021,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E074.png"
     },
     {
         "name": "Reseller, Agil",
@@ -2049,7 +2049,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E075.png"
     },
     {
         "name": "Battle in the Front Lines, Kirito",
@@ -2075,7 +2075,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E076.png"
     },
     {
         "name": "Friendly Youth, Klein",
@@ -2103,7 +2103,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E077.png"
     },
     {
         "name": "《The Seed》",
@@ -2129,7 +2129,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E078.png"
     },
     {
         "name": "Confrontation Between the Strongest Players",
@@ -2159,7 +2159,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E079.png"
     },
     {
         "name": "Reunion with Yui",
@@ -2188,7 +2188,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/ws_sao_s26_e080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_E080.png"
     },
     {
         "name": "《Star Splash》",
@@ -2390,7 +2390,7 @@
         "set": "SAO",
         "release": "26",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S26_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_PE01.png"
     },
     {
         "name": "In the Sunlight Forest, Asuna & Kirito",
@@ -2416,6 +2416,6 @@
         "set": "SAO",
         "release": "26",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S26_PE02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s26/SAO_S26_PE02.png"
     }
 ]

--- a/DB/SAOE1_SE23.json
+++ b/DB/SAOE1_SE23.json
@@ -25,7 +25,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E01R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E01.png"
     },
     {
         "name": "Bitter Memories, Asuna",
@@ -52,7 +52,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E02C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E02.png"
     },
     {
         "name": "《ALO》 Days, Asuna",
@@ -79,7 +79,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E03C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E03.png"
     },
     {
         "name": "Autumn Walk, Asuna",
@@ -105,7 +105,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E04C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E04.png"
     },
     {
         "name": "Sibling Moment, Suguha",
@@ -134,7 +134,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E05R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E05.png"
     },
     {
         "name": "Gathering Materials, Leafa",
@@ -163,7 +163,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E06C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E06.png"
     },
     {
         "name": "Gathering Materials, Silica",
@@ -190,7 +190,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E07R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E07.png"
     },
     {
         "name": "Shoichi Shinkawa",
@@ -217,7 +217,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E08R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E08.png"
     },
     {
         "name": "Sterben 《Death Gun》",
@@ -246,7 +246,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E09R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E09.png"
     },
     {
         "name": "Watching the Match Together, Lisbeth",
@@ -272,7 +272,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E10C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E10.png"
     },
     {
         "name": "Red Player, 《Death Gun》",
@@ -298,7 +298,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E11C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E11.png"
     },
     {
         "name": "Reaper Manifestation, 《Death Gun》",
@@ -324,7 +324,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E12C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E12.png"
     },
     {
         "name": "Excessive Obsession, Kyoji",
@@ -353,7 +353,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E13C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E13.png"
     },
     {
         "name": "Mob Hunting Together, Lisbeth",
@@ -382,7 +382,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E14C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E14.png"
     },
     {
         "name": "Death-causing Bullet, 《Death Gun》",
@@ -411,7 +411,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E15C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E15.png"
     },
     {
         "name": "Usual Silica",
@@ -439,7 +439,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E16C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E16.png"
     },
     {
         "name": "Fateful Estoc Wielder",
@@ -468,7 +468,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E17C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E17.png"
     },
     {
         "name": "Ideal Self, Sinon",
@@ -494,7 +494,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E18R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E18.png"
     },
     {
         "name": "In the Sunlight Forest, Sinon",
@@ -521,7 +521,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E19R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E19.png"
     },
     {
         "name": "Temporary Alliance, Kirito",
@@ -548,7 +548,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E20R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E20.png"
     },
     {
         "name": "Temporary Alliance, Sinon",
@@ -575,7 +575,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E21R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E21.png"
     },
     {
         "name": "Strong Existence, Sinon",
@@ -604,7 +604,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E22R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E22.png"
     },
     {
         "name": "End of Fate, Kirito",
@@ -634,7 +634,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E23R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E23.png"
     },
     {
         "name": "Last Shot, Sinon",
@@ -664,7 +664,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E24R.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E24.png"
     },
     {
         "name": "Basic Knowledge of Guns, Sinon",
@@ -690,7 +690,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E25C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E25.png"
     },
     {
         "name": "Diving Kirito",
@@ -716,7 +716,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E26C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E26.png"
     },
     {
         "name": "Autumn Walk, Kazuto",
@@ -743,7 +743,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E27C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E27.png"
     },
     {
         "name": "Shino Wishes to be Stronger",
@@ -770,7 +770,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E28C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E28.png"
     },
     {
         "name": "Beautiful Avatar, Kirito",
@@ -799,7 +799,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E30C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E30.png"
     },
     {
         "name": "Angry Sinon",
@@ -828,7 +828,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E31C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E31.png"
     },
     {
         "name": "\"Check Six\" Sinon",
@@ -857,7 +857,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E32C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E32.png"
     },
     {
         "name": "Confrontation with 《Death Gun》, Kirito",
@@ -885,7 +885,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E33C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E33.png"
     },
     {
         "name": "Past Name",
@@ -915,7 +915,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E34C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E34.png"
     },
     {
         "name": "Phantom Bullet",
@@ -944,7 +944,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E35C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E35.png"
     },
     {
         "name": "A Small Step",
@@ -973,7 +973,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_E36C.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_E36.png"
     },
     {
         "name": "Mission in the Twilight, Sinon",
@@ -1000,7 +1000,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_PE01.png"
     },
     {
         "name": "Kirito taking on 《Death Gun》",
@@ -1028,7 +1028,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_PE02.png"
     },
     {
         "name": "Winning Combination, Sinon & Kirito",
@@ -1056,7 +1056,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_PE03.png"
     },
     {
         "name": "Kazuto & Asuna in Uniform",
@@ -1082,7 +1082,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "PE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_PE04b.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_PE04.png"
     },
     {
         "name": "Light-hearted Talk, Kyoji",
@@ -1109,7 +1109,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE01.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE01.png"
     },
     {
         "name": "Kyoji Protecting Shino",
@@ -1136,7 +1136,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE02.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE02.png"
     },
     {
         "name": "Gathering Materials, Lisbeth",
@@ -1162,7 +1162,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE03.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE03.png"
     },
     {
         "name": "Unknown Identity, 《Death Gun》",
@@ -1189,7 +1189,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE04.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE04.png"
     },
     {
         "name": "Confident Silica",
@@ -1217,7 +1217,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE05.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE05.png"
     },
     {
         "name": "\"True\" Power, 《Death Gun》",
@@ -1247,7 +1247,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE06.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE06.png"
     },
     {
         "name": "Unexpected Encounter, 《Death Gun》",
@@ -1275,7 +1275,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE07.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE07.png"
     },
     {
         "name": "Power of 《Death Gun》",
@@ -1304,7 +1304,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE08.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE08.png"
     },
     {
         "name": "Like a Girl, Kirito",
@@ -1330,7 +1330,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE09.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE09.png"
     },
     {
         "name": "Place to Return to, Asuna",
@@ -1356,7 +1356,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE10.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE10.png"
     },
     {
         "name": "M9000 Model Avatar, Kirito",
@@ -1383,7 +1383,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE11.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE11.png"
     },
     {
         "name": "Friendly Guide, Sinon",
@@ -1409,7 +1409,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE12.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE12.png"
     },
     {
         "name": "Another Self, Shino",
@@ -1438,7 +1438,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE13.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE13.png"
     },
     {
         "name": "\"Gun World Swordsman\" Kirito",
@@ -1464,7 +1464,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE14.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE14.png"
     },
     {
         "name": "\"Machine of Ice\" Sinon",
@@ -1493,7 +1493,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE15.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE15.png"
     },
     {
         "name": "The Will to Shoot, Kirito",
@@ -1521,7 +1521,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE16.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE16.png"
     },
     {
         "name": "Excellent Sniper, Sinon",
@@ -1550,7 +1550,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE17.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE17.png"
     },
     {
         "name": "Late Self-introduction",
@@ -1577,7 +1577,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE18.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE18.png"
     },
     {
         "name": "《Photon Sword》 Wielder",
@@ -1606,7 +1606,7 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE19.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE19.png"
     },
     {
         "name": "Partner 《Hecate Ⅱ》",
@@ -1635,6 +1635,6 @@
         "set": "SAO",
         "release": "E23",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE23_TE20.jpg"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se23/SAO_SE23_TE20.png"
     }
 ]

--- a/DB/SAOE2_SE26.json
+++ b/DB/SAOE2_SE26.json
@@ -23,7 +23,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E01R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E01.png"
     },
     {
         "name": "Vestige of an Elder Sister, Asuna",
@@ -52,7 +52,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E02R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E02.png"
     },
     {
         "name": "Restful Stroll, Asuna",
@@ -79,7 +79,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E03C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E03.png"
     },
     {
         "name": "Childhood Asuna",
@@ -106,7 +106,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E04C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E04.png"
     },
     {
         "name": "《Berserk Healer》 Asuna",
@@ -135,7 +135,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E05C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E05.png"
     },
     {
         "name": "Demise of 《Zekken》",
@@ -165,7 +165,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E06C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E06.png"
     },
     {
         "name": "Undefeated Super Swordsman, Yuuki",
@@ -192,7 +192,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E07R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E07.png"
     },
     {
         "name": "《Sword Skill Lore》 Yuuki",
@@ -219,7 +219,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E08R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E08.png"
     },
     {
         "name": "《Sleeping Knights》 Talken & Nori & Jun",
@@ -246,7 +246,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E09R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E09.png"
     },
     {
         "name": "《Zekken》 Yuuki",
@@ -273,7 +273,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E10R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E10.png"
     },
     {
         "name": "Memories That Were Fun, Yuuki",
@@ -302,7 +302,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E11R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E11.png"
     },
     {
         "name": "Yuuki's Raised Antenna",
@@ -329,7 +329,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E12C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E12.png"
     },
     {
         "name": "《Sleeping Knights》 Yuuki",
@@ -356,7 +356,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E13C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E13.png"
     },
     {
         "name": "Simultaneous Attack, Leafa",
@@ -382,7 +382,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E14C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E14.png"
     },
     {
         "name": "Time Limit, Leafa",
@@ -409,7 +409,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E15C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E15.png"
     },
     {
         "name": "《Imp》 Girl, Yuuki",
@@ -438,7 +438,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E16C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E16.png"
     },
     {
         "name": "Innocent and Uninhibited, Yuuki",
@@ -467,7 +467,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E17C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E17.png"
     },
     {
         "name": "Asuna & Yuuki",
@@ -496,7 +496,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E18C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E18.png"
     },
     {
         "name": "《Sleeping Knights》 Siune & Tecchi",
@@ -525,7 +525,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E19C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E19.png"
     },
     {
         "name": "《Mother's Rosario》",
@@ -554,7 +554,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E20C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E20.png"
     },
     {
         "name": "Braves of 27th floor",
@@ -583,7 +583,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E21C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E21.png"
     },
     {
         "name": "Strong and Stout-hearted, Lisbeth",
@@ -610,7 +610,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E22R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E22.png"
     },
     {
         "name": "Trusted Skills, Lisbeth",
@@ -637,7 +637,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E23R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E23.png"
     },
     {
         "name": "Sinister Glint,《Death Gun》",
@@ -663,7 +663,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E24C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E24.png"
     },
     {
         "name": "Fluffy on the Head, Silica",
@@ -690,7 +690,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E25C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E25.png"
     },
     {
         "name": "Battle Stance, Silica",
@@ -719,7 +719,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E26C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E26.png"
     },
     {
         "name": "《SAO Survivor》 Kirito",
@@ -746,7 +746,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E27R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E27.png"
     },
     {
         "name": "Brains of the Party, Yui",
@@ -772,7 +772,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E28R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E28.png"
     },
     {
         "name": "Getting the Holy Sword, Kirito",
@@ -802,7 +802,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E29",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E29R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E29.png"
     },
     {
         "name": "Wildcat Girl, Sinon",
@@ -828,7 +828,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E30",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E30C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E30.png"
     },
     {
         "name": "Challenging Many, Kirito",
@@ -855,7 +855,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E31",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E31C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E31.png"
     },
     {
         "name": "Providing Information, Yui",
@@ -881,7 +881,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E32",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E32C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E32.png"
     },
     {
         "name": "In the Face of “Death”, Kirito & Sinon",
@@ -910,7 +910,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E33",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E33C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E33.png"
     },
     {
         "name": "《Cait Sith》 Archer, Sinon",
@@ -939,7 +939,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E34",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E34C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E34.png"
     },
     {
         "name": "《Skill Connect》 Kirito",
@@ -968,7 +968,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E35",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E35C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E35.png"
     },
     {
         "name": "Quest to Get 《Excalibur》",
@@ -998,7 +998,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "E36",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_E36C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_E36.png"
     },
     {
         "name": "Swimsuit Sinon",
@@ -1024,7 +1024,7 @@
         "set": "SAO",
         "release": "E26",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_PE01.png"
     },
     {
         "name": "Summer Festival, Asuna",
@@ -1050,6 +1050,6 @@
         "set": "SAO",
         "release": "E26",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_SE26_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_se26/SAO_SE26_PE02.png"
     }
 ]

--- a/DB/SAOM_S51.json
+++ b/DB/SAOM_S51.json
@@ -24,7 +24,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E001.png"
     },
     {
         "name": "Promise Under the Meteors, Asuna",
@@ -51,7 +51,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E002.png"
     },
     {
         "name": "Overcoming Fear, Asuna",
@@ -80,7 +80,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E003.png"
     },
     {
         "name": "Park Date, Asuna",
@@ -107,7 +107,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E004.png"
     },
     {
         "name": "Kirito's Love, Asuna",
@@ -134,7 +134,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E005.png"
     },
     {
         "name": "Snack Time, Asuna",
@@ -163,7 +163,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E006.png"
     },
     {
         "name": "《Lightning Flash》 Asuna & 《Black Swordsman》 Kirito",
@@ -193,7 +193,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E007.png"
     },
     {
         "name": "\"Link Strike\" Asuna",
@@ -220,7 +220,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E008.png"
     },
     {
         "name": "Long-Awaited Promised Day, Asuna",
@@ -247,7 +247,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E009.png"
     },
     {
         "name": "Promise in your Heart, Asuna & Kirito",
@@ -275,7 +275,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E010.png"
     },
     {
         "name": "Today's MVP, Asuna",
@@ -304,7 +304,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E011.png"
     },
     {
         "name": "Seductive Shore, Asuna",
@@ -331,7 +331,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E012.png"
     },
     {
         "name": "Taking On the Boss Battle, Asuna",
@@ -357,7 +357,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E013.png"
     },
     {
         "name": "Important Habit, Asuna",
@@ -384,7 +384,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E014.png"
     },
     {
         "name": "Thrusting Gale, Asuna",
@@ -410,7 +410,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E015.png"
     },
     {
         "name": "Prepared for Battle, Asuna",
@@ -439,7 +439,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E016.png"
     },
     {
         "name": "\"Genius Game Designer\" Kayaba",
@@ -467,7 +467,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E017.png"
     },
     {
         "name": "Sudden Whisper",
@@ -493,7 +493,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E018.png"
     },
     {
         "name": "《Mother's Rosario》",
@@ -522,7 +522,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E019.png"
     },
     {
         "name": "Enduring Emotions",
@@ -551,7 +551,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E020.png"
     },
     {
         "name": "Sister Fond of Her Brother, Leafa",
@@ -578,7 +578,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E021.png"
     },
     {
         "name": "《Songstress》 Yuna",
@@ -608,7 +608,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E022.png"
     },
     {
         "name": "Kendo Boot Camp, Suguha",
@@ -635,7 +635,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E023.png"
     },
     {
         "name": "Swimsuit Suguha",
@@ -662,7 +662,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E024.png"
     },
     {
         "name": "\"AR Idol\" Yuna",
@@ -689,7 +689,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E025.png"
     },
     {
         "name": "Profound Communication, Yuna",
@@ -718,7 +718,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E026.png"
     },
     {
         "name": "Inviting Provocation, Eiji",
@@ -747,7 +747,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E027.png"
     },
     {
         "name": "Vexation of Being Absent, Leafa",
@@ -776,7 +776,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E028.png"
     },
     {
         "name": "Instantaneous Movement, Eiｊi",
@@ -803,7 +803,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E029.png"
     },
     {
         "name": "Fragment of Memory, Yuna",
@@ -830,7 +830,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E030.png"
     },
     {
         "name": "Confident Profile, Eiji",
@@ -857,7 +857,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E031.png"
     },
     {
         "name": "《Knights of the Blood Oath》 Nautilus",
@@ -883,7 +883,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E032.png"
     },
     {
         "name": "《Augma》 Developer, Shigemura",
@@ -913,7 +913,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E033.png"
     },
     {
         "name": "Special Stage, Yuna",
@@ -942,7 +942,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E034.png"
     },
     {
         "name": "《An Incarnate of the Radius》",
@@ -972,7 +972,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E035.png"
     },
     {
         "name": "Mysterious Young Swordsman, Eiji",
@@ -999,7 +999,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E036.png"
     },
     {
         "name": "A Lonely Toast, Eiji",
@@ -1025,7 +1025,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E037.png"
     },
     {
         "name": "Really Loves Singing, Yuna",
@@ -1051,7 +1051,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E038.png"
     },
     {
         "name": "In the Midst of Loud Cheering, Yuna",
@@ -1077,7 +1077,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E039.png"
     },
     {
         "name": "Toto Institute of Technology Professor, Shigemura",
@@ -1103,7 +1103,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E040.png"
     },
     {
         "name": "The Smile I Wanted to Protect, Yuna",
@@ -1129,7 +1129,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E041.png"
     },
     {
         "name": "Magic Attack, Leafa",
@@ -1155,7 +1155,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E042.png"
     },
     {
         "name": "Stable Sister, Leafa",
@@ -1184,7 +1184,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E043.png"
     },
     {
         "name": "Opposition by the Shield",
@@ -1210,7 +1210,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E044.png"
     },
     {
         "name": "Ordinal Scale",
@@ -1237,7 +1237,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E045.png"
     },
     {
         "name": "The Complete SAO Incident Records",
@@ -1264,7 +1264,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E046.png"
     },
     {
         "name": "The Giant Stage of Dreams",
@@ -1293,7 +1293,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E047.png"
     },
     {
         "name": "Ordinal Number 2",
@@ -1322,7 +1322,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E048.png"
     },
     {
         "name": "White Holy Tree",
@@ -1351,7 +1351,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E049.png"
     },
     {
         "name": "Assistance From the Fairies",
@@ -1380,7 +1380,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E050.png"
     },
     {
         "name": "Immalleable Intentions, Lisbeth",
@@ -1407,7 +1407,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E051.png"
     },
     {
         "name": "\"Link Strike\" Silica",
@@ -1436,7 +1436,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E052.png"
     },
     {
         "name": "On Stage, Silica",
@@ -1463,7 +1463,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E053.png"
     },
     {
         "name": "Refreshing Personality, Lisbeth",
@@ -1490,7 +1490,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E054.png"
     },
     {
         "name": "Lively Post-Lessons, Rika",
@@ -1516,7 +1516,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E055.png"
     },
     {
         "name": "Silica On Guard",
@@ -1542,7 +1542,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E056.png"
     },
     {
         "name": "\"Link Strike\" Lisbeth",
@@ -1571,7 +1571,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E057.png"
     },
     {
         "name": "Close Call, Silica",
@@ -1598,7 +1598,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E058.png"
     },
     {
         "name": "Beacon of Counterattack, Lisbeth",
@@ -1625,7 +1625,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E059.png"
     },
     {
         "name": "Surging Raid, Silica",
@@ -1654,7 +1654,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E060.png"
     },
     {
         "name": "Taking On the Boss Battle, Lisbeth",
@@ -1681,7 +1681,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E061.png"
     },
     {
         "name": "Stunned Keiko",
@@ -1707,7 +1707,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E062.png"
     },
     {
         "name": "Buoyant Behavior, Silica",
@@ -1734,7 +1734,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E063.png"
     },
     {
         "name": "Taking On the Boss Battle, Silica",
@@ -1760,7 +1760,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E064.png"
     },
     {
         "name": "Stunned Rika",
@@ -1788,7 +1788,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E065.png"
     },
     {
         "name": "Rhapsodic Lisbeth",
@@ -1817,7 +1817,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E066.png"
     },
     {
         "name": "Cheerful Singing",
@@ -1844,7 +1844,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E067.png"
     },
     {
         "name": "Former Formidable Foe",
@@ -1870,7 +1870,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E068.png"
     },
     {
         "name": "Experienced Multiplayer",
@@ -1899,7 +1899,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E069.png"
     },
     {
         "name": "Heinous Trap",
@@ -1929,7 +1929,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E070.png"
     },
     {
         "name": "\"Time to Get Serious\" Kirito",
@@ -1956,7 +1956,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E071.png"
     },
     {
         "name": "\"Link Strike\" Sinon",
@@ -1986,7 +1986,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E072.png"
     },
     {
         "name": "\"Link Strike\" Kirito",
@@ -2015,7 +2015,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E073.png"
     },
     {
         "name": "In Doubt, Sinon",
@@ -2042,7 +2042,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E074.png"
     },
     {
         "name": "《SAO Survivor》 Asuna & Kazuto",
@@ -2069,7 +2069,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E075.png"
     },
     {
         "name": "Reliable Reinforcement, Sinon",
@@ -2096,7 +2096,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E076.png"
     },
     {
         "name": "AR Battle, Kirito",
@@ -2122,7 +2122,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E077.png"
     },
     {
         "name": "Welcome Assistance, Yui",
@@ -2149,7 +2149,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E078.png"
     },
     {
         "name": "Full of Vigor, Yui",
@@ -2179,7 +2179,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E079.png"
     },
     {
         "name": "Asuna's Love, Kirito",
@@ -2206,7 +2206,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E080.png"
     },
     {
         "name": "Kazuto Can't Get Used to AR",
@@ -2233,7 +2233,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E081.png"
     },
     {
         "name": "Fawning Klein",
@@ -2260,7 +2260,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E082.png"
     },
     {
         "name": "Snack Time, Yui",
@@ -2287,7 +2287,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E083.png"
     },
     {
         "name": "\"Link Strike\" Agil",
@@ -2314,7 +2314,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E084.png"
     },
     {
         "name": "Data Collection, Yui",
@@ -2343,7 +2343,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E085.png"
     },
     {
         "name": "Cuddling Couple, Kazuto & Asuna",
@@ -2371,7 +2371,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E086.png"
     },
     {
         "name": "Sweating From a Tough Fight, Agil",
@@ -2398,7 +2398,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E087.png"
     },
     {
         "name": "Angry Confrontation, Kirito",
@@ -2424,7 +2424,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E088.png"
     },
     {
         "name": "Drive of An Angry God, Kirito",
@@ -2451,7 +2451,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E089.png"
     },
     {
         "name": "Kirito Seeking a Lead",
@@ -2477,7 +2477,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E090.png"
     },
     {
         "name": "Gentle Expression, Kirito",
@@ -2503,7 +2503,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E091.png"
     },
     {
         "name": "Cool Confutation, Sinon",
@@ -2532,7 +2532,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E092.png"
     },
     {
         "name": "Urgent Participation in Battle, Klein",
@@ -2561,7 +2561,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E093.png"
     },
     {
         "name": "Somehow Seeming Lonely, Kazuto",
@@ -2590,7 +2590,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E094.png"
     },
     {
         "name": "Investigation Report",
@@ -2617,7 +2617,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E095.png"
     },
     {
         "name": "Ordinal Number 1",
@@ -2644,7 +2644,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E096.png"
     },
     {
         "name": "《Black Swordsman》 Once More",
@@ -2674,7 +2674,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E097.png"
     },
     {
         "name": "Dependable Marksmanship",
@@ -2704,7 +2704,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E098.png"
     },
     {
         "name": "Sorry to Keep You Waiting!",
@@ -2733,7 +2733,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E099.png"
     },
     {
         "name": "Perpetuation of the Promise",
@@ -2762,7 +2762,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E100.png"
     },
     {
         "name": "2 Years' Confrontation, Asuna",
@@ -2790,7 +2790,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E101.png"
     },
     {
         "name": "Seductive Shore, Leafa",
@@ -2816,7 +2816,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E102.png"
     },
     {
         "name": "Bonus Time! Yuna",
@@ -2842,7 +2842,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E103.png"
     },
     {
         "name": "The Reason I Won't Lose, Kirito",
@@ -2870,7 +2870,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_E104.png"
     },
     {
         "name": "Real Physical Sensation, Kirito",
@@ -2897,7 +2897,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_PE01.png"
     },
     {
         "name": "Precise Battle Orders, Asuna",
@@ -2923,7 +2923,7 @@
         "set": "SAO",
         "release": "51",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_PE02.png"
     },
     {
         "name": "Maid Clothes Asuna",
@@ -2949,6 +2949,6 @@
         "set": "SAO",
         "release": "51",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S51_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s51/SAO_S51_PE03.png"
     }
 ]

--- a/DB/SAOR_S47.json
+++ b/DB/SAOR_S47.json
@@ -24,7 +24,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E001.png"
     },
     {
         "name": "《Lightning Flash》Asuna",
@@ -53,7 +53,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E002.png"
     },
     {
         "name": "Asuna's Commanding Strength",
@@ -82,7 +82,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E003.png"
     },
     {
         "name": "Beacon of Hope, Asuna",
@@ -111,7 +111,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E004.png"
     },
     {
         "name": "Asuna Lays on the Sofa",
@@ -137,7 +137,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E005.png"
     },
     {
         "name": "Asuna's Married Life",
@@ -164,7 +164,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E006.png"
     },
     {
         "name": "Vice Commander, Asuna",
@@ -191,7 +191,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E007.png"
     },
     {
         "name": "Asuna Joins a Party",
@@ -217,7 +217,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E008.png"
     },
     {
         "name": "《Lead Group》Asuna",
@@ -243,7 +243,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E009.png"
     },
     {
         "name": "Asuna's Quiet Time",
@@ -271,7 +271,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E010.png"
     },
     {
         "name": "Vestige of an Elder Sister, Asuna",
@@ -300,7 +300,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E011.png"
     },
     {
         "name": "Restful Stroll, Asuna",
@@ -327,7 +327,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E012.png"
     },
     {
         "name": "Childhood Asuna",
@@ -353,7 +353,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E013.png"
     },
     {
         "name": "《ALO》 Days, Asuna",
@@ -380,7 +380,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E014.png"
     },
     {
         "name": "Asuna Takes Shelter",
@@ -407,7 +407,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E015.png"
     },
     {
         "name": "Autumn Walk, Asuna",
@@ -433,7 +433,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E016.png"
     },
     {
         "name": "Asuna Putting Herself in the Front Lines",
@@ -461,7 +461,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E017.png"
     },
     {
         "name": "Asuna Replies to a Proposal",
@@ -490,7 +490,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E018.png"
     },
     {
         "name": "《Berserk Healer》 Asuna",
@@ -519,7 +519,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E019.png"
     },
     {
         "name": "Asuna Yuuki",
@@ -548,7 +548,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E020.png"
     },
     {
         "name": "Asuna Changes Clothes",
@@ -576,7 +576,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E021.png"
     },
     {
         "name": "Self-sacrifice",
@@ -602,7 +602,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E022.png"
     },
     {
         "name": "Demise of 《Zekken》",
@@ -632,7 +632,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E023.png"
     },
     {
         "name": "《Star Splash》",
@@ -662,7 +662,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E024.png"
     },
     {
         "name": "On Top of the 《World Tree》",
@@ -692,7 +692,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E025.png"
     },
     {
         "name": "Undefeated Super Swordsman, Yuuki",
@@ -718,7 +718,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E026.png"
     },
     {
         "name": "《Sleeping Knights》 Talken & Nori & Jun",
@@ -745,7 +745,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E027.png"
     },
     {
         "name": "《Zekken》 Yuuki",
@@ -772,7 +772,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E028.png"
     },
     {
         "name": "Leafa's Pure Wish",
@@ -802,7 +802,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E029.png"
     },
     {
         "name": "Virtual and Reality, Leafa & Suguha",
@@ -831,7 +831,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E030.png"
     },
     {
         "name": "Yuuki's Raised Antenna",
@@ -858,7 +858,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E031.png"
     },
     {
         "name": "《Sword Skill Lore》 Yuuki",
@@ -885,7 +885,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E032.png"
     },
     {
         "name": "Reliable Guide, Leafa",
@@ -911,7 +911,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E033.png"
     },
     {
         "name": "Time Limit, Leafa",
@@ -938,7 +938,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E034.png"
     },
     {
         "name": "《Imp》 Girl, Yuuki",
@@ -967,7 +967,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E035.png"
     },
     {
         "name": "Sibling Moment, Suguha",
@@ -996,7 +996,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E036.png"
     },
     {
         "name": "Memories That Were Fun, Yuuki",
@@ -1025,7 +1025,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E037.png"
     },
     {
         "name": "Simultaneous Attack, Leafa",
@@ -1051,7 +1051,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E038.png"
     },
     {
         "name": "\"Speedholic\" Leafa",
@@ -1078,7 +1078,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E039.png"
     },
     {
         "name": "《Sylph》Girl, Leafa",
@@ -1105,7 +1105,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E040.png"
     },
     {
         "name": "Gathering Materials, Leafa",
@@ -1134,7 +1134,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E041.png"
     },
     {
         "name": "Innocent and Uninhibited, Yuuki",
@@ -1163,7 +1163,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E042.png"
     },
     {
         "name": "《Sleeping Knights》 Yuuki",
@@ -1190,7 +1190,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E043.png"
     },
     {
         "name": "Asuna & Yuuki",
@@ -1219,7 +1219,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E044.png"
     },
     {
         "name": "Tutor, Suguha",
@@ -1247,7 +1247,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E045.png"
     },
     {
         "name": "《Sleeping Knights》 Siune & Tecchi",
@@ -1276,7 +1276,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E046.png"
     },
     {
         "name": "Recon's Courage",
@@ -1302,7 +1302,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E047.png"
     },
     {
         "name": "《Mother's Rosario》",
@@ -1331,7 +1331,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E048.png"
     },
     {
         "name": "Fairy Dance",
@@ -1360,7 +1360,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E049.png"
     },
     {
         "name": "Braves of 27th floor",
@@ -1389,7 +1389,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E050.png"
     },
     {
         "name": "Gathering Materials, Silica",
@@ -1416,7 +1416,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E051.png"
     },
     {
         "name": "Strong and Stout-hearted, Lisbeth",
@@ -1443,7 +1443,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E052.png"
     },
     {
         "name": "Trusted Skills, Lisbeth",
@@ -1470,7 +1470,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E053.png"
     },
     {
         "name": "Lisbeth Changes Clothes",
@@ -1496,7 +1496,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E054.png"
     },
     {
         "name": "Like a Younger Sister, Silica",
@@ -1525,7 +1525,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E055.png"
     },
     {
         "name": "Lisbeth's Professional Pride",
@@ -1552,7 +1552,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E056.png"
     },
     {
         "name": "Silica Looking Up At the Sky",
@@ -1578,7 +1578,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E057.png"
     },
     {
         "name": "Silica's Unyielding Trust",
@@ -1604,7 +1604,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E058.png"
     },
     {
         "name": "Unknown Identity, 《Death Gun》",
@@ -1631,7 +1631,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E059.png"
     },
     {
         "name": "《Cait Sith》 Girl, Silica",
@@ -1657,7 +1657,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E060.png"
     },
     {
         "name": "Searching Lisbeth",
@@ -1685,7 +1685,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E061.png"
     },
     {
         "name": "Sterben 《Death Gun》",
@@ -1714,7 +1714,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E062.png"
     },
     {
         "name": "Light-hearted Talk, Kyoji",
@@ -1741,7 +1741,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E063.png"
     },
     {
         "name": "Shoichi Shinkawa",
@@ -1768,7 +1768,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E064.png"
     },
     {
         "name": "Familiar, Pina",
@@ -1795,7 +1795,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E065.png"
     },
     {
         "name": "Sinister Glint,《Death Gun》",
@@ -1821,7 +1821,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E066.png"
     },
     {
         "name": "Fluffy on the Head, Silica",
@@ -1848,7 +1848,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E067.png"
     },
     {
         "name": "Lisbeth's Determined Confession",
@@ -1877,7 +1877,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E068.png"
     },
     {
         "name": "Excessive Obsession, Kyoji",
@@ -1906,7 +1906,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E069.png"
     },
     {
         "name": "Battle Stance, Silica",
@@ -1935,7 +1935,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E070.png"
     },
     {
         "name": "Lisbeth's Shining Smile",
@@ -1964,7 +1964,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E071.png"
     },
     {
         "name": "《Demonic Sword Gram》",
@@ -1991,7 +1991,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E072.png"
     },
     {
         "name": "Seeking Warmth",
@@ -2020,7 +2020,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E073.png"
     },
     {
         "name": "Pina's Resurrection",
@@ -2049,7 +2049,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E074.png"
     },
     {
         "name": "Fateful Estoc Wielder",
@@ -2078,7 +2078,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E075.png"
     },
     {
         "name": "Last Shot, Sinon",
@@ -2108,7 +2108,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E076.png"
     },
     {
         "name": "Temporary Alliance, Kirito",
@@ -2135,7 +2135,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E077.png"
     },
     {
         "name": "Temporary Alliance, Sinon",
@@ -2162,7 +2162,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E078.png"
     },
     {
         "name": "\"Machine of Ice\" Sinon",
@@ -2191,7 +2191,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E079.png"
     },
     {
         "name": "Getting the Holy Sword, Kirito",
@@ -2221,7 +2221,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E080.png"
     },
     {
         "name": "Demon of 《Dual-wielding》, Kirito",
@@ -2250,7 +2250,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E081.png"
     },
     {
         "name": "《SAO Survivor》 Kirito",
@@ -2277,7 +2277,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E082.png"
     },
     {
         "name": "In the Sunlight Forest, Sinon",
@@ -2304,7 +2304,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E083.png"
     },
     {
         "name": "Choice to Fight, Kirito",
@@ -2330,7 +2330,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E084.png"
     },
     {
         "name": "In the Face of “Death”, Kirito & Sinon",
@@ -2359,7 +2359,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E085.png"
     },
     {
         "name": "Strong Existence, Sinon",
@@ -2388,7 +2388,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E086.png"
     },
     {
         "name": "Kirito Discovers a Unique Skill",
@@ -2418,7 +2418,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E087.png"
     },
     {
         "name": "《Black Swordsman》 Kirito",
@@ -2447,7 +2447,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E088.png"
     },
     {
         "name": "Blade User, Klein",
@@ -2474,7 +2474,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E089.png"
     },
     {
         "name": "Brains of the Party, Yui",
@@ -2500,7 +2500,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E090.png"
     },
     {
         "name": "Challenging Many, Kirito",
@@ -2527,7 +2527,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E091.png"
     },
     {
         "name": "Providing Information, Yui",
@@ -2553,7 +2553,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E092.png"
     },
     {
         "name": "Kirito's Strong Bond",
@@ -2580,7 +2580,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E093.png"
     },
     {
         "name": "Angry Sinon",
@@ -2609,7 +2609,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E094.png"
     },
     {
         "name": "Kirito's Natural Gentleness",
@@ -2635,7 +2635,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E095.png"
     },
     {
         "name": "《Skill Connect》 Kirito",
@@ -2664,7 +2664,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E096.png"
     },
     {
         "name": "Late Self-introduction",
@@ -2691,7 +2691,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E097.png"
     },
     {
         "name": "Phantom Bullet",
@@ -2720,7 +2720,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E098.png"
     },
     {
         "name": "《Dual-wielding》User",
@@ -2749,7 +2749,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E099.png"
     },
     {
         "name": "Quest to Get 《Excalibur》",
@@ -2779,7 +2779,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E100.png"
     },
     {
         "name": "Inherited Sword Skill, Asuna",
@@ -2806,7 +2806,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E101.png"
     },
     {
         "name": "Attack in Waves, Asuna",
@@ -2836,7 +2836,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E102.png"
     },
     {
         "name": "Comforting Moment, Asuna",
@@ -2863,7 +2863,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E103.png"
     },
     {
         "name": "Agile Start, Asuna",
@@ -2889,7 +2889,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E104.png"
     },
     {
         "name": "Quest to Get 《Excalibur》",
@@ -2918,7 +2918,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E105.png"
     },
     {
         "name": "Summer Festival, Suguha",
@@ -2946,7 +2946,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E106.png"
     },
     {
         "name": "Adventure with Everyone, Leafa",
@@ -2976,7 +2976,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E107.png"
     },
     {
         "name": "Adventure with Everyone, Lisbeth",
@@ -3006,7 +3006,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E108.png"
     },
     {
         "name": "Adventure with Everyone, Silica",
@@ -3033,7 +3033,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E109",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E109.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E109.png"
     },
     {
         "name": "After Party, Keiko",
@@ -3060,7 +3060,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E110",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E110.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E110.png"
     },
     {
         "name": "Rika Delighted at the Meeting",
@@ -3089,7 +3089,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E111",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E111.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E111.png"
     },
     {
         "name": "Attack in Waves, Kirito",
@@ -3119,7 +3119,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E112",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E112.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E112.png"
     },
     {
         "name": "After the Battle, Kirito",
@@ -3146,7 +3146,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E113",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E113.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E113.png"
     },
     {
         "name": "Determination with Life on the Line, Kirito",
@@ -3173,7 +3173,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E114",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E114.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E114.png"
     },
     {
         "name": "Adventure with Everyone, Yui",
@@ -3200,7 +3200,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E115",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E115.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E115.png"
     },
     {
         "name": "Frightened Eyes, Sinon",
@@ -3226,7 +3226,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E116",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E116.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E116.png"
     },
     {
         "name": "Intense Spirit, Klein",
@@ -3253,7 +3253,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E117",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E117.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E117.png"
     },
     {
         "name": "“Dicey Cafe” Gilbert",
@@ -3282,7 +3282,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E118",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E118.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E118.png"
     },
     {
         "name": "Adventure with Everyone, Sinon",
@@ -3311,7 +3311,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E119",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E119.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E119.png"
     },
     {
         "name": "《Star Splash》",
@@ -3369,7 +3369,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E121",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E121PRo.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E121.png"
     },
     {
         "name": "Mission in the Twilight, Sinon",
@@ -3396,7 +3396,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E122",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_SAO_S47_E122PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E122.png"
     },
     {
         "name": "Sinon Takes on a Powerful Opponent",
@@ -3423,7 +3423,7 @@
         "set": "SAO",
         "release": "47",
         "sid": "E123",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_W47_E123.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s47/SAO_S47_E123.png"
     },
     {
         "name": "Heading for the Memorable Floor 22, Asuna",

--- a/DB/SAO_S65.json
+++ b/DB/SAO_S65.json
@@ -22,7 +22,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E001.png"
     },
     {
         "name": "Resolution to Break Away, Alice",
@@ -47,7 +47,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E002.png"
     },
     {
         "name": "\"If You Want My Answer\" Asuna",
@@ -75,7 +75,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E003.png"
     },
     {
         "name": "Brilliant Female Knight, Alice",
@@ -103,7 +103,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E004.png"
     },
     {
         "name": "Party in Full Swing, Selka",
@@ -129,7 +129,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E005.png"
     },
     {
         "name": "Lifeline Chains, Alice",
@@ -154,7 +154,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E006.png"
     },
     {
         "name": "How About Something Sweet? Asuna",
@@ -181,7 +181,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E007.png"
     },
     {
         "name": "Cooking with the Sacred Arts, Alice",
@@ -207,7 +207,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E008.png"
     },
     {
         "name": "Glittering Osmanthus, Alice",
@@ -235,7 +235,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E009.png"
     },
     {
         "name": "Information About the Virtual World, Asuna",
@@ -261,7 +261,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E010.png"
     },
     {
         "name": "Sore Loser, Alice",
@@ -287,7 +287,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E011.png"
     },
     {
         "name": "Incident of a Certain Summer, Alice",
@@ -313,7 +313,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E012.png"
     },
     {
         "name": "Memories of a Younger Sister, Alice",
@@ -340,7 +340,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E013.png"
     },
     {
         "name": "An Unexpected Welcome, Alice",
@@ -365,7 +365,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E014.png"
     },
     {
         "name": "Dauntless Perfect Control Art, Alice",
@@ -390,7 +390,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E015.png"
     },
     {
         "name": "Confrontation with PK Squadron, Asuna",
@@ -416,7 +416,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E016.png"
     },
     {
         "name": "Fighting with Minions, Alice",
@@ -442,7 +442,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E017.png"
     },
     {
         "name": "Feelings Towards Older Sister, Selka",
@@ -468,7 +468,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E018.png"
     },
     {
         "name": "Girl to Be Saved, Alice",
@@ -493,7 +493,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E019.png"
     },
     {
         "name": "\"Ocean Turtle\" Asuna",
@@ -521,7 +521,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E020.png"
     },
     {
         "name": "Godsend",
@@ -546,7 +546,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E021.png"
     },
     {
         "name": "Sergeant First Class Natsuki Aki",
@@ -571,7 +571,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E022.png"
     },
     {
         "name": "Osmanthus Sword",
@@ -600,7 +600,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E023.png"
     },
     {
         "name": "Declaration of Independence",
@@ -629,7 +629,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E024.png"
     },
     {
         "name": "To Where You Are",
@@ -658,7 +658,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E025.png"
     },
     {
         "name": "\"With Pride\" Cardinal",
@@ -684,7 +684,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E026.png"
     },
     {
         "name": "Spending a Day Off, Sortiliena",
@@ -710,7 +710,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E027.png"
     },
     {
         "name": "Fight Between Bitter Enemies, Cardinal",
@@ -736,7 +736,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E028.png"
     },
     {
         "name": "Girls of Age, Ronie & Tiese",
@@ -765,7 +765,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E029.png"
     },
     {
         "name": "\"Perfect Control Art\" Cardinal",
@@ -793,7 +793,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E030.png"
     },
     {
         "name": "\"The Sage of the Library\" Cardinal",
@@ -820,7 +820,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E031.png"
     },
     {
         "name": "\"The Legendary Hero\" Bercouli Synthesis One",
@@ -848,7 +848,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E032.png"
     },
     {
         "name": "The Girl Called Lyserith, Cardinal",
@@ -874,7 +874,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E033.png"
     },
     {
         "name": "\"Sister-In-Training\" Fizel Synthesis Twenty-Nine",
@@ -900,7 +900,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E034.png"
     },
     {
         "name": "Appeal to the Integrity Knight, Tiese & Ronie",
@@ -925,7 +925,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E035.png"
     },
     {
         "name": "Heroic Warrior, Bercouli",
@@ -950,7 +950,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E036.png"
     },
     {
         "name": "\"Page\" Tiese",
@@ -976,7 +976,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E037.png"
     },
     {
         "name": "Serlut Style User, Sortiliena",
@@ -1001,7 +1001,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E038.png"
     },
     {
         "name": "\"Detestable Face\" Fanatio",
@@ -1028,7 +1028,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E039.png"
     },
     {
         "name": "\"The Crimson Knight\" Deusolbert Synthesis Seven",
@@ -1054,7 +1054,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E040.png"
     },
     {
         "name": "\"Page\" Ronie",
@@ -1079,7 +1079,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E041.png"
     },
     {
         "name": "\"Sister-In-Training\" Linel Synthesis Twenty-Eight",
@@ -1104,7 +1104,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E042.png"
     },
     {
         "name": "\"Violet-Haired Suave Man\" Eldrie Synthesis Thirty-One",
@@ -1130,7 +1130,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E043.png"
     },
     {
         "name": "Information About the Virtual World, Leafa",
@@ -1156,7 +1156,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E044.png"
     },
     {
         "name": "\"The Relentless Knight\" Fanatio Synthesis Two",
@@ -1181,7 +1181,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E045.png"
     },
     {
         "name": "Knight on Flying Dragon, Deulsolbert",
@@ -1208,7 +1208,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E046.png"
     },
     {
         "name": "\"Swordsman's Pride\" Volo",
@@ -1233,7 +1233,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E047.png"
     },
     {
         "name": "Cardinal's Dagger",
@@ -1259,7 +1259,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E048.png"
     },
     {
         "name": "What It Means to Be Human",
@@ -1287,7 +1287,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E049.png"
     },
     {
         "name": "Conclusion After 200 Years",
@@ -1315,7 +1315,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E050.png"
     },
     {
         "name": "Bercouli and the Northern White Dragon",
@@ -1343,7 +1343,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E051.png"
     },
     {
         "name": "\"Pontifex of the Axiom Church\" Administrator",
@@ -1371,7 +1371,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E052.png"
     },
     {
         "name": "\"Sacred Arts Researcher\" Quinella",
@@ -1397,7 +1397,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E053.png"
     },
     {
         "name": "Preparation for the Load Test, Administrator",
@@ -1423,7 +1423,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E054.png"
     },
     {
         "name": "Brutal Lightning Attack, Administrator",
@@ -1449,7 +1449,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E055.png"
     },
     {
         "name": "Sweet Temptation, Administrator",
@@ -1475,7 +1475,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E056.png"
     },
     {
         "name": "\"Ruler\" Administrator",
@@ -1503,7 +1503,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E057.png"
     },
     {
         "name": "Confrontation with PK Squadron, Lisbeth",
@@ -1531,7 +1531,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E058.png"
     },
     {
         "name": "\"Sword Skill\" Administrator",
@@ -1559,7 +1559,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E059.png"
     },
     {
         "name": "\"Endless Thirst to Rule\" Quinella",
@@ -1587,7 +1587,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E060.png"
     },
     {
         "name": "Unexpected Limit, Administrator",
@@ -1613,7 +1613,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E061.png"
     },
     {
         "name": "\"Your Eminence, Prime Senator\" Chudelkin",
@@ -1639,7 +1639,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E062.png"
     },
     {
         "name": "Information About the Virtual World, Silica",
@@ -1667,7 +1667,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E063.png"
     },
     {
         "name": "\"Sword Automaton\" Sword Golem",
@@ -1695,7 +1695,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E064.png"
     },
     {
         "name": "Piety Module",
@@ -1721,7 +1721,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E065.png"
     },
     {
         "name": "Memory Crystal",
@@ -1746,7 +1746,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E066.png"
     },
     {
         "name": "Ruler of the 《Human Realm》",
@@ -1774,7 +1774,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E067.png"
     },
     {
         "name": "Temptation into Eternal Stasis",
@@ -1802,7 +1802,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E068.png"
     },
     {
         "name": "\"Eugeo's Partner\" Kirito",
@@ -1828,7 +1828,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E069.png"
     },
     {
         "name": "Roommate of a Free Spirit, Eugeo",
@@ -1854,7 +1854,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E070.png"
     },
     {
         "name": "\"Kirito's Partner\" Eugeo",
@@ -1884,7 +1884,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E071.png"
     },
     {
         "name": "Night-Sky-Colored Hero, Kirito",
@@ -1913,7 +1913,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E072.png"
     },
     {
         "name": "Repayment for Lunch, Kirito",
@@ -1939,7 +1939,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E073.png"
     },
     {
         "name": "\"Power of Meaning\" Kirito",
@@ -1965,7 +1965,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E074.png"
     },
     {
         "name": "Body into Sword, Eugeo",
@@ -1991,7 +1991,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E075.png"
     },
     {
         "name": "Light from Sacred Arts, Eugeo",
@@ -2016,7 +2016,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E076.png"
     },
     {
         "name": "Taboo and Justice, Eugeo",
@@ -2044,7 +2044,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E077.png"
     },
     {
         "name": "\"Eternal Ice and the Rose\" Eugeo",
@@ -2073,7 +2073,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E078.png"
     },
     {
         "name": "Searching for Papa, Yui",
@@ -2099,7 +2099,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E079.png"
     },
     {
         "name": "To the Cave in the North, Kirito",
@@ -2125,7 +2125,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E080.png"
     },
     {
         "name": "Seventh-Generation Carver, Eugeo",
@@ -2150,7 +2150,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E081.png"
     },
     {
         "name": "Confrontation with PK Squadron, Kirito",
@@ -2177,7 +2177,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E082.png"
     },
     {
         "name": "\"Swordsman's Pride\" Kirito",
@@ -2202,7 +2202,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E083.png"
     },
     {
         "name": "Information About the Virtual World, Sinon",
@@ -2231,7 +2231,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E084.png"
     },
     {
         "name": "\"Truce\" Kirito",
@@ -2259,7 +2259,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E085.png"
     },
     {
         "name": "Departure from Rulid Village, Kirito",
@@ -2287,7 +2287,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E086.png"
     },
     {
         "name": "Spurring on a Best Friend, Eugeo",
@@ -2315,7 +2315,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E087.png"
     },
     {
         "name": "To the Cave in the North, Eugeo",
@@ -2341,7 +2341,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E088.png"
     },
     {
         "name": "Zephilia Buds, Kirito",
@@ -2367,7 +2367,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E089.png"
     },
     {
         "name": "Former Appearance, Kirito",
@@ -2392,7 +2392,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E090.png"
     },
     {
         "name": "Confrontation with PK Squadron, Sinon",
@@ -2418,7 +2418,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E091.png"
     },
     {
         "name": "\"The 32nd Knight\" Eugeo Synthesis Thirty-Two",
@@ -2443,7 +2443,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E092.png"
     },
     {
         "name": "Suspicious Part-Time Job? Kazuto",
@@ -2468,7 +2468,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E093.png"
     },
     {
         "name": "Someone Else's Sword Skill, Eugeo",
@@ -2496,7 +2496,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E094.png"
     },
     {
         "name": "Charlotte's Assist",
@@ -2521,7 +2521,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E095.png"
     },
     {
         "name": "\"The Demon Tree\" Gigas Cedar",
@@ -2547,7 +2547,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E096.png"
     },
     {
         "name": "Red Rose Sword",
@@ -2576,7 +2576,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E097.png"
     },
     {
         "name": "Night-Sky Blade",
@@ -2604,7 +2604,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E098.png"
     },
     {
         "name": "Blue Rose Sword",
@@ -2633,7 +2633,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E099.png"
     },
     {
         "name": "Stay Cool",
@@ -2661,7 +2661,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E100.png"
     },
     {
         "name": "Glitter of the Water's Surface, Asuna",
@@ -2687,7 +2687,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E101.png"
     },
     {
         "name": "Glitter of the Water's Surface, Alice",
@@ -2715,7 +2715,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E102.png"
     },
     {
         "name": "How a Noble Should Be, Tiese & Ronie",
@@ -2741,7 +2741,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E103.png"
     },
     {
         "name": "\"The Other Pontifex\" Cardinal",
@@ -2766,7 +2766,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E104.png"
     },
     {
         "name": "Willowy Body, Administrator",
@@ -2794,7 +2794,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E105.png"
     },
     {
         "name": "Glitter of the Water's Surface, Eugeo & Kirito",
@@ -2820,7 +2820,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_E106.png"
     },
     {
         "name": "\"Because We Were Together\" Kirito & Eugeo",
@@ -2846,7 +2846,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_PE03.png"
     },
     {
         "name": "\"Memories That Shouldn't Exist\" Alice",
@@ -2872,7 +2872,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE01.png"
     },
     {
         "name": "Dazzling Gold, Alice",
@@ -2898,7 +2898,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE02.png"
     },
     {
         "name": "Seeking Ice, Alice",
@@ -2924,7 +2924,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE03.png"
     },
     {
         "name": "Hard Worker, Selka",
@@ -2951,7 +2951,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE04.png"
     },
     {
         "name": "\"The Osmanthus Knight\" Alice Synthesis Thirty",
@@ -2979,7 +2979,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE05.png"
     },
     {
         "name": "\"Female Childhood Friend\" Alice",
@@ -3007,7 +3007,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE06.png"
     },
     {
         "name": "Crime Committed by Fingertips",
@@ -3036,7 +3036,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE07.png"
     },
     {
         "name": "Right Hand Self to Left",
@@ -3064,7 +3064,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE08.png"
     },
     {
         "name": "Somber Expression, Eugeo",
@@ -3090,7 +3090,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE09.png"
     },
     {
         "name": "Seeking Ice, Kirito",
@@ -3115,7 +3115,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE10.png"
     },
     {
         "name": "\"Primary Trainee\" Eugeo & Kirito",
@@ -3140,7 +3140,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE11.png"
     },
     {
         "name": "\"Carver of the Giant Tree\" Kirito",
@@ -3165,7 +3165,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE12.png"
     },
     {
         "name": "Lunch Time, Eugeo",
@@ -3190,7 +3190,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE13.png"
     },
     {
         "name": "Fate Beginning to Change, Eugeo",
@@ -3215,7 +3215,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE14.png"
     },
     {
         "name": "\"Memories That Shouldn't Exist\" Eugeo",
@@ -3240,7 +3240,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE15.png"
     },
     {
         "name": "\"Carver of the Giant Tree\" Eugeo",
@@ -3268,7 +3268,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE16.png"
     },
     {
         "name": "\"Lost Child of Vecta\" Kirito",
@@ -3296,7 +3296,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE17.png"
     },
     {
         "name": "Stacia Window",
@@ -3321,7 +3321,7 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE18.png"
     },
     {
         "name": "Adventure of the Past",
@@ -3349,6 +3349,6 @@
         "set": "SAO",
         "release": "65",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SAO_S65_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sao_s65/SAO_S65_TE19.png"
     }
 ]

--- a/DB/SBY_W64.json
+++ b/DB/SBY_W64.json
@@ -24,7 +24,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E001.png"
     },
     {
         "name": "On Housewatch, Kaede Azusagawa",
@@ -51,7 +51,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E002.png"
     },
     {
         "name": "Pent-Up Feelings, Nodoka Toyohama",
@@ -78,7 +78,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E003.png"
     },
     {
         "name": "Talented Individual, Mai Sakurajima",
@@ -104,7 +104,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E004.png"
     },
     {
         "name": "Surfaced Feelings, Mai Sakurajima",
@@ -133,7 +133,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E005.png"
     },
     {
         "name": "Sunset Sky, Mai Sakurajima",
@@ -162,7 +162,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E006.png"
     },
     {
         "name": "Brother Complex, Kaede Azusagawa",
@@ -191,7 +191,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E007.png"
     },
     {
         "name": "Longing and Respect, Nodoka Toyohama",
@@ -220,7 +220,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E008.png"
     },
     {
         "name": "Indoors Preference, Kaede Azusagawa",
@@ -247,7 +247,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E009.png"
     },
     {
         "name": "First Steps, Kaede Azusagawa",
@@ -273,7 +273,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E010.png"
     },
     {
         "name": "Sisterly Thoughts, Nodoka Toyohama",
@@ -300,7 +300,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E011.png"
     },
     {
         "name": "Press Interview, Mai Sakurajima",
@@ -326,7 +326,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E012.png"
     },
     {
         "name": "A Strong Impact, Mai Sakurajima",
@@ -353,7 +353,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E013.png"
     },
     {
         "name": "Awkward Kindness, Sakuta Azusagawa",
@@ -380,7 +380,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E014.png"
     },
     {
         "name": "Complex Feelings, Mai Sakurajima",
@@ -407,7 +407,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E015.png"
     },
     {
         "name": "Embarassed, Mai Sakurajima",
@@ -433,7 +433,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E016.png"
     },
     {
         "name": "Secret of Lost Memories, Mai Sakurajima",
@@ -459,7 +459,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E017.png"
     },
     {
         "name": "Crisis as a Sister, Kaede Azusagawa",
@@ -485,7 +485,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E018.png"
     },
     {
         "name": "Announcer, Fumika Nanjo",
@@ -514,7 +514,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E019.png"
     },
     {
         "name": "Courage to Move On, Kaede Azusagawa",
@@ -543,7 +543,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E020.png"
     },
     {
         "name": "Panda Pajamas",
@@ -569,7 +569,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E021.png"
     },
     {
         "name": "Secret Treasure",
@@ -595,7 +595,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E022.png"
     },
     {
         "name": "A Shot to the Heart",
@@ -624,7 +624,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E023.png"
     },
     {
         "name": "Sister Panic",
@@ -654,7 +654,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E024.png"
     },
     {
         "name": "The Kaede Quest",
@@ -684,7 +684,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E025.png"
     },
     {
         "name": "Dreaming Girl, Shoko Makinohara",
@@ -714,7 +714,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E026.png"
     },
     {
         "name": "Observation Theory, Rio Futaba",
@@ -741,7 +741,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E027.png"
     },
     {
         "name": "Clear Blue Skies, Tomoe Koga",
@@ -768,7 +768,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E028.png"
     },
     {
         "name": "Phantom Elder Sister, Shoko Makinohara",
@@ -795,7 +795,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E029.png"
     },
     {
         "name": "Sunset Sky, Shoko Makinohara",
@@ -822,7 +822,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E030.png"
     },
     {
         "name": "Sunset Sky, Rio Futaba",
@@ -849,7 +849,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E031.png"
     },
     {
         "name": "Cool and Collected, Rio Futaba",
@@ -879,7 +879,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E032.png"
     },
     {
         "name": "Swimsuit, Tomoe Koga",
@@ -908,7 +908,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E033.png"
     },
     {
         "name": "Sudden Reunion, Tomoe Koga",
@@ -935,7 +935,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E034.png"
     },
     {
         "name": "Laplace's Demon, Tomoe Koga",
@@ -962,7 +962,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E035.png"
     },
     {
         "name": "Indirectly Showing Off, Tomoe Koga",
@@ -989,7 +989,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E036.png"
     },
     {
         "name": "Scathing Words, Rio Futaba",
@@ -1016,7 +1016,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E037.png"
     },
     {
         "name": "What Lies Ahead, Rio Futaba",
@@ -1044,7 +1044,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E038.png"
     },
     {
         "name": "Lost, Sakuta Azusagawa",
@@ -1071,7 +1071,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E039.png"
     },
     {
         "name": "Two of Myself, Rio Futaba",
@@ -1097,7 +1097,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E040.png"
     },
     {
         "name": "Honest Opinion, Shoko Makinohara",
@@ -1123,7 +1123,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E041.png"
     },
     {
         "name": "Home Visit, Shoko Makinohara",
@@ -1149,7 +1149,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E042.png"
     },
     {
         "name": "Parting in the Rain, Sakuta Azusagawa",
@@ -1178,7 +1178,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E043.png"
     },
     {
         "name": "Memories That Remain, Shoko Makinohara",
@@ -1207,7 +1207,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E044.png"
     },
     {
         "name": "Visiting the Sick, Tomoe Koga",
@@ -1235,7 +1235,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E045.png"
     },
     {
         "name": "First Love's Reason",
@@ -1261,7 +1261,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E046.png"
     },
     {
         "name": "Looping World",
@@ -1288,7 +1288,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E047.png"
     },
     {
         "name": "All the Lies I Have for You",
@@ -1317,7 +1317,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E048.png"
     },
     {
         "name": "Shrewd Brainiac",
@@ -1346,7 +1346,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E049.png"
     },
     {
         "name": "Amongst the Pain in the Rain",
@@ -1375,7 +1375,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E050.png"
     },
     {
         "name": "Bunny Girl Senpai, Mai Sakurajima",
@@ -1402,7 +1402,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E051.png"
     },
     {
         "name": "Sunset Sky, Kaede Azusagawa",
@@ -1432,7 +1432,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E052.png"
     },
     {
         "name": "Irreplaceable Existence, Mai Sakurajima",
@@ -1462,7 +1462,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E053.png"
     },
     {
         "name": "Sunset Sky, Nodoka Toyohama",
@@ -1489,7 +1489,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E054.png"
     },
     {
         "name": "Girl Who Loves Her Big Brother, Kaede Azusagawa",
@@ -1516,7 +1516,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E055.png"
     },
     {
         "name": "Welcoming With Nasuno, Kaede Azusagawa",
@@ -1543,7 +1543,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E056.png"
     },
     {
         "name": "Schooling High School Idol, Nodoka Toyohama",
@@ -1572,7 +1572,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E057.png"
     },
     {
         "name": "Self-Loathing, Nodoka Toyohama",
@@ -1598,7 +1598,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E058.png"
     },
     {
         "name": "Paper-Thin Existence, Mai Sakurajima",
@@ -1627,7 +1627,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E059.png"
     },
     {
         "name": "Present?, Kaede Azusagawa",
@@ -1653,7 +1653,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E060.png"
     },
     {
         "name": "As a Lover, Mai Sakurajima",
@@ -1682,7 +1682,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E061.png"
     },
     {
         "name": "Rascal, Sakuta Azusagawa",
@@ -1713,7 +1713,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E062.png"
     },
     {
         "name": "Runaway, Nodoka Toyohama",
@@ -1742,7 +1742,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E063.png"
     },
     {
         "name": "Secret of Lost Memories, Nodoka Toyohama",
@@ -1769,7 +1769,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E064.png"
     },
     {
         "name": "Emotions Escalating Quickly, Mai Sakurajima",
@@ -1796,7 +1796,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E065.png"
     },
     {
         "name": "An Adult's Charm, Mai Sakurajima",
@@ -1823,7 +1823,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E066.png"
     },
     {
         "name": "Change of Clothes, Kaede Azusagawa",
@@ -1849,7 +1849,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E067.png"
     },
     {
         "name": "Fluffy Breakfast, Kaede Azusagawa",
@@ -1875,7 +1875,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E068.png"
     },
     {
         "name": "On Set, Mai Sakurajima",
@@ -1904,7 +1904,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E069.png"
     },
     {
         "name": "Confidence to Face Tomorrow, Kaede Azusagawa",
@@ -1934,7 +1934,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E070.png"
     },
     {
         "name": "Scars",
@@ -1960,7 +1960,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E071.png"
     },
     {
         "name": "Feelings That Bind",
@@ -1986,7 +1986,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E072.png"
     },
     {
         "name": "The World Without You",
@@ -2015,7 +2015,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E073.png"
     },
     {
         "name": "A Sparkling Stage",
@@ -2044,7 +2044,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E074.png"
     },
     {
         "name": "Together With Nasuno",
@@ -2074,7 +2074,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E075.png"
     },
     {
         "name": "Girl Shrouded in Mystery, Shoko Makinohara",
@@ -2101,7 +2101,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E076.png"
     },
     {
         "name": "Petit Devil Kouhai, Tomoe Koga",
@@ -2128,7 +2128,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E077.png"
     },
     {
         "name": "Devilish Kouhai, Tomoe Koga",
@@ -2158,7 +2158,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E078.png"
     },
     {
         "name": "Logical Witch, Rio Futaba",
@@ -2188,7 +2188,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E079.png"
     },
     {
         "name": "Unspoken Significance, Shoko Makinohara",
@@ -2215,7 +2215,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E080.png"
     },
     {
         "name": "Love's Frustrations, Rio Futaba",
@@ -2242,7 +2242,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E081.png"
     },
     {
         "name": "Sunset Sky, Tomoe Koga",
@@ -2268,7 +2268,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E082.png"
     },
     {
         "name": "Wholesome Middle School Student, Shoko Makinohara",
@@ -2297,7 +2297,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E083.png"
     },
     {
         "name": "Study Session, Shoko Makinohara",
@@ -2323,7 +2323,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E084.png"
     },
     {
         "name": "Corrupt Gaze, Tomoe Koga",
@@ -2350,7 +2350,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E085.png"
     },
     {
         "name": "Seized Present, Tomoe Koga",
@@ -2377,7 +2377,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E086.png"
     },
     {
         "name": "Basketball Club, Yuma Kunimi",
@@ -2403,7 +2403,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E087.png"
     },
     {
         "name": "Classmate, Saki Kamisato",
@@ -2433,7 +2433,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E088.png"
     },
     {
         "name": "Together with Hayate, Shoko Makinohara",
@@ -2461,7 +2461,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E089.png"
     },
     {
         "name": "Protective Shadow, Rio Futaba",
@@ -2488,7 +2488,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E090.png"
     },
     {
         "name": "Study Session, Rio Futaba",
@@ -2514,7 +2514,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E091.png"
     },
     {
         "name": "Back From Shopping, Rio Futaba",
@@ -2540,7 +2540,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E092.png"
     },
     {
         "name": "Unconditional Support, Shoko Makinohara",
@@ -2566,7 +2566,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E093.png"
     },
     {
         "name": "Roundabout Solution, Sakuta Azusagawa",
@@ -2592,7 +2592,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E094.png"
     },
     {
         "name": "Responding Unenthusiastically, Rio Futaba",
@@ -2621,7 +2621,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E095.png"
     },
     {
         "name": "Mind-Reader? Tomoe Koga",
@@ -2649,7 +2649,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E096.png"
     },
     {
         "name": "Nasuno and Hayate",
@@ -2675,7 +2675,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E097.png"
     },
     {
         "name": "Adolescence Paradox",
@@ -2705,7 +2705,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E098.png"
     },
     {
         "name": "Returning World, Unreturned Feelings",
@@ -2734,7 +2734,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E099.png"
     },
     {
         "name": "Blue-Filled Vision",
@@ -2764,7 +2764,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E100.png"
     },
     {
         "name": "SD Nodoka Toyohama",
@@ -2793,7 +2793,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E101.png"
     },
     {
         "name": "SD Kaede Azusagawa",
@@ -2820,7 +2820,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E102.png"
     },
     {
         "name": "SD Tomoe Koga",
@@ -2847,7 +2847,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E103.png"
     },
     {
         "name": "SD Mai Sakurajima",
@@ -2874,7 +2874,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E104.png"
     },
     {
         "name": "SD Rio Futaba",
@@ -2901,7 +2901,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E105.png"
     },
     {
         "name": "SD Shoko Makinohara",
@@ -2929,7 +2929,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_E106.png"
     },
     {
         "name": "Seductive Proposal, Mai Sakurajima",
@@ -2958,7 +2958,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "PE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_PE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_PE01.png"
     },
     {
         "name": "Summertime Memories, Mai Sakurajima",
@@ -2984,7 +2984,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "PE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_PE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_PE02.png"
     },
     {
         "name": "Autumn Visit, Mai Sakurajima",
@@ -3011,7 +3011,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "PE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_PE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_PE03.png"
     },
     {
         "name": "Cruel Hypothesis, Rio Futaba",
@@ -3038,7 +3038,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE01.png"
     },
     {
         "name": "Self-Introduction, Shoko Makinohara",
@@ -3065,7 +3065,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE02.png"
     },
     {
         "name": "Sudden Assault, Tomoe Koga",
@@ -3092,7 +3092,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE03.png"
     },
     {
         "name": "Call During Wee Hours, Rio Futaba",
@@ -3118,7 +3118,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE04.png"
     },
     {
         "name": "Hidden Feelings, Rio Futaba",
@@ -3146,7 +3146,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE05.png"
     },
     {
         "name": "Impactful Words, Tomoe Koga",
@@ -3172,7 +3172,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE06.png"
     },
     {
         "name": "Unnamed Letter, Rio Futaba",
@@ -3201,7 +3201,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE07.png"
     },
     {
         "name": "An Extraordinary Theory",
@@ -3230,7 +3230,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE08.png"
     },
     {
         "name": "Misunderstanding",
@@ -3259,7 +3259,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE09.png"
     },
     {
         "name": "Unreliable Smile, Kaede Azusagawa",
@@ -3286,7 +3286,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE10.png"
     },
     {
         "name": "Enroute to School, Sakuta Azusagawa",
@@ -3313,7 +3313,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE11.png"
     },
     {
         "name": "Popular Talent, Mai Sakurajima",
@@ -3339,7 +3339,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE12.png"
     },
     {
         "name": "Building Trust, Nodoka Toyohama",
@@ -3366,7 +3366,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE13.png"
     },
     {
         "name": "Judging Stare, Mai Sakurajima",
@@ -3392,7 +3392,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE14.png"
     },
     {
         "name": "Sudden Move, Nodoka Toyohama",
@@ -3421,7 +3421,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE15.png"
     },
     {
         "name": "Big Misunderstanding, Kaede Azusagawa",
@@ -3449,7 +3449,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE16.png"
     },
     {
         "name": "Unexpected Reply, Mai Sakurajima",
@@ -3477,7 +3477,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE17.png"
     },
     {
         "name": "Ephemeral Existence, Mai Sakurajima",
@@ -3506,7 +3506,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE18.png"
     },
     {
         "name": "Bitter Memories",
@@ -3533,7 +3533,7 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE19.png"
     },
     {
         "name": "Heart-to-Heart Talk",
@@ -3562,6 +3562,6 @@
         "set": "SBY",
         "release": "64",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/SBY_W64_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sby_w64/SBY_W64_TE20.png"
     }
 ]

--- a/DB/SYE_WE09.json
+++ b/DB/SYE_WE09.json
@@ -23,7 +23,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E01_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E01.png"
     },
     {
         "name": "Koizumi Talking About the Stars",
@@ -49,7 +49,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E02_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E02.png"
     },
     {
         "name": "Kyon Looking Up at the Night Sky",
@@ -76,7 +76,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E03_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E03.png"
     },
     {
         "name": "5th Grade Elementary Student, Kyon's Sister",
@@ -104,7 +104,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E04_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E04.png"
     },
     {
         "name": "Mikuru Wishing Upon the Stars",
@@ -131,7 +131,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E05_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E05.png"
     },
     {
         "name": "Time Travel, Kyon & Mikuru",
@@ -158,7 +158,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E06_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E06.png"
     },
     {
         "name": "Encounter with Mikuru, Mikuru(Adult)",
@@ -187,7 +187,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E07_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E07.png"
     },
     {
         "name": "Energetic Senior, Tsuruya",
@@ -214,7 +214,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E08_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E08.png"
     },
     {
         "name": "Mikuru Working Part-time",
@@ -240,7 +240,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E09_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E09.png"
     },
     {
         "name": "Flower Viewing, Mikuru",
@@ -266,7 +266,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E10_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E10.png"
     },
     {
         "name": "Cicada Capturing Competition, Mikuru",
@@ -294,7 +294,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E11_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E11.png"
     },
     {
         "name": "Guiding Role",
@@ -323,7 +323,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E12_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E12.png"
     },
     {
         "name": "“Super Director” Haruhi",
@@ -352,7 +352,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E13_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E13.png"
     },
     {
         "name": "Flower Viewing, Haruhi",
@@ -380,7 +380,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E14_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E14.png"
     },
     {
         "name": "“Bamboo Leaf Rhapsody” Haruhi",
@@ -409,7 +409,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E15_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E15.png"
     },
     {
         "name": "Girl Who Will Change the World, Haruhi",
@@ -435,7 +435,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E16_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E16.png"
     },
     {
         "name": "Swimsuit Haruhi",
@@ -461,7 +461,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E17_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E17.png"
     },
     {
         "name": "Haruhi at a Summer Festival",
@@ -487,7 +487,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E18_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E18.png"
     },
     {
         "name": "Endless Eight",
@@ -515,7 +515,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19a",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19a_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19a.png"
     },
     {
         "name": "Endless Eight",
@@ -543,7 +543,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19b",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19b_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19b.png"
     },
     {
         "name": "Endless Eight",
@@ -571,7 +571,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19c",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19c_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19c.png"
     },
     {
         "name": "Endless Eight",
@@ -599,7 +599,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19d",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19d_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19d.png"
     },
     {
         "name": "Endless Eight",
@@ -627,7 +627,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19e",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19e_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19e.png"
     },
     {
         "name": "Endless Eight",
@@ -655,7 +655,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19f",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19f_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19f.png"
     },
     {
         "name": "Endless Eight",
@@ -683,7 +683,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19g",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19g_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19g.png"
     },
     {
         "name": "Endless Eight",
@@ -711,7 +711,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E19h",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E19h_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E19h.png"
     },
     {
         "name": "I am here",
@@ -740,7 +740,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E20_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E20.png"
     },
     {
         "name": "End of Summer",
@@ -769,7 +769,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E21_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E21.png"
     },
     {
         "name": "Observer, Nagato",
@@ -795,7 +795,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E22_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E22.png"
     },
     {
         "name": "Mage Nagato & Shamisen",
@@ -822,7 +822,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E23",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E23_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E23.png"
     },
     {
         "name": "Nagato at a Summer Festival",
@@ -851,7 +851,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E24",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E24_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E24.png"
     },
     {
         "name": "Standby Mode, Nagato",
@@ -877,7 +877,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E25",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E25_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E25.png"
     },
     {
         "name": "Flower Viewing, Nagato",
@@ -905,7 +905,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E26",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E26_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E26.png"
     },
     {
         "name": "Night with Two Weeks Left",
@@ -934,7 +934,7 @@
         "set": "SY",
         "release": "E09",
         "sid": "E27",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E27_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E27.png"
     },
     {
         "name": "Literature Club Yuki",
@@ -962,6 +962,6 @@
         "set": "SY",
         "release": "E09",
         "sid": "E28",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_WE09_E28_PR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_we09/SY_WE09_E28_PR.png"
     }
 ]

--- a/DB/SY_W08.json
+++ b/DB/SY_W08.json
@@ -23,7 +23,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E001_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E001.png"
     },
     {
         "name": "Santa Girl Haruhi & Kyon",
@@ -52,7 +52,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E002_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E002.png"
     },
     {
         "name": "Xmas Party, Kyon's Sister",
@@ -79,7 +79,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E003_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E003.png"
     },
     {
         "name": "Mystery Transfer Student, Koizumi",
@@ -106,7 +106,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E004_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E004.png"
     },
     {
         "name": "Unseen Trust, Haruhi & Kyon",
@@ -134,7 +134,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E005_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E005.png"
     },
     {
         "name": "\"Usual\" Kyon",
@@ -162,7 +162,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E006_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E006.png"
     },
     {
         "name": "Kyon in Yukata",
@@ -190,7 +190,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E007_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E007.png"
     },
     {
         "name": "Sonou Mori",
@@ -217,7 +217,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E008_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E008.png"
     },
     {
         "name": "Swimsuit Kyon's Sister",
@@ -244,7 +244,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E009_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E009.png"
     },
     {
         "name": "Kyon in the Clubroom",
@@ -272,7 +272,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E010_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E010.png"
     },
     {
         "name": "Itsuki Koizumi",
@@ -301,7 +301,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E011_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E011.png"
     },
     {
         "name": "Nagato & Koizumi in the Clubroom",
@@ -330,7 +330,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E012_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E012.png"
     },
     {
         "name": "Classmate Kunikida",
@@ -356,7 +356,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E013_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E013.png"
     },
     {
         "name": "Kyon's Apron Look",
@@ -383,7 +383,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E014_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E014.png"
     },
     {
         "name": "Koizumi's Apron Look",
@@ -409,7 +409,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E015_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E015.png"
     },
     {
         "name": "Classmate Taniguchi",
@@ -435,7 +435,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E016_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E016.png"
     },
     {
         "name": "Mikuru & Kyon Trying Too Hard",
@@ -461,7 +461,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E017_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E017.png"
     },
     {
         "name": "Dandy Butler, Arakawa",
@@ -487,7 +487,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E018_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E018.png"
     },
     {
         "name": "Kyon's Sister & Asakura",
@@ -515,7 +515,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E019_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E019.png"
     },
     {
         "name": "Camp Night",
@@ -542,7 +542,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E020_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E020.png"
     },
     {
         "name": "Way Back on a Rainy Day",
@@ -568,7 +568,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E021_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E021.png"
     },
     {
         "name": "Fumoffu!",
@@ -594,7 +594,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E022_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E022.png"
     },
     {
         "name": "Haruhi Suzumiya's Good News",
@@ -623,7 +623,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E023_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E023.png"
     },
     {
         "name": "sleeping beauty_",
@@ -653,7 +653,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E024_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E024.png"
     },
     {
         "name": "Enclosed Space",
@@ -683,7 +683,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E025_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E025.png"
     },
     {
         "name": "From Another Time, Mikuru & Mikuru(Adult)",
@@ -712,7 +712,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E026_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E026.png"
     },
     {
         "name": "Clumsy Girl Mikuru",
@@ -741,7 +741,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E027_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E027.png"
     },
     {
         "name": "Primp and Proper Tsuruya",
@@ -768,7 +768,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E028_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E028.png"
     },
     {
         "name": "Mikuru Asahina",
@@ -794,7 +794,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E029_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E029.png"
     },
     {
         "name": "Hot Springs Tsuruya",
@@ -820,7 +820,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E030_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E030.png"
     },
     {
         "name": "Girl Who Leapt Through Time, Mikuru",
@@ -847,7 +847,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E031_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E031.png"
     },
     {
         "name": "Swimsuit Haruhi & Mikuru",
@@ -876,7 +876,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E032_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E032.png"
     },
     {
         "name": "Primp and Proper Mikuru",
@@ -903,7 +903,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E033_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E033.png"
     },
     {
         "name": "Cat Ears, Tsuruya",
@@ -930,7 +930,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E034_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E034.png"
     },
     {
         "name": "Beach Volleyball, Mikuru & Tsuruya",
@@ -956,7 +956,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E035_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E035.png"
     },
     {
         "name": "Waitress, Tsuruya",
@@ -985,7 +985,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E036_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E036.png"
     },
     {
         "name": "Cat Ears, Mikuru",
@@ -1014,7 +1014,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E037_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E037.png"
     },
     {
         "name": "Autograph Session Mikuru",
@@ -1041,7 +1041,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E038_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E038.png"
     },
     {
         "name": "SOS Brigade's Mascot, Mikuru",
@@ -1067,7 +1067,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E039_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E039.png"
     },
     {
         "name": "Waitress, Mikuru",
@@ -1093,7 +1093,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E040_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E040.png"
     },
     {
         "name": "Bunnygirl, Haruhi & Nagato & Mikuru",
@@ -1119,7 +1119,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E041_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E041.png"
     },
     {
         "name": "Mikuru From the Future",
@@ -1146,7 +1146,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E042_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E042.png"
     },
     {
         "name": "Xmas Party, Tsuruya & Mikuru",
@@ -1174,7 +1174,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E043_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E043.png"
     },
     {
         "name": "Miracle Girl, Mikuru",
@@ -1202,7 +1202,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E044_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E044.png"
     },
     {
         "name": "Mikuru Beam",
@@ -1231,7 +1231,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E045_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E045.png"
     },
     {
         "name": "She Came Freely?",
@@ -1257,7 +1257,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E046_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E046.png"
     },
     {
         "name": "Baseball Tournament",
@@ -1283,7 +1283,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E047_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E047.png"
     },
     {
         "name": "Days with Haruhi Suzumiya",
@@ -1312,7 +1312,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E048_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E048.png"
     },
     {
         "name": "Classified Information",
@@ -1341,7 +1341,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E049_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E049.png"
     },
     {
         "name": "We're Raking It In!",
@@ -1370,7 +1370,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E050_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E050.png"
     },
     {
         "name": "Xmas Party, Haruhi & Kyon",
@@ -1398,7 +1398,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E051_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E051.png"
     },
     {
         "name": "SOS Brigade Leader, Haruhi",
@@ -1426,7 +1426,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E052_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E052.png"
     },
     {
         "name": "Haruhi in Yukata",
@@ -1453,7 +1453,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E053_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E053.png"
     },
     {
         "name": "Hot Springs Haruhi",
@@ -1480,7 +1480,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E054_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E054.png"
     },
     {
         "name": "Center of the World Haruhi & Puny Haruhi",
@@ -1506,7 +1506,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E055_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E055.png"
     },
     {
         "name": "\"Usual\" Haruhi",
@@ -1532,7 +1532,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E056_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E056.png"
     },
     {
         "name": "Beach Volleyball, Haruhi",
@@ -1560,7 +1560,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E057_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E057.png"
     },
     {
         "name": "Super Editor-in-Chief Haruhi",
@@ -1587,7 +1587,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E058_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E058.png"
     },
     {
         "name": "Primp and Proper Haruhi",
@@ -1613,7 +1613,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E059_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E059.png"
     },
     {
         "name": "Haruhi Hates Boredom",
@@ -1640,7 +1640,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E060_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E060.png"
     },
     {
         "name": "Haruhi & Mikuru in Yukata",
@@ -1666,7 +1666,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E061_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E061.png"
     },
     {
         "name": "Happy Valentine Haruhi",
@@ -1694,7 +1694,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E062_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E062.png"
     },
     {
         "name": "Flowers in Both Hands, Haruhi",
@@ -1721,7 +1721,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E063_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E063.png"
     },
     {
         "name": "Haruhi Suzumiya",
@@ -1747,7 +1747,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E064_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E064.png"
     },
     {
         "name": "Vocalist, Haruhi",
@@ -1775,7 +1775,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E065_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E065.png"
     },
     {
         "name": "Haruhi's Victory Declaration",
@@ -1804,7 +1804,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E066_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E066.png"
     },
     {
         "name": "Cat Ears, Haruhi",
@@ -1832,7 +1832,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E067_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E067.png"
     },
     {
         "name": "Party Popper, Haruhi",
@@ -1860,7 +1860,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E068_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E068.png"
     },
     {
         "name": "Trouble Girl, Haruhi",
@@ -1889,7 +1889,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E069_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E069.png"
     },
     {
         "name": "Touring the City",
@@ -1915,7 +1915,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E070_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E070.png"
     },
     {
         "name": "I'm Not Interested in Ordinary Humans",
@@ -1942,7 +1942,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E072_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E072.png"
     },
     {
         "name": "Happy Valentine",
@@ -1971,7 +1971,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E073_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E073.png"
     },
     {
         "name": "Birth of SOS Brigade!",
@@ -2000,7 +2000,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E074_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E074.png"
     },
     {
         "name": "Someday in the Rain",
@@ -2029,7 +2029,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E075_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E075.png"
     },
     {
         "name": "Alien, Nagato & Asakura & Kimidori",
@@ -2056,7 +2056,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E076_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E076.png"
     },
     {
         "name": "Primp and Proper Nagato",
@@ -2085,7 +2085,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E077_RR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E077.png"
     },
     {
         "name": "Yuki Nagato",
@@ -2112,7 +2112,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E078_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E078.png"
     },
     {
         "name": "Glasses Girl, Nagato",
@@ -2138,7 +2138,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E079_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E079.png"
     },
     {
         "name": "Ryoko Asakura",
@@ -2167,7 +2167,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E080_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E080.png"
     },
     {
         "name": "Silent Character, Nagato",
@@ -2196,7 +2196,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E081_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E081.png"
     },
     {
         "name": "China Dress Nagato",
@@ -2225,7 +2225,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E082_R.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E082.png"
     },
     {
         "name": "Swimsuit Haruhi & Nagato",
@@ -2251,7 +2251,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E083_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E083.png"
     },
     {
         "name": "Hot Springs Nagato & Mikuru",
@@ -2277,7 +2277,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E084_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E084.png"
     },
     {
         "name": "Beach Volleyball, Nagato",
@@ -2306,7 +2306,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E085_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E085.png"
     },
     {
         "name": "Guitarist, Nagato",
@@ -2335,7 +2335,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E086_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E086.png"
     },
     {
         "name": "Information Integration Thought Entity's Interface, Nagato",
@@ -2363,7 +2363,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E087_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E087.png"
     },
     {
         "name": "Xmas Party, Nagato",
@@ -2389,7 +2389,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E088_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E088.png"
     },
     {
         "name": "Nagato & Kyon's Sister in Yukata",
@@ -2415,7 +2415,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E089_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E089.png"
     },
     {
         "name": "Nagato's Apron Look",
@@ -2442,7 +2442,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E090_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E090.png"
     },
     {
         "name": "Nagato Eating Watermelon",
@@ -2468,7 +2468,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E091_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E091.png"
     },
     {
         "name": "Cat Ears, Nagato",
@@ -2494,7 +2494,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E092_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E092.png"
     },
     {
         "name": "First Client, Kimidori",
@@ -2521,7 +2521,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E093_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E093.png"
     },
     {
         "name": "Cool Girl, Nagato",
@@ -2549,7 +2549,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E094_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E094.png"
     },
     {
         "name": "Message on the Bookmark",
@@ -2577,7 +2577,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E095_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E095.png"
     },
     {
         "name": "Don't Leave My Side",
@@ -2603,7 +2603,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E096_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E096.png"
     },
     {
         "name": "Release of Information Binding",
@@ -2629,7 +2629,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E097_C.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E097.png"
     },
     {
         "name": "About Me. I'll Tell You",
@@ -2658,7 +2658,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E098_CR.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E098.png"
     },
     {
         "name": "Battle in the Information Control Area",
@@ -2687,7 +2687,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E099_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E099.png"
     },
     {
         "name": "That's Impossible",
@@ -2716,7 +2716,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E100_CC.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E100.png"
     },
     {
         "name": "Usual Haruhi & Mikuru",
@@ -2745,7 +2745,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E101_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E101.png"
     },
     {
         "name": "Usual Nagato",
@@ -2771,7 +2771,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E102_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E102.png"
     },
     {
         "name": "Curious Haruhi",
@@ -2798,7 +2798,7 @@
         "set": "SY",
         "release": "08",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_E104_U.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_E104.png"
     },
     {
         "name": "Wedding Dress Nagato",
@@ -2988,7 +2988,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE01_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE01.png"
     },
     {
         "name": "Flowers in Both Hands, Haruhi",
@@ -3015,7 +3015,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE02_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE02.png"
     },
     {
         "name": "Haruhi & Mikuru in Yukata",
@@ -3041,7 +3041,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE03_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE03.png"
     },
     {
         "name": "Vocalist, Haruhi",
@@ -3069,7 +3069,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE04_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE04.png"
     },
     {
         "name": "Cat Ears, Haruhi",
@@ -3097,7 +3097,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE05_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE05.png"
     },
     {
         "name": "Haruhi's Victory Declaration",
@@ -3126,7 +3126,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE06_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE06.png"
     },
     {
         "name": "Party Popper, Haruhi",
@@ -3154,7 +3154,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE07_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE07.png"
     },
     {
         "name": "Trouble Girl, Haruhi",
@@ -3183,7 +3183,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE08_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE08.png"
     },
     {
         "name": "Birth of SOS Brigade!",
@@ -3212,7 +3212,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE09_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE09.png"
     },
     {
         "name": "Someday in the Rain",
@@ -3241,7 +3241,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE10_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE10.png"
     },
     {
         "name": "Xmas Party, Nagato",
@@ -3267,7 +3267,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE11_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE11.png"
     },
     {
         "name": "Cat Ears, Nagato",
@@ -3293,7 +3293,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE12_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE12.png"
     },
     {
         "name": "Nagato Eating Watermelon",
@@ -3319,7 +3319,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE13_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE13.png"
     },
     {
         "name": "Swimsuit Haruhi & Nagato",
@@ -3345,7 +3345,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE14_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE14.png"
     },
     {
         "name": "Hot Springs Nagato & Mikuru",
@@ -3371,7 +3371,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE15_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE15.png"
     },
     {
         "name": "Release of Information Binding",
@@ -3397,7 +3397,7 @@
         "set": "SY",
         "release": "08",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE16_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE16.png"
     },
     {
         "name": "About me. I'll tell you",
@@ -3426,6 +3426,6 @@
         "set": "SY",
         "release": "08",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WSE_SY_W08_TE17_TD.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/s/sy_w08/SY_W08_TE17.png"
     }
 ]

--- a/DB/TL1_W37.json
+++ b/DB/TL1_W37.json
@@ -27,7 +27,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E001.png"
     },
     {
         "name": "Mea Kurosaki",
@@ -56,7 +56,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E002.png"
     },
     {
         "name": "“Lollipop” Mea",
@@ -83,7 +83,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E003.png"
     },
     {
         "name": "“Sitting” Mea",
@@ -109,7 +109,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E004.png"
     },
     {
         "name": "“Sitting” Yami",
@@ -136,7 +136,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E005.png"
     },
     {
         "name": "“Own Heart” Yami",
@@ -165,7 +165,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E006.png"
     },
     {
         "name": "“Killing Order of Rito” Yami",
@@ -192,7 +192,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E007.png"
     },
     {
         "name": "“Just Like It Was Till Now” Yami",
@@ -219,7 +219,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E008.png"
     },
     {
         "name": "Kyoko Kirisaki",
@@ -245,7 +245,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E009.png"
     },
     {
         "name": "“Wrapping With Ribbons” Mea",
@@ -272,7 +272,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E010.png"
     },
     {
         "name": "“Memories That Connect to the Future” Yami",
@@ -301,7 +301,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E011.png"
     },
     {
         "name": "“Heart-racing Bath Time” Mea",
@@ -327,7 +327,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E012.png"
     },
     {
         "name": "“Weapon Born for Battle” Mea",
@@ -356,7 +356,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E013.png"
     },
     {
         "name": "Tearju Lunatique",
@@ -382,7 +382,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E014.png"
     },
     {
         "name": "“Enduring Teacher” Tearju",
@@ -409,7 +409,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E015.png"
     },
     {
         "name": "Ren Elise Jewelria",
@@ -435,7 +435,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E016.png"
     },
     {
         "name": "“Psychological Invasion” Mea",
@@ -461,7 +461,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E017.png"
     },
     {
         "name": "“Collected and Calm” Yami",
@@ -488,7 +488,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E018.png"
     },
     {
         "name": "“Southern Beach Resort” Mea",
@@ -514,7 +514,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E019.png"
     },
     {
         "name": "“Southern Beach Resort” Yami",
@@ -540,7 +540,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E020.png"
     },
     {
         "name": "“Blue Metallia” Run",
@@ -567,7 +567,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E021.png"
     },
     {
         "name": "“Heart-racing Bath Time” Yami",
@@ -595,7 +595,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E022.png"
     },
     {
         "name": "“Thoughts From Master” Mea",
@@ -623,7 +623,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E023.png"
     },
     {
         "name": "Ryoko Mikado",
@@ -651,7 +651,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E024.png"
     },
     {
         "name": "Run Elise Jewelria",
@@ -679,7 +679,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E025.png"
     },
     {
         "name": "Comforting Warmth",
@@ -704,7 +704,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E026.png"
     },
     {
         "name": "Project Darkness",
@@ -730,7 +730,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E027.png"
     },
     {
         "name": "Gentle Time",
@@ -759,7 +759,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E028.png"
     },
     {
         "name": "Taiyaki Key Holder",
@@ -787,7 +787,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E029.png"
     },
     {
         "name": "Warm Town “Sainan”",
@@ -816,7 +816,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E030.png"
     },
     {
         "name": "“Sitting” Mikan",
@@ -844,7 +844,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E031.png"
     },
     {
         "name": "Mikan Yuki",
@@ -873,7 +873,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E032.png"
     },
     {
         "name": "Yui Kotegawa",
@@ -902,7 +902,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E033.png"
     },
     {
         "name": "“Sitting” Yui",
@@ -929,7 +929,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E034.png"
     },
     {
         "name": "“Cute Pajamas” Mikan",
@@ -956,7 +956,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E035.png"
     },
     {
         "name": "“Only a Dress Shirt” Yui",
@@ -983,7 +983,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E036.png"
     },
     {
         "name": "“Feelings of Love” Yui",
@@ -1009,7 +1009,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E037.png"
     },
     {
         "name": "“Regretting a Little?” Yui",
@@ -1037,7 +1037,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E038.png"
     },
     {
         "name": "“Nap Time” Mikan",
@@ -1063,7 +1063,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E039.png"
     },
     {
         "name": "“Putting Away Clothes” Mikan",
@@ -1090,7 +1090,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E040.png"
     },
     {
         "name": "Aya Fujisaki",
@@ -1116,7 +1116,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E041.png"
     },
     {
         "name": "Saki Tenjoin",
@@ -1142,7 +1142,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E042.png"
     },
     {
         "name": "“Preparing Breakfast” Mikan",
@@ -1171,7 +1171,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E043.png"
     },
     {
         "name": "“Good At Cooking” Mikan",
@@ -1200,7 +1200,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E044.png"
     },
     {
         "name": "“Worried Stare” Mikan",
@@ -1226,7 +1226,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E045.png"
     },
     {
         "name": "“Talk Between Two” Yui",
@@ -1252,7 +1252,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E046.png"
     },
     {
         "name": "“Discipline Committee Activity Report” Yui",
@@ -1278,7 +1278,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E047.png"
     },
     {
         "name": "“Usual Day” Mikan",
@@ -1304,7 +1304,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E048.png"
     },
     {
         "name": "“Cat Notification Tone” Yui",
@@ -1333,7 +1333,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E049.png"
     },
     {
         "name": "“Shameful Happening” Yui",
@@ -1362,7 +1362,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E050.png"
     },
     {
         "name": "Rin Kujo",
@@ -1389,7 +1389,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E051.png"
     },
     {
         "name": "Black Cat Mode",
@@ -1415,7 +1415,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E052.png"
     },
     {
         "name": "Taiyaki Key Holder",
@@ -1443,7 +1443,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E053.png"
     },
     {
         "name": "Heart-racing Voice",
@@ -1471,7 +1471,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E054.png"
     },
     {
         "name": "Alluring Voice",
@@ -1499,7 +1499,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E055.png"
     },
     {
         "name": "Lala-Satarin-Deviluke",
@@ -1526,7 +1526,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E056.png"
     },
     {
         "name": "Nana-Astar-Deviluke",
@@ -1552,7 +1552,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E057.png"
     },
     {
         "name": "Momo-Belia-Deviluke",
@@ -1582,7 +1582,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E058.png"
     },
     {
         "name": "“Alluring Pajama Look” Momo",
@@ -1609,7 +1609,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E059.png"
     },
     {
         "name": "“Sitting” Momo",
@@ -1636,7 +1636,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E060.png"
     },
     {
         "name": "“Trusting Stare” Lala",
@@ -1662,7 +1662,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E061R.png"
     },
     {
         "name": "“Gentle Warmth” Nana",
@@ -1689,7 +1689,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E062.png"
     },
     {
         "name": "“Sitting” Lala",
@@ -1718,7 +1718,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E063.png"
     },
     {
         "name": "“Sitting” Nana",
@@ -1747,7 +1747,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E064.png"
     },
     {
         "name": "“Friendly? Three Sisters” Lala",
@@ -1774,7 +1774,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E065.png"
     },
     {
         "name": "“Modest Support” Momo",
@@ -1800,7 +1800,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E066.png"
     },
     {
         "name": "“True Friends” Nana",
@@ -1826,7 +1826,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E067.png"
     },
     {
         "name": "“Friendly? Three Sisters” Momo",
@@ -1852,7 +1852,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E068.png"
     },
     {
         "name": "“Friendly? Three Sisters” Nana",
@@ -1878,7 +1878,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E069.png"
     },
     {
         "name": "“Twirling Mechanical Pencil” Lala",
@@ -1907,7 +1907,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E070.png"
     },
     {
         "name": "“Twin Sisters” Nana",
@@ -1936,7 +1936,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E071.png"
     },
     {
         "name": "“Friend From Planet Tentac” Nana",
@@ -1965,7 +1965,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E072.png"
     },
     {
         "name": "“Bond of Trust” Lala",
@@ -1993,7 +1993,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E073.png"
     },
     {
         "name": "“Surprisingly Aggressive” Nana",
@@ -2019,7 +2019,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E074.png"
     },
     {
         "name": "“Sorting Inventions” Lala",
@@ -2045,7 +2045,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E075.png"
     },
     {
         "name": "“Transport System 【DeDial】” Momo",
@@ -2071,7 +2071,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E076.png"
     },
     {
         "name": "“Black-hearted Strategist” Momo",
@@ -2097,7 +2097,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E077.png"
     },
     {
         "name": "Worrying Nana",
@@ -2123,7 +2123,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E078.png"
     },
     {
         "name": "“Heart-racing Bath Time” Momo",
@@ -2152,7 +2152,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E079.png"
     },
     {
         "name": "“Southern Beach Resort” Momo",
@@ -2180,7 +2180,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E080.png"
     },
     {
         "name": "Project Harem",
@@ -2205,7 +2205,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E081.png"
     },
     {
         "name": "Heart-racing Approach",
@@ -2233,7 +2233,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E082.png"
     },
     {
         "name": "Secret Flower Garden?",
@@ -2261,7 +2261,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E083.png"
     },
     {
         "name": "Alluring Pose",
@@ -2289,7 +2289,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E084.png"
     },
     {
         "name": "True Friends",
@@ -2317,7 +2317,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E085.png"
     },
     {
         "name": "Haruna Sairenji",
@@ -2344,7 +2344,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E086.png"
     },
     {
         "name": "Celine",
@@ -2370,7 +2370,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E087.png"
     },
     {
         "name": "“Sitting” Haruna",
@@ -2400,7 +2400,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E088.png"
     },
     {
         "name": "“Naked Apron” Haruna",
@@ -2426,7 +2426,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E089.png"
     },
     {
         "name": "Mio Sawada",
@@ -2452,7 +2452,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E090.png"
     },
     {
         "name": "Risa Morioka",
@@ -2480,7 +2480,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E091.png"
     },
     {
         "name": "“Reading a Book” Haruna",
@@ -2507,7 +2507,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E092.png"
     },
     {
         "name": "“Psychokinesis Converge!!!” Oshizu",
@@ -2533,7 +2533,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E093.png"
     },
     {
         "name": "“Wedding Dress” Haruna",
@@ -2560,7 +2560,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E094.png"
     },
     {
         "name": "“Packing Up” Haruna?",
@@ -2586,7 +2586,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E095.png"
     },
     {
         "name": "“In a Pinch” Haruna",
@@ -2614,7 +2614,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E096.png"
     },
     {
         "name": "Oshizu",
@@ -2642,7 +2642,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E097.png"
     },
     {
         "name": "White Cat Mode",
@@ -2667,7 +2667,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E098.png"
     },
     {
         "name": "Ripping Happening",
@@ -2695,7 +2695,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E099.png"
     },
     {
         "name": "Bound Happening",
@@ -2724,7 +2724,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E100.png"
     },
     {
         "name": "Petit Mea",
@@ -2750,7 +2750,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E101.png"
     },
     {
         "name": "Petit Yami",
@@ -2776,7 +2776,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E102.png"
     },
     {
         "name": "Petit Mikan",
@@ -2802,7 +2802,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E103.png"
     },
     {
         "name": "Petit Yui",
@@ -2828,7 +2828,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E104.png"
     },
     {
         "name": "Petit Lala",
@@ -2855,7 +2855,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E105.png"
     },
     {
         "name": "Petit Nana",
@@ -2881,7 +2881,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E106",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E106.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E106.png"
     },
     {
         "name": "Petit Momo",
@@ -2907,7 +2907,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E107",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E107.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E107.png"
     },
     {
         "name": "Petit Haruna",
@@ -2935,7 +2935,7 @@
         "set": "TL",
         "release": "37",
         "sid": "E108",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_E108.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_E108.png"
     },
     {
         "name": "\"Troubled Days\" Momo & Yami",
@@ -3017,7 +3017,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE01.png"
     },
     {
         "name": "“Changing Clothes” Mikan",
@@ -3043,7 +3043,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE02.png"
     },
     {
         "name": "“Changing Clothes” Yui",
@@ -3069,7 +3069,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE03.png"
     },
     {
         "name": "“Loves Licking” Mea",
@@ -3095,7 +3095,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE04.png"
     },
     {
         "name": "“Midsummer Poolside” Yui",
@@ -3121,7 +3121,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE05.png"
     },
     {
         "name": "“Doubtful Heart” Mea",
@@ -3150,7 +3150,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE06.png"
     },
     {
         "name": "“Yuki Household Dining Table” Mikan",
@@ -3178,7 +3178,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE07.png"
     },
     {
         "name": "“Reading a Book” Yami",
@@ -3207,7 +3207,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE08.png"
     },
     {
         "name": "“Darkness” Yami",
@@ -3236,7 +3236,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE09.png"
     },
     {
         "name": "Heart-racing Happening",
@@ -3265,7 +3265,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE10.png"
     },
     {
         "name": "Precious Younger Sister",
@@ -3295,7 +3295,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE11.png"
     },
     {
         "name": "“Ideal Project Harem” Momo",
@@ -3322,7 +3322,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE12.png"
     },
     {
         "name": "“Pure and Sweet? Girl” Momo",
@@ -3349,7 +3349,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE13.png"
     },
     {
         "name": "“Midsummer Poolside” Haruna",
@@ -3375,7 +3375,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE14.png"
     },
     {
         "name": "“Midsummer Poolside” Nana",
@@ -3401,7 +3401,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE15.png"
     },
     {
         "name": "“Looking After Younger Sisters” Lala",
@@ -3427,7 +3427,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE16.png"
     },
     {
         "name": "“Encounter With a Happening” Haruna",
@@ -3453,7 +3453,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE17.png"
     },
     {
         "name": "“Heart-racing Bath Time” Nana",
@@ -3479,7 +3479,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE18.png"
     },
     {
         "name": "“Innovative Girl” Lala",
@@ -3505,7 +3505,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE19.png"
     },
     {
         "name": "“Gentle and Brave” Rito",
@@ -3531,7 +3531,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE20.png"
     },
     {
         "name": "Melting Ice-cream",
@@ -3557,7 +3557,7 @@
         "set": "TL",
         "release": "37",
         "sid": "TE21",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE21.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE21.png"
     },
     {
         "name": "Friends",
@@ -3586,6 +3586,6 @@
         "set": "TL",
         "release": "37",
         "sid": "TE22",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/WS_TL_W37_TE22.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tl_w37/TL_W37_TE22.png"
     }
 ]

--- a/DB/TSK_S70.json
+++ b/DB/TSK_S70.json
@@ -24,7 +24,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E001",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E001.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E001.png"
     },
     {
         "name": "Successor, Rimuru",
@@ -54,7 +54,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E002",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E002.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E002.png"
     },
     {
         "name": "Achieving Vindication, Shion",
@@ -84,7 +84,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E003",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E003.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E003.png"
     },
     {
         "name": "Cutting Down in One Blow, Hakurou",
@@ -111,7 +111,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E004",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E004.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E004.png"
     },
     {
         "name": "Feeling of Respect, Eren",
@@ -138,7 +138,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E005",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E005.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E005.png"
     },
     {
         "name": "\"Caretaker of the Great Forest\" Treyni",
@@ -164,7 +164,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E006",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E006.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E006.png"
     },
     {
         "name": "\"Samurai\" Shion",
@@ -190,7 +190,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E007",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E007.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E007.png"
     },
     {
         "name": "Mighty Warrior, Shion",
@@ -217,7 +217,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E008",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E008.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E008.png"
     },
     {
         "name": "Shared Journey, Rimuru",
@@ -246,7 +246,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E009",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E009.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E009.png"
     },
     {
         "name": "Mysterious Demon, Cromwell",
@@ -275,7 +275,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E010",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E010.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E010.png"
     },
     {
         "name": "\"Orc Disaster\" Geld",
@@ -305,7 +305,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E011",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E011.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E011.png"
     },
     {
         "name": "\"Orc Lord\" Geld",
@@ -334,7 +334,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E012",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E012.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E012.png"
     },
     {
         "name": "Elemental Colossus",
@@ -360,7 +360,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E013",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E013.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E013.png"
     },
     {
         "name": "\"Demon Lord\" Ramiris",
@@ -386,7 +386,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E014",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E014.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E014.png"
     },
     {
         "name": "\"Instructor\" Hakurou",
@@ -414,7 +414,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E015",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E015.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E015.png"
     },
     {
         "name": "Master, Hakurou",
@@ -443,7 +443,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E016",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E016.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E016.png"
     },
     {
         "name": "\"Hero King\" Gazel",
@@ -472,7 +472,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E017",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E017.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E017.png"
     },
     {
         "name": "Cunning Majin, Gelmud",
@@ -499,7 +499,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E018",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E018.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E018.png"
     },
     {
         "name": "Orcs",
@@ -527,7 +527,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E019",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E019.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E019.png"
     },
     {
         "name": "Expert Blacksmith, Kaijin",
@@ -554,7 +554,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E020",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E020.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E020.png"
     },
     {
         "name": "\"Grandmaster\" Yuuki",
@@ -580,7 +580,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E021",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E021.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E021.png"
     },
     {
         "name": "Orc General",
@@ -610,7 +610,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E022",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E022.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E022.png"
     },
     {
         "name": "Troublemakers Kaval & Eren & Gido",
@@ -637,7 +637,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E023",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E023.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E023.png"
     },
     {
         "name": "Successor of Orc Disaster's Dying Wishes, Geld",
@@ -666,7 +666,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E024",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E024.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E024.png"
     },
     {
         "name": "Fierce Rivalry, Shion",
@@ -695,7 +695,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E025",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E025.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E025.png"
     },
     {
         "name": "Shion's Home Cooking",
@@ -722,7 +722,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E026",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E026.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E026.png"
     },
     {
         "name": "Weapons Made in Tempest",
@@ -748,7 +748,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E027",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E027.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E027.png"
     },
     {
         "name": "Meguru Mono",
@@ -778,7 +778,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E028",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E028.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E028.png"
     },
     {
         "name": "Overwhelming Blow",
@@ -808,7 +808,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E029",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E029.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E029.png"
     },
     {
         "name": "Death March Dance",
@@ -838,7 +838,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E030",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E030.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E030.png"
     },
     {
         "name": "Tribe's Princess, Shuna",
@@ -865,7 +865,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E031",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E031.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E031.png"
     },
     {
         "name": "Child on the Inside? Milim",
@@ -892,7 +892,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E032",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E032.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E032.png"
     },
     {
         "name": "\"Dragonoid\" Milim",
@@ -922,7 +922,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E033",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E033.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E033.png"
     },
     {
         "name": "Power of a Kijin, Benimaru",
@@ -950,7 +950,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E034",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E034.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E034.png"
     },
     {
         "name": "A Blow from Above, Rimuru",
@@ -977,7 +977,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E035",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E035.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E035.png"
     },
     {
         "name": "Loss of Fighting Spirit, Milim",
@@ -1003,7 +1003,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E036",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E036.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E036.png"
     },
     {
         "name": "Shared Journey, Shizu",
@@ -1029,7 +1029,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E037",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E037.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E037.png"
     },
     {
         "name": "Imperial Wrath, Milim",
@@ -1055,7 +1055,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E038",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E038.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E038.png"
     },
     {
         "name": "Glare, Rimuru",
@@ -1084,7 +1084,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E039",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E039.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E039.png"
     },
     {
         "name": "For Everyone's Sake, Shuna",
@@ -1114,7 +1114,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E040",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E040.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E040.png"
     },
     {
         "name": "Pursuit, Milim",
@@ -1143,7 +1143,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E041",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E041.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E041.png"
     },
     {
         "name": "Daily Training, Benimaru",
@@ -1170,7 +1170,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E042",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E042.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E042.png"
     },
     {
         "name": "\"Swordsmith\" Kurobe",
@@ -1197,7 +1197,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E043",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E043.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E043.png"
     },
     {
         "name": "Everyone's Teacher, Rimuru",
@@ -1225,7 +1225,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E044",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E044.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E044.png"
     },
     {
         "name": "Honed Senses, Kurobe",
@@ -1252,7 +1252,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E045",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E045.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E045.png"
     },
     {
         "name": "\"Shrine Maiden Princess\" Shuna",
@@ -1278,7 +1278,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E046",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E046.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E046.png"
     },
     {
         "name": "Ifrit's Manifestation, Shizu",
@@ -1305,7 +1305,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E047",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E047.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E047.png"
     },
     {
         "name": "\"Highest-Ranked Flame Spirit\" Ifrit",
@@ -1333,7 +1333,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E048",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E048.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E048.png"
     },
     {
         "name": "Strong Will, Benimaru",
@@ -1360,7 +1360,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E049",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E049.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E049.png"
     },
     {
         "name": "Radiant Smile, Milim",
@@ -1386,7 +1386,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E050",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E050.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E050.png"
     },
     {
         "name": "Which One Do You Choose? Rimuru",
@@ -1412,7 +1412,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E051",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E051.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E051.png"
     },
     {
         "name": "A Break at the Hot Springs, Milim",
@@ -1438,7 +1438,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E052",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E052.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E052.png"
     },
     {
         "name": "\"Black Lightning\" Rimuru",
@@ -1465,7 +1465,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E053",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E053.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E053.png"
     },
     {
         "name": "Taking Care Together, Shizu",
@@ -1494,7 +1494,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E054",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E054.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E054.png"
     },
     {
         "name": "Fierce Rivalry, Shuna",
@@ -1523,7 +1523,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E055",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E055.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E055.png"
     },
     {
         "name": "\"Samurai General\" Benimaru",
@@ -1552,7 +1552,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E056",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E056.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E056.png"
     },
     {
         "name": "Declaration of Being Besties!",
@@ -1578,7 +1578,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E057",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E057.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E057.png"
     },
     {
         "name": "Flare Circle",
@@ -1604,7 +1604,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E058",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E058.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E058.png"
     },
     {
         "name": "A Way of Saying Hello",
@@ -1633,7 +1633,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E059",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E059.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E059.png"
     },
     {
         "name": "New Power",
@@ -1663,7 +1663,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E060",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E060.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E060.png"
     },
     {
         "name": "Power of a Demon Lord",
@@ -1692,7 +1692,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E061",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E061.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E061.png"
     },
     {
         "name": "A Scenery to Be Shared",
@@ -1722,7 +1722,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E062",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E062.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E062.png"
     },
     {
         "name": "Awoken Impulse",
@@ -1751,7 +1751,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E063",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E063.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E063.png"
     },
     {
         "name": "Head of the Monsters, Rimuru",
@@ -1778,7 +1778,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E064",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E064.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E064.png"
     },
     {
         "name": "\"Conqueror of Flames\" Shizu",
@@ -1805,7 +1805,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E065",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E065.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E065.png"
     },
     {
         "name": "Memories of Japan, Shizu",
@@ -1835,7 +1835,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E066",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E066.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E066.png"
     },
     {
         "name": "Request at the Kingdom of Filtwood, Shizu",
@@ -1862,7 +1862,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E067",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E067.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E067.png"
     },
     {
         "name": "Partner Sharing Body and Soul, Rimuru",
@@ -1889,7 +1889,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E068",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E068.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E068.png"
     },
     {
         "name": "Power to Protect Comrades, Rimuru",
@@ -1916,7 +1916,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E069",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E069.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E069.png"
     },
     {
         "name": "\"Intimidation\" Ranga",
@@ -1943,7 +1943,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E070",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E070.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E070.png"
     },
     {
         "name": "Inherited Wishes, Rimuru",
@@ -1972,7 +1972,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E071",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E071.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E071.png"
     },
     {
         "name": "Secret Strategy, Rimuru",
@@ -2001,7 +2001,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E072",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E072.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E072.png"
     },
     {
         "name": "Quiet Anger, Souei",
@@ -2030,7 +2030,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E073",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E073.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E073.png"
     },
     {
         "name": "\"Auto-Battle Mode\" Rimuru",
@@ -2057,7 +2057,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E074",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E074.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E074.png"
     },
     {
         "name": "Last Journey, Shizu",
@@ -2084,7 +2084,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E075",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E075.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E075.png"
     },
     {
         "name": "Sensible Rigur",
@@ -2110,7 +2110,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E076",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E076.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E076.png"
     },
     {
         "name": "All to Oneself, Chloe",
@@ -2137,7 +2137,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E077",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E077.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E077.png"
     },
     {
         "name": "Creating Potions! Rimuru",
@@ -2165,7 +2165,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E078",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E078.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E078.png"
     },
     {
         "name": "\"Spy\" Souei",
@@ -2192,7 +2192,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E079",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E079.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E079.png"
     },
     {
         "name": "\"Sticky Steel Thread\" Rimuru",
@@ -2219,7 +2219,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E080",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E080.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E080.png"
     },
     {
         "name": "Attendance Check, Rimuru",
@@ -2245,7 +2245,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E081",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E081.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E081.png"
     },
     {
         "name": "The One Who Devours All, Rimuru",
@@ -2273,7 +2273,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E082",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E082.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E082.png"
     },
     {
         "name": "Power of a Hero, Shizu",
@@ -2302,7 +2302,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E083",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E083.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E083.png"
     },
     {
         "name": "Execution of Duty, Souei",
@@ -2331,7 +2331,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E084",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E084.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E084.png"
     },
     {
         "name": "Into the Midst of Battle, Ranga",
@@ -2358,7 +2358,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E085",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E085.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E085.png"
     },
     {
         "name": "New Subordinate, Soka",
@@ -2385,7 +2385,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E086",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E086.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E086.png"
     },
     {
         "name": "\"Vortex Crash\" Gabiru",
@@ -2411,7 +2411,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E087",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E087.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E087.png"
     },
     {
         "name": "Clone, Souei",
@@ -2437,7 +2437,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E088",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E088.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E088.png"
     },
     {
         "name": "Desperate Battle, Gobta",
@@ -2463,7 +2463,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E089",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E089.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E089.png"
     },
     {
         "name": "Name Overwritten, Gabiru",
@@ -2489,7 +2489,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E090",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E090.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E090.png"
     },
     {
         "name": "Chloe & Alice & Kenya & Ryota & Gale",
@@ -2515,7 +2515,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E091",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E091.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E091.png"
     },
     {
         "name": "A Break at the Hot Springs, Rimuru",
@@ -2544,7 +2544,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E092",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E092.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E092.png"
     },
     {
         "name": "\"Rigurd Shock\" Rigurd",
@@ -2572,7 +2572,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E093",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E093.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E093.png"
     },
     {
         "name": "\"Shadow Movement\" Ranga",
@@ -2600,7 +2600,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E094",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E094.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E094.png"
     },
     {
         "name": "Anti-Magic Mask",
@@ -2627,7 +2627,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E095",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E095.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E095.png"
     },
     {
         "name": "Unique Skill \"Great Sage\"",
@@ -2654,7 +2654,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E096",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E096.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E096.png"
     },
     {
         "name": "Legendary Hero",
@@ -2684,7 +2684,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E097",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E097.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E097.png"
     },
     {
         "name": "A Trap Laid Out",
@@ -2713,7 +2713,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E098",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E098.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E098.png"
     },
     {
         "name": "Last-Ditch Effort",
@@ -2743,7 +2743,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E099",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E099.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E099.png"
     },
     {
         "name": "Squaring off Against a Spirit",
@@ -2772,7 +2772,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E100",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E100.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E100.png"
     },
     {
         "name": "Life Amongst Bountiful Valleys, Rimuru",
@@ -2801,7 +2801,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E101",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E101.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E101.png"
     },
     {
         "name": "A Break at the Hot Springs, Shion",
@@ -2828,7 +2828,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E102",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E102.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E102.png"
     },
     {
         "name": "Splendid Transformation! Milim",
@@ -2856,7 +2856,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E103",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E103.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E103.png"
     },
     {
         "name": "A Break at the Hot Springs, Shuna",
@@ -2882,7 +2882,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E104",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E104.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E104.png"
     },
     {
         "name": "Everyone's Teacher, Shizu",
@@ -2909,7 +2909,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "E105",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_E105.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_E105.png"
     },
     {
         "name": "Rimuru Tempest",
@@ -2936,7 +2936,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE01",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE01.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE01.png"
     },
     {
         "name": "Soon-to-be Sage, Mikami Satoru",
@@ -2962,7 +2962,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE02",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE02.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE02.png"
     },
     {
         "name": "Bonds of Friendship, Veldora",
@@ -2989,7 +2989,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE03",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE03.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE03.png"
     },
     {
         "name": "Reincarnated From Another World, Rimuru",
@@ -3016,7 +3016,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE04",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE04.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE04.png"
     },
     {
         "name": "\"Free Union Adventurer\" Gido",
@@ -3042,7 +3042,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE05",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE05.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE05.png"
     },
     {
         "name": "\"Free Union Adventurer\" Kaval",
@@ -3069,7 +3069,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE06",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE06.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE06.png"
     },
     {
         "name": "\"Free Union Adventurer\" Eren",
@@ -3098,7 +3098,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE07",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE07.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE07.png"
     },
     {
         "name": "\"Predator\" Rimuru",
@@ -3128,7 +3128,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE08",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE08.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE08.png"
     },
     {
         "name": "Naming",
@@ -3158,7 +3158,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE09",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE09.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE09.png"
     },
     {
         "name": "Promises and Gratitude",
@@ -3187,7 +3187,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE10",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE10.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE10.png"
     },
     {
         "name": "Looking for Party Members, Shizu",
@@ -3214,7 +3214,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE11",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE11.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE11.png"
     },
     {
         "name": "\"Water Blade\"Rimuru",
@@ -3241,7 +3241,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE12",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE12.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE12.png"
     },
     {
         "name": "Muscles Everywhere, Rigurd",
@@ -3267,7 +3267,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE13",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE13.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE13.png"
     },
     {
         "name": "Solitary Path, Shizu",
@@ -3294,7 +3294,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE14",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE14.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE14.png"
     },
     {
         "name": "Summoning Tempest Wolves! Gobta",
@@ -3323,7 +3323,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE15",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE15.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE15.png"
     },
     {
         "name": "Heart of Loyalty, Ranga",
@@ -3352,7 +3352,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE16",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE16.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE16.png"
     },
     {
         "name": "Bonds of Friendship, Rimuru",
@@ -3380,7 +3380,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE17",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE17.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE17.png"
     },
     {
         "name": "Gushing Flames, Shizu",
@@ -3409,7 +3409,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE18",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE18.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE18.png"
     },
     {
         "name": "Anti-Magic Mask",
@@ -3435,7 +3435,7 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE19",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE19.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE19.png"
     },
     {
         "name": "Fated One",
@@ -3465,6 +3465,6 @@
         "set": "TSK",
         "release": "70",
         "sid": "TE20",
-        "image": "https://en.ws-tcg.com/cardlist/cardimages/TSK_S70_TE20.png"
+        "image": "https://en.ws-tcg.com/wp/wp-content/images/cardimages/t/tsk_s70/TSK_S70_TE20.png"
     }
 ]


### PR DESCRIPTION
- Updated old images
- Added RR+ rarity to KC_S25 and PD2_S29
- Fixed typos on bcs/bsf promo cards
- Deleted alternate rarity cards in KC2_S31

Script used to programmatically update old image links: https://gist.github.com/DiZeroX/3586f0aa0683720f6e88767aa1ac00e5